### PR TITLE
Updates to Bio-Weapons

### DIFF
--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -1826,99 +1826,189 @@
 			<page>111</page>
 		</bioware>
 		<!--Chrome Flesh Bio-Weapons -->
-		<bioware>
-			<id></id>
-			<name>Small Tusk(s)</name>
-			<category>Cosmetic Bioware</category>
+    <bioware>
+      <id>dfd48ff5-3ecf-47b4-81fd-62b1ff3f74e4</id>
+      <name>Claws</name>
+      <category>Bio-Weapons</category>
+      <ess>0.1*Rating</ess>
+      <rating>2</rating>
+      <notes>Rating is used to indicate number of claws.</notes>
+      <capacity>0</capacity>
+      <avail>4R</avail>
+      <cost>500</cost>
+      <addweapon>Claws (Bio-Weapon)</addweapon>
+      <source>CF</source>
+      <page>120</page>
+    </bioware>
+    <bioware>
+      <id>885aa282-e624-4f8d-94e6-afafe672b3af</id>
+      <name>Claws (Retractable)</name>
+      <category>Bio-Weapons</category>
+      <ess>0.15*Rating</ess>
+      <rating>2</rating>
+      <notes>Rating is used to indicate number of claws.</notes>
+      <capacity>0</capacity>
+      <avail>6R</avail>
+      <cost>1000</cost>
+      <addweapon>Retractable Claws (Bio-Weapon)</addweapon>
+      <source>CF</source>
+      <page>120</page>
+    </bioware>
+    <bioware>
+      <id>787ff755-16f5-4dfa-9cf8-49b8399103e6</id>
+      <name>Electrical Discharge</name>
+      <category>Bio-Weapons</category>
+      <ess>0.3</ess>
+      <capacity>0</capacity>
+      <avail>8</avail>
+      <cost>10000</cost>
+      <addweapon>Electrical Discharge</addweapon>
+      <source>CF</source>
+      <page>120</page>
+    </bioware>
+    <bioware>
+      <id>82780b5b-41dd-49ae-964f-c14ca91a0f14</id>
+      <name>Fangs</name>
+      <category>Bio-Weapons</category>
+      <ess>0.1</ess>
+      <capacity>0</capacity>
+      <avail>4</avail>
+      <cost>500</cost>
+      <addweapon>Fangs (Bio-Weapon)</addweapon>
+      <source>CF</source>
+      <page>120</page>
+    </bioware>
+    <bioware>
+      <id>3f0fda69-a098-4c9a-855e-5dd2d46ae3da</id>
+      <name>Fangs (Retractable)</name>
+      <category>Bio-Weapons</category>
+      <ess>0.15</ess>
+      <capacity>0</capacity>
+      <avail>6</avail>
+      <cost>1000</cost>
+      <addweapon>Retractable Fangs (Bio-Weapon)</addweapon>
+      <source>CF</source>
+      <page>120</page>
+    </bioware>
+    <bioware>
+      <id>cbe09df9-556d-44d4-9d68-073415850deb</id>
+      <name>Horns</name>
+      <category>Bio-Weapons</category>
+      <ess>0.1</ess>
+      <capacity>0</capacity>
+      <avail>4</avail>
+      <cost>500</cost>
+      <addweapon>Horns (Bio-Weapon)</addweapon>
+      <source>CF</source>
+      <page>120</page>
+    </bioware>
+    <bioware>
+      <id>605b82f9-9f12-4a14-b567-091dd5fcde80</id>
+      <name>Muzzle</name>
+      <category>Bio-Weapons</category>
+      <ess>0.3</ess>
+      <capacity>0</capacity>
+      <avail>8R</avail>
+      <cost>2000</cost>
+      <addweapon></addweapon>
+      <source>CF</source>
+      <page>121</page>
+    </bioware>
+    <bioware>
+      <id>828ca5e9-4409-42aa-a6df-87fc907fede2</id>
+      <name>Sprayer</name>
+      <category>Bio-Weapons</category>
+      <ess>0.25</ess>
+      <capacity>0</capacity>
+      <avail>8</avail>
+      <cost>4000</cost>
+      <addweapon></addweapon>
+      <source>CF</source>
+      <page>121</page>
+    </bioware>
+    <bioware>
+      <id>b9085cbe-8e67-4205-8e49-603e31f9d6f7</id>
+      <name>Stinger, Tiny</name>
+      <category>Bio-Weapons</category>
+      <ess>0.05</ess>
+      <capacity>0</capacity>
+      <avail>8</avail>
+      <cost>100</cost>
+      <source>CF</source>
+      <page>121</page>
+    </bioware>
+    <bioware>
+      <id></id>
+      <name>Stinger, Medium</name>
+      <category>Bio-Weapons</category>
+      <ess>0.1</ess>
+      <capacity>0</capacity>
+      <avail>8R</avail>
+      <addweapon>Medium Stinger</addweapon>
+      <cost>2000</cost>
+      <source>CF</source>
+      <page>121</page>
+    </bioware>
+    <bioware>
+      <id>c466a6cf-bf31-4300-b53e-0f83af141342</id>
+      <name>Stinger, Large</name>
+      <category>Bio-Weapons</category>
+      <ess>0.2</ess>
+      <capacity>0</capacity>
+      <avail>12F</avail>
+      <cost>8000</cost>
+      <addweapon>Large Stinger</addweapon>
+      <source>CF</source>
+      <page>121</page>
+    </bioware>
+    <bioware>
+      <id>8832f6ac-0082-4b9b-9e1c-7f90874a23a1</id>
+      <name>Striking Callus</name>
+      <category>Bio-Weapons</category>
+      <ess>0.05*Rating</ess>
+      <rating>4</rating>
+      <bonus>
+        <unarmeddv>Rating*0.5</unarmeddv>
+        <unarmeddvphysical />
+      </bonus>
+      <notes>Rating is used to represent hands and feet. Every 2 Rating will grant +1 Unarmed damage.</notes>
+      <capacity>0</capacity>
+      <avail>2</avail>
+      <cost>Rating*250</cost>
+      <source>CF</source>
+      <page>121</page>
+    </bioware>
+    <bioware>
+			<id>f56ee63d-7ed3-4b5f-bde9-5b581eca9220</id>
+			<name>Tusk(s), Small</name>
+			<category>Bio-Weapons</category>
 			<ess>0</ess>
 			<rating>2</rating>
+      <notes>Rating is used to indicate number of tusks.</notes>
 			<capacity>0</capacity>
 			<avail>2</avail>
 			<cost>Rating*100</cost>
 			<addweapon></addweapon>
 			<source>CF</source>
-			<page>111</page>
+			<page>121</page>
 		</bioware>
 		<bioware>
-			<id></id>
-			<name>Large Stinger</name>
-			<category>Bio-Weapons</category>
-			<ess>0.2</ess>
-			<capacity>0</capacity>
-			<avail>12F</avail>
-			<cost>8000</cost>
-			<addweapon>Large Stinger</addweapon>
-			<source>CF</source>
-			<page>111</page>
-		</bioware>
-		<bioware>
-			<id></id>
-			<name>Small Stinger</name>
-			<category>Bio-Weapons</category>
-			<ess>0.05</ess>
-			<capacity>0</capacity>
-			<avail>8</avail>
-			<cost>100</cost>
-			<source>CF</source>
-			<page>111</page>
-		</bioware>
-		<bioware>
-			<id></id>
-			<name>Medium Stinger</name>
-			<category>Bio-Weapons</category>
-			<ess>0.1</ess>
-			<capacity>0</capacity>
-			<avail>8R</avail>
-			<addweapon>Medium Stinger</addweapon>
-			<cost>2000</cost>
-			<source>CF</source>
-			<page>111</page>
-		</bioware>
-		<bioware>
-			<id></id>
-			<name>Large Stinger</name>
-			<category>Bio-Weapons</category>
-			<ess>0.2</ess>
-			<capacity>0</capacity>
-			<avail>12F</avail>
-			<cost>8000</cost>
-			<addweapon>Large Stinger</addweapon>
-			<source>CF</source>
-			<page>111</page>
-		</bioware>
-		<bioware>
-			<id></id>
-			<name>Striking Callus</name>
-			<category>Bio-Weapons</category>
-			<ess>0.05*Rating</ess>
-			<rating>4</rating>
-			<bonus>
-				<unarmeddv>Rating*0.5</unarmeddv>
-				<unarmeddvphysical />
-			</bonus>
-			<notes>Rating is used to represent hands and feet. Every 2 Rating will grant +1 Unarmed damage.</notes>
-			<capacity>0</capacity>
-			<avail>2</avail>
-			<cost>Rating*250</cost>
-			<source>CF</source>
-			<page>111</page>
-		</bioware>
-		<bioware>
-			<id></id>
-			<name>Medium Tusk(s)</name>
+			<id>3caa7752-63ee-40c9-ba3f-d11aef038812</id>
+			<name>Tusk(s), Medium</name>
 			<category>Bio-Weapons</category>
 			<ess>0.1*Rating</ess>
 			<rating>2</rating>
+      <notes>Rating is used to indicate number of tusks.</notes>
 			<capacity>0</capacity>
 			<avail>2</avail>
 			<addweapon>Medium Tusk(s)</addweapon>
 			<cost>Rating*500</cost>
 			<source>CF</source>
-			<page>111</page>
+			<page>121</page>
 		</bioware>
 		<bioware>
-			<id></id>
-			<name>Large Tusk(s)</name>
+			<id>d5e4c407-58e4-4b24-ba11-65c45d256f97</id>
+			<name>Tusk(s), Large</name>
 			<category>Bio-Weapons</category>
 			<ess>0.2*Rating</ess>
 			<rating>2</rating>
@@ -1927,7 +2017,7 @@
 			<cost>Rating*1000</cost>
 			<addweapon>Large Tusk(s)</addweapon>
 			<source>CF</source>
-			<page>111</page>
+			<page>121</page>
 		</bioware>
   </biowares>
 </chummer>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -6730,6 +6730,7 @@
 			<source>CF</source>
 			<page>91</page>
 		</weapon>
+    <!--Chrome Flesh Bio-Weapons -->
 		<weapon>
 			<name>Claws (Bio-Weapon)</name>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
@@ -6773,12 +6774,12 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Electrical Discharge</name>
-			<category>Tasers</category>
+			<category>Bio-Weapon</category>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
 			<reach>0</reach>
-			<damage>1S(e) (Special)</damage>
+			<damage>1-8S(e) (Special)</damage>
 			<ap>-4</ap>
 			<mode>0</mode>
 			<rc>0</rc>
@@ -6788,7 +6789,7 @@
 			<allowaccessory>false</allowaccessory>
 			<useskill>Unarmed Combat</useskill>
 			<source>CF</source>
-			<page>113</page>
+			<page>122</page>
 		</weapon>
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
@@ -6810,19 +6811,39 @@
 			<source>CF</source>
 			<page>121</page>
 		</weapon>
+    <weapon>
+      <id>576770af-b5da-4b76-afdf-5559e7401e2d</id>
+      <name>Retractable Fangs (Bio-Weapon)</name>
+      <category>Bio-Weapon</category>
+      <type>Melee</type>
+      <reach>0</reach>
+      <damage>(STR+2)P</damage>
+      <ap>-4</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <conceal>0</conceal>
+      <accuracy>3</accuracy>
+      <avail>0</avail>
+      <cost>0</cost>
+      <allowaccessory>false</allowaccessory>
+      <useskill>Unarmed Combat</useskill>
+      <source>CF</source>
+      <page>121</page>
+    </weapon>
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Horns (Bio-Weapon)</name>
 			<category>Bio-Weapon</category>
 			<type>Melee</type>
 			<reach>0</reach>
-			<damage>(STR+2)P</damage>
+			<damage>(STR+1)P</damage>
 			<ap>-4</ap>
 			<mode>0</mode>
 			<rc>0</rc>
 			<ammo>0</ammo>
 			<conceal>0</conceal>
-			<accuracy>3</accuracy>
+			<accuracy>4</accuracy>
 			<avail>0</avail>
 			<cost>0</cost>
 			<allowaccessory>false</allowaccessory>
@@ -6832,7 +6853,7 @@
 		</weapon>
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
-			<name>Stinger (Large)</name>
+			<name>Large Stinger</name>
 			<category>Bio-Weapon</category>
 			<type>Melee</type>
 			<reach>1</reach>
@@ -6852,7 +6873,7 @@
 		</weapon>
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
-			<name>Stinger (Medium)</name>
+			<name>Medium Stinger</name>
 			<category>Bio-Weapon</category>
 			<type>Melee</type>
 			<reach>1</reach>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -6165,7 +6165,7 @@ Only one attribute may be at its Maximum value during character creation.</text>
 		</string>
 		<string>
 			<key>Checkbox_Options_ExceedNegativeQualities</key>
-			<text>Allow characters to exceed their Positive Quality limit</text>
+			<text>Allow characters to exceed their Negative Quality limit</text>
 		</string>
 		<string>
 			<key>Checkbox_Options_ExceedNegativeQualitiesLimit</key>


### PR DESCRIPTION
en-us.xml
 - corrected text "Positive" to "Negative" on the negative quality limit option

bioware.xml
 - added missing Bio-Weapons (claws, horns, etc)
 - removed double/incorrect data for Large Stinger
 - fixed Bio-Weapons names and page numbers for current entries
 - added notes to explain ratings values for tusks
 - moved small tusks to correct bioware category
 - reformatted Bio-Weapon names to flow better alphabetically

weapons.xml
 - Changed category on Electrical Discharge Bio-Weapon from "Taser" to "Bio-Weapon"
 - Corrected damage level for Horns (Bio-Weapon) from STR+2 to STR+1
 - Corrected accuracy for Horns (Bio-Weapon) from 3 to 4
 - Corrected page numbers for several Bio-Weapons references
 - added entry for Retractable Fangs (Bio-Weapon)
 - Changed names of Bio-Weapon Stingers to match the bioware.xml entries