### PR TITLE
Fix so that automatic mandatory qualities do not count towards Karma …

### DIFF
--- a/Chummer/Character Creation/frmKarmaMetatype.cs
+++ b/Chummer/Character Creation/frmKarmaMetatype.cs
@@ -633,6 +633,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 						
 						// Add any created Weapons to the character.
@@ -654,6 +655,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -687,6 +689,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -708,6 +711,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.

--- a/Chummer/Character Creation/frmKarmaMetatype.cs
+++ b/Chummer/Character Creation/frmKarmaMetatype.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Windows.Forms;
 using System.Xml;
@@ -633,7 +633,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
-                        objQuality.ContributeToLimit = false;
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 						
 						// Add any created Weapons to the character.
@@ -655,7 +655,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
-                        objQuality.ContributeToLimit = false;
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -689,7 +689,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
-                        objQuality.ContributeToLimit = false;
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -711,7 +711,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
-                        objQuality.ContributeToLimit = false;
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -1144,6 +1144,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 						
 						// Add any created Weapons to the character.
@@ -1165,6 +1166,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -1196,6 +1196,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -1217,6 +1218,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.

--- a/Chummer/Character Creation/frmSumtoTenMetatype.cs
+++ b/Chummer/Character Creation/frmSumtoTenMetatype.cs
@@ -1029,6 +1029,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.
@@ -1050,6 +1051,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.
@@ -1091,6 +1093,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.
@@ -1112,6 +1115,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.


### PR DESCRIPTION
…limit on chargen.

I added one line <code>objQuality.ContributeToLimit = false;</code> for every location where qualities were being automatically added as a result of a particular metatype/metavariant choice.