### PR TITLE
#135 - Number of boxes for Drone condition monitor incorrect

### DIFF
--- a/Chummer/clsEquipment.cs
+++ b/Chummer/clsEquipment.cs
@@ -14392,6 +14392,17 @@ namespace Chummer
 			}
 		}
 
+        /// <summary>
+        /// Is this vehicle a drone?
+        /// </summary>
+        public Boolean IsDrone
+        {
+            get
+            {
+                return Category.Contains("Drone");
+            }
+        }
+
 		/// <summary>
 		/// Handling.
 		/// </summary>
@@ -14534,15 +14545,32 @@ namespace Chummer
 			}
 		}
 
+        /// <summary>
+        /// Base Physical Boxes. 12 for vehicles, 6 for Drones.
+        /// </summary>
+        public int BasePhysicalBoxes
+        {
+            get
+            {
+                int basePhysicalBoxes = 12;
+
+                if (this.IsDrone)
+                {
+                    basePhysicalBoxes = 6;
+                }
+                return basePhysicalBoxes;
+            }
+        }
+
 		/// <summary>
 		/// Physical Condition Monitor boxes.
 		/// </summary>
 		public int PhysicalCM
 		{
-			get
-			{
-				return 12 + Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_intBody, GlobalOptions.Instance.CultureInfo) / 2.0));
-			}
+            get
+            {
+                return BasePhysicalBoxes + Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_intBody, GlobalOptions.Instance.CultureInfo) / 2.0));
+            }
 		}
 
 		/// <summary>

--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+Chummer is a character generator for Shadowrun 4th Edition. Not only can you create your character quickly and easily, but you can also use Chummer during your character's shadowrunning career, to accurately track your Karma, Nuyen, ammo, and everything else all in one place. Chummer also includes support for a number of optional rules and house rules and even includes support for critters and is useful for players and Game Masters alike! It also supports four languages: English, French, German, and Japanese.
+
+Chummer is continuously updated to address bugs and introduce new and interesting features suggested by the community. If you have a bug to report or idea to suggest, please report them on the Dumpshock forums by using the link in the menu.
+
+This project picks up from the projects Chummer and Chummer5, character generator programs for Shadowrun 4th and 5th editions, respectively. 
+
+The repository for Keith's original code can be found at: https://code.google.com/p/chummer/, and a github repository has been created at https://github.com/chummer5a/chummer (Please note, this application is not maintained by the chummer5a team, and exists solely for historical purposes.)
+
+The repository for Adam Schmidt's original code can be found at: https://code.google.com/p/chummer5/, and a github repository has been created at https://github.com/chummer5a/chummer for archival purposes.
+


### PR DESCRIPTION
This was a simple fix to correct the calculation for drone condition monitors. 

Rather than adding a flag to the xml to indicate if a vehicle was a drone or not, I set the IsDrone property based on if the word 'Drone' is in the Category Name. 
