### PR TITLE
Nuyen tooltip now displays acctual karma to nuyen value instead of {0}

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -22623,7 +22623,7 @@ namespace Chummer
 			tipTooltip.SetToolTip(lblAttributesBase, LanguageManager.Instance.GetString("Tip_CommonAttributesBase"));
 			tipTooltip.SetToolTip(lblAttributesAug, LanguageManager.Instance.GetString("Tip_CommonAttributesAug"));
 			tipTooltip.SetToolTip(lblAttributesMetatype, LanguageManager.Instance.GetString("Tip_CommonAttributesMetatypeLimits"));
-			tipTooltip.SetToolTip(lblNuyen, LanguageManager.Instance.GetString("Tip_CommonNuyen"));
+			tipTooltip.SetToolTip(lblNuyen, String.Format(LanguageManager.Instance.GetString("Tip_CommonNuyen"), _objCharacter.Options.KarmaNuyenPer));
 			tipTooltip.SetToolTip(lblRatingLabel, LanguageManager.Instance.GetString("Tip_CommonAIRating"));
 			tipTooltip.SetToolTip(lblSystemLabel, LanguageManager.Instance.GetString("Tip_CommonAISystem"));
 			tipTooltip.SetToolTip(lblFirewallLabel, LanguageManager.Instance.GetString("Tip_CommonAIFirewall"));

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -55,6 +55,7 @@ namespace Chummer
 			_objCharacter.UncouthChanged += objCharacter_UncouthChanged;
             _objCharacter.SchoolOfHardKnocksChanged += objCharacter_SchoolOfHardKnocksChanged;
 			_objCharacter.InfirmChanged += objCharacter_InfirmChanged;
+            _objCharacter.EXConChanged += _objCharacter_EXConChanged;
 			GlobalOptions.Instance.MRUChanged += PopulateMRU;
 
 			LanguageManager.Instance.Load(GlobalOptions.Instance.Language, this);
@@ -71,6 +72,8 @@ namespace Chummer
 			SetTooltips();
 			MoveControls();
 		}
+
+        
 
 		/// <summary>
 		/// Set the form to Loading mode so that certain events do not fire while data is being populated.
@@ -2121,6 +2124,14 @@ namespace Chummer
 				}
 			}
 		}
+
+        void _objCharacter_EXConChanged(object sender)
+        {
+            if (_blnReapplyImprovements)
+                return;
+
+            return; //We don't acctualy do anything with this before validation
+        }
 		#endregion
 
 		#region Menu Events
@@ -20017,6 +20028,7 @@ namespace Chummer
 			int intRestrictedAllowed = _objImprovementManager.ValueOf(Improvement.ImprovementType.RestrictedItemCount);
 			int intRestrictedCount = 0;
 			string strAvailItems = "";
+		    string strExConItems = "";
 
             // Check limits specific to the Priority build method.
             if (_objCharacter.BuildMethod == CharacterBuildMethod.Priority || _objCharacter.BuildMethod == CharacterBuildMethod.SumtoTen)
@@ -20315,6 +20327,13 @@ namespace Chummer
 					intRestrictedCount++;
 					strAvailItems += "\n\t\t" + objCyberware.DisplayNameShort;
 				}
+
+			    if (_objCharacter.EXCon && 
+                    (objCyberware.Avail.Contains("F") || objCyberware.Avail.Contains("R")))
+			    {
+			        strExConItems += "\n\t\t" + objCyberware.DisplayNameShort;
+			    }
+
 				foreach (Cyberware objPlugin in objCyberware.Children)
 				{
 					if (!objPlugin.TotalAvail.StartsWith("+"))
@@ -20607,6 +20626,13 @@ namespace Chummer
 				strMessage += "\n\t" + LanguageManager.Instance.GetString("Message_InvalidAvail").Replace("{0}", (intRestrictedCount - intRestrictedAllowed).ToString()).Replace("{1}", _objCharacter.MaximumAvailability.ToString());
 				strMessage += strAvailItems;
 			}
+
+		    if (!String.IsNullOrWhiteSpace(strExConItems))
+		    {
+		        blnValid = false;
+		        strMessage += "\n\t" + LanguageManager.Instance.GetString("Message_InvalidExConWare");
+		        strMessage += strExConItems;
+		    }
 
 			// Check item Capacities if the option is enabled.
             List<string> lstOverCapacity = new List<string>();

--- a/Chummer/clsCharacter.cs
+++ b/Chummer/clsCharacter.cs
@@ -34,6 +34,8 @@ public delegate void InfirmChangedHandler(Object sender);
 public delegate void CharacterNameChangedHandler(Object sender);
 // BlackMarketEnabledChanged Event Handler
 public delegate void BlackMarketEnabledChangedHandler(Object sender);
+// EX-Con event handler
+public delegate void EXConChangedChangeHandler(Object sender);
 
 namespace Chummer
 {
@@ -133,6 +135,7 @@ namespace Chummer
 		private bool _blnIsCritter = false;
 		private bool _blnPossessed = false;
 		private bool _blnBlackMarket = false;
+	    private bool _blnEXCon = false;
 		
 		// Attributes.
 		private Attribute _attBOD = new Attribute("BOD");
@@ -246,6 +249,7 @@ namespace Chummer
 		public event InfirmChangedHandler InfirmChanged;
 		public event CharacterNameChangedHandler CharacterNameChanged;
 		public event BlackMarketEnabledChangedHandler BlackMarketEnabledChanged;
+	    public event EXConChangedChangeHandler EXConChanged;
 
 		private frmViewer _frmPrintView;
 		
@@ -466,7 +470,9 @@ namespace Chummer
             objWriter.WriteElementString("schoolofhardknocks", _blnSchoolOfHardKnocks.ToString());
             // <infirm />
 			objWriter.WriteElementString("infirm", _blnInfirm.ToString());
-			// <blackmarket />
+            // <excon />
+            objWriter.WriteElementString("excon", _blnEXCon.ToString());
+            // <blackmarket />
 			objWriter.WriteElementString("blackmarket", _blnBlackMarket.ToString());
 
 			// <attributes>
@@ -1371,6 +1377,14 @@ namespace Chummer
 			catch
 			{
 			}
+		    try
+		    {
+		        _blnEXCon = Convert.ToBoolean(objXmlCharacter["excon"].InnerText);
+		    }
+		    catch
+		    {
+		    }
+
 			try
 			{
 				_blnBlackMarket = Convert.ToBoolean(objXmlCharacter["blackmarket"].InnerText);
@@ -2813,6 +2827,7 @@ namespace Chummer
 			_blnTechnomancerEnabled = false;
 			_blnInitiationEnabled = false;
 			_blnCritterEnabled = false;
+		    _blnEXCon = false;
 		
 			// Reset Attributes.
 			_attBOD = new Attribute("BOD");
@@ -6687,6 +6702,24 @@ namespace Chummer
 				}
 			}
 		}
+
+	    public bool EXCon
+	    {
+	        get
+	        {
+	            return _blnEXCon;
+	        }
+	        set
+	        {
+	            bool blnOldValue = _blnEXCon;
+	            _blnEXCon = value;
+	            if (blnOldValue != value)
+	            {
+	                if (EXConChanged != null) EXConChanged(this);
+	            }
+	            
+	        }
+	    }
 
 		/// <summary>
 		/// Convert a string to a CharacterBuildMethod.

--- a/Chummer/clsImprovement.cs
+++ b/Chummer/clsImprovement.cs
@@ -14,91 +14,91 @@ namespace Chummer
             Skill = 0,
             Attribute = 1,
             Text = 2,
-			Armor = 3,
-			Reach = 5,
-			Nuyen = 6,
-			Essence = 7,
-			Reaction = 8,
-			PhysicalCM = 9,
-			StunCM = 10,
-			UnarmedDV = 11,
-			SkillGroup = 12,
-			SkillCategory = 13,
-			SkillAttribute = 14,
-			InitiativePass = 15,
-			MatrixInitiative = 16,
-			MatrixInitiativePass = 17,
-			LifestyleCost = 18,
-			CMThreshold = 19,
-			EnhancedArticulation = 20,
-			WeaponCategoryDV = 21,
-			CyberwareEssCost = 22,
-			SpecialTab = 23,
-			Initiative = 24,
-			Uneducated = 25,
-			LivingPersonaResponse = 26,
-			LivingPersonaSignal = 27,
-			LivingPersonaFirewall = 28,
-			LivingPersonaSystem = 29,
-			LivingPersonaBiofeedback = 30,
-			Smartlink = 31,
-			BiowareEssCost = 32,
-			GenetechCostMultiplier = 33,
-			BasicBiowareEssCost = 34,
-			TransgenicsBiowareCost = 35,
-			SoftWeave = 36,
-			SensitiveSystem = 37,
-			ConditionMonitor = 38,
-			UnarmedDVPhysical = 39,
-			MovementPercent = 40,
-			Adapsin = 41,
-			FreePositiveQualities = 42,
-			FreeNegativeQualities = 43,
-			NuyenMaxBP = 44,
-			CMOverflow = 45,
-			FreeSpiritPowerPoints = 46,
-			AdeptPowerPoints = 47,
-			ArmorEncumbrancePenalty = 48,
-			Uncouth = 49,
-			Initiation = 50,
-			Submersion = 51,
-			Infirm = 52,
-			Skillwire = 53,
-			DamageResistance = 54,
-			RestrictedItemCount = 55,
-			AdeptLinguistics = 56,
-			SwimPercent = 57,
-			FlyPercent = 58,
-			FlySpeed = 59,
-			JudgeIntentions = 60,
-			LiftAndCarry = 61,
-			Memory = 62,
-			Concealability = 63,
-			SwapSkillAttribute = 64,
-			DrainResistance = 65,
-			FadingResistance = 66,
-			MatrixInitiativePassAdd = 67,
-			InitiativePassAdd = 68,
-			Composure = 69,
-			UnarmedAP = 70,
-			CMThresholdOffset = 71,
-			Restricted = 72,
-			Notoriety = 73,
-			SpellCategory = 74,
-			ThrowRange = 75,
-			SkillsoftAccess = 76,
-			AddSprite = 77,
-			BlackMarketDiscount = 78,
-			SelectWeapon = 79,
-			ComplexFormLimit = 80,
-			SpellLimit = 81,
-			QuickeningMetamagic = 82,
-			BasicLifestyleCost = 83,
-			ThrowSTR = 84,
-			IgnoreCMPenaltyStun = 85,
-			IgnoreCMPenaltyPhysical = 86,
-			CyborgEssence = 87,
-			EssenceMax = 88,
+            Armor = 3,
+            Reach = 5,
+            Nuyen = 6,
+            Essence = 7,
+            Reaction = 8,
+            PhysicalCM = 9,
+            StunCM = 10,
+            UnarmedDV = 11,
+            SkillGroup = 12,
+            SkillCategory = 13,
+            SkillAttribute = 14,
+            InitiativePass = 15,
+            MatrixInitiative = 16,
+            MatrixInitiativePass = 17,
+            LifestyleCost = 18,
+            CMThreshold = 19,
+            EnhancedArticulation = 20,
+            WeaponCategoryDV = 21,
+            CyberwareEssCost = 22,
+            SpecialTab = 23,
+            Initiative = 24,
+            Uneducated = 25,
+            LivingPersonaResponse = 26,
+            LivingPersonaSignal = 27,
+            LivingPersonaFirewall = 28,
+            LivingPersonaSystem = 29,
+            LivingPersonaBiofeedback = 30,
+            Smartlink = 31,
+            BiowareEssCost = 32,
+            GenetechCostMultiplier = 33,
+            BasicBiowareEssCost = 34,
+            TransgenicsBiowareCost = 35,
+            SoftWeave = 36,
+            SensitiveSystem = 37,
+            ConditionMonitor = 38,
+            UnarmedDVPhysical = 39,
+            MovementPercent = 40,
+            Adapsin = 41,
+            FreePositiveQualities = 42,
+            FreeNegativeQualities = 43,
+            NuyenMaxBP = 44,
+            CMOverflow = 45,
+            FreeSpiritPowerPoints = 46,
+            AdeptPowerPoints = 47,
+            ArmorEncumbrancePenalty = 48,
+            Uncouth = 49,
+            Initiation = 50,
+            Submersion = 51,
+            Infirm = 52,
+            Skillwire = 53,
+            DamageResistance = 54,
+            RestrictedItemCount = 55,
+            AdeptLinguistics = 56,
+            SwimPercent = 57,
+            FlyPercent = 58,
+            FlySpeed = 59,
+            JudgeIntentions = 60,
+            LiftAndCarry = 61,
+            Memory = 62,
+            Concealability = 63,
+            SwapSkillAttribute = 64,
+            DrainResistance = 65,
+            FadingResistance = 66,
+            MatrixInitiativePassAdd = 67,
+            InitiativePassAdd = 68,
+            Composure = 69,
+            UnarmedAP = 70,
+            CMThresholdOffset = 71,
+            Restricted = 72,
+            Notoriety = 73,
+            SpellCategory = 74,
+            ThrowRange = 75,
+            SkillsoftAccess = 76,
+            AddSprite = 77,
+            BlackMarketDiscount = 78,
+            SelectWeapon = 79,
+            ComplexFormLimit = 80,
+            SpellLimit = 81,
+            QuickeningMetamagic = 82,
+            BasicLifestyleCost = 83,
+            ThrowSTR = 84,
+            IgnoreCMPenaltyStun = 85,
+            IgnoreCMPenaltyPhysical = 86,
+            CyborgEssence = 87,
+            EssenceMax = 88,
             AdeptPower = 89,
             SpecificQuality = 90,
             MartialArt = 91,
@@ -107,6 +107,7 @@ namespace Chummer
             MentalLimit = 94,
             SocialLimit = 95,
             SchoolOfHardKnocks = 96,
+            EXCon = 97,
         }
 
         public enum ImprovementSource
@@ -2245,7 +2246,7 @@ namespace Chummer
                     }
 
                     // Check for Initiative Pass modifiers. Only the highest one ever applies.
-                    if (NodeExists(nodBonus, "initiativepass"))
+                    if (NodeExists(nodBonus, "initiativepass"))  //TODO: Easy lightning reflexes?
                     {
                         objFunctions.LogWrite(CommonFunctions.LogType.Message, "Chummer.ImprovementManager", "initiativepass");
                         objFunctions.LogWrite(CommonFunctions.LogType.Content, "Chummer.ImprovementManager", "initiativepass = " + nodBonus["initiativepass"].OuterXml.ToString());
@@ -2389,6 +2390,14 @@ namespace Chummer
                         objFunctions.LogWrite(CommonFunctions.LogType.Message, "Chummer.ImprovementManager", "Calling CreateImprovement");
                         CreateImprovement("", objImprovementSource, strSourceName, Improvement.ImprovementType.Infirm, strUnique);
                         _objCharacter.Infirm = true;
+                    }
+
+                    if (NodeExists(nodBonus, "excon"))
+                    {
+                        objFunctions.LogWrite(CommonFunctions.LogType.Message, "Chummer.ImprovementManager", "excon");
+                        objFunctions.LogWrite(CommonFunctions.LogType.Message, "Chummer.ImprovementManager", "Calling CreateImprovement");
+                        CreateImprovement("", objImprovementSource, strSourceName, Improvement.ImprovementType.EXCon, strUnique);
+                        _objCharacter.EXCon = true;
                     }
 
                     // Check for Adept Linguistics.
@@ -4292,6 +4301,28 @@ namespace Chummer
                     if (!blnFound)
                         _objCharacter.SchoolOfHardKnocks = false;
                 }
+
+                //Turn off the Ex-Con flag if it is being removed
+			    if (objImprovement.ImproveType == Improvement.ImprovementType.EXCon)
+			    {
+                    bool blnFound = false;
+                    // See if the character has anything else that is granting them access to SchoolOfHardKnocks.
+                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
+                    {
+                        // Skip items from the current Improvement source.
+                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
+                        {
+                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.EXCon)
+                            {
+                                blnFound = true;
+                                break;
+                            }
+                        }
+                    }
+
+                    if (!blnFound)
+                        _objCharacter.EXCon = false;
+			    }
 
 				// Turn off the Infirm flag if it is being removed.
 				if (objImprovement.ImproveType == Improvement.ImprovementType.Infirm)

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -5471,6 +5471,7 @@
 			<category>Negative</category>
 			<bonus>
 				<freepositivequalities>-10</freepositivequalities>
+        <excon/>
 			</bonus>
 			<addqualities>
 				<addquality>SINner (Criminal)</addquality>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -1989,6 +1989,10 @@
 			<key>Message_InvalidAvail</key>
 			<text>{0} more items with Avail higher than {1} than allowed</text>
 		</string>
+    <string>
+      <key>Message_InvalidExConWare</key>
+      <text>The following pieces of restricted Cyber/Bioware are not allowed on an ExCon:</text>
+    </string>
 		<string>
 			<key>Message_OverPositiveMetagenicQualities</key>
 			<text>Too many positive Metagenic qualities. Current: {0} Maximum: {1}</text>


### PR DESCRIPTION
Fixed Nuyen tooltip to display actual karma to nuyen value instead of {0}

Actual fix is slightly messy and not general purpose. I don't have enough knowglede of the chummer5a source code to be able to suggest a better way/place to fix this other than simply removing the {0} in the language file.