### PR TITLE
Karma limits for purchasing +/- qualities do not include racial traits

### DIFF
--- a/Chummer/Character Creation/frmKarmaMetatype.cs
+++ b/Chummer/Character Creation/frmKarmaMetatype.cs
@@ -633,6 +633,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 						
 						// Add any created Weapons to the character.
@@ -654,6 +655,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -687,6 +689,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -708,6 +711,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -1144,6 +1144,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 						
 						// Add any created Weapons to the character.
@@ -1165,6 +1166,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -1196,6 +1198,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.
@@ -1217,6 +1220,7 @@ namespace Chummer
 						if (objXmlQualityItem.Attributes["removable"] != null)
 							objSource = QualitySource.MetatypeRemovable;
 						objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+						objQuality.ContributeToLimit = false;
 						_objCharacter.Qualities.Add(objQuality);
 
 						// Add any created Weapons to the character.

--- a/Chummer/Character Creation/frmSumtoTenMetatype.cs
+++ b/Chummer/Character Creation/frmSumtoTenMetatype.cs
@@ -1029,6 +1029,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.
@@ -1050,6 +1051,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.
@@ -1091,6 +1093,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.
@@ -1112,6 +1115,7 @@ namespace Chummer
                         if (objXmlQualityItem.Attributes["removable"] != null)
                             objSource = QualitySource.MetatypeRemovable;
                         objQuality.Create(objXmlQuality, _objCharacter, objSource, objNode, objWeapons, objWeaponNodes, strForceValue);
+                        objQuality.ContributeToLimit = false;
                         _objCharacter.Qualities.Add(objQuality);
 
                         // Add any created Weapons to the character.


### PR DESCRIPTION
I resubmitted this because the previous pull request had reformatted files which threw git off when diffing.

The reason for this pull request is that racial traits are not considered bought so therefore they should not be included in the 25 karma limit for purchasing positive and/or negative qualities.

Currently, racial traits for metatypes don't count towards the 25 karma limit because they are set to cost 0 when added to the character sheet.

Either the changes I've requested or by setting the karma cost to 0 for metagenetic would work. Although I think my way is better because it takes advantage of the ContributeToLimit that already exists.