### PR TITLE
Essence Discount and tooltip tweaks

### DIFF
--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -2012,7 +2012,8 @@
 			<category>Bio-Weapons</category>
 			<ess>0.2*Rating</ess>
 			<rating>2</rating>
-			<capacity>0</capacity>
+      <notes>Rating is used to indicate number of tusks.</notes>
+      <capacity>0</capacity>
 			<avail>8R</avail>
 			<cost>Rating*1000</cost>
 			<addweapon>Large Tusk(s)</addweapon>

--- a/Chummer/frmOptions.Designer.cs
+++ b/Chummer/frmOptions.Designer.cs
@@ -2657,7 +2657,7 @@
 			this.chkAllowInitiation.TabIndex = 7;
 			this.chkAllowInitiation.Tag = "Checkbox_Options_AllowInitiation";
 			this.chkAllowInitiation.Text = "Allow Initiation/Submersion in Create mode";
-			this.tipTooltip.SetToolTip(this.chkAllowInitiation, "Enabling this house rule will allow Initiation/Submersion in Create mode.");
+			this.tipTooltip.SetToolTip(this.chkAllowInitiation, "Allows Initiation/Submersion using Karma during Create mode.");
 			this.chkAllowInitiation.UseVisualStyleBackColor = true;
 			// 
 			// chkUsePointsOnBrokenGroups
@@ -2669,8 +2669,8 @@
 			this.chkUsePointsOnBrokenGroups.TabIndex = 6;
 			this.chkUsePointsOnBrokenGroups.Tag = "Checkbox_Options_PointsOnBrokenGroups";
 			this.chkUsePointsOnBrokenGroups.Text = "Use Skill Points on broken groups";
-			this.tipTooltip.SetToolTip(this.chkUsePointsOnBrokenGroups, "Enabling this house rule will allow Skill Points to be spent on skills belonging " +
-        "to a broken skill group.");
+			this.tipTooltip.SetToolTip(this.chkUsePointsOnBrokenGroups, "Allows Skill Points to be spent on skills belonging " +
+                                                                        "to a broken skill group.");
 			this.chkUsePointsOnBrokenGroups.UseVisualStyleBackColor = true;
 			// 
 			// chkDontDoubleQualities
@@ -2682,9 +2682,8 @@
 			this.chkDontDoubleQualities.TabIndex = 5;
 			this.chkDontDoubleQualities.Tag = "Checkbox_Options_DontDoubleQualities";
 			this.chkDontDoubleQualities.Text = "Don\'t double the cost of Qualities in Career Mode";
-			this.tipTooltip.SetToolTip(this.chkDontDoubleQualities, "Enabling this house rule will allow characters in Career mode to purchase Positiv" +
-        "e Qualities and buy off Negative at their normal price instead of doubling them." +
-        "");
+			this.tipTooltip.SetToolTip(this.chkDontDoubleQualities, "Allows characters in Career mode to purchase Positive " +
+                                                                    "Qualities and buy off Negative at their normal price instead of doubling them.");
 			this.chkDontDoubleQualities.UseVisualStyleBackColor = true;
 			// 
 			// chkCyberlegMovement
@@ -2696,8 +2695,8 @@
 			this.chkCyberlegMovement.TabIndex = 2;
 			this.chkCyberlegMovement.Tag = "Checkbox_Options_CyberlegMovement";
 			this.chkCyberlegMovement.Text = "Use Cyberleg Stats for Movement";
-			this.tipTooltip.SetToolTip(this.chkCyberlegMovement, "Enabling this house rule will allow characters with two cyberlegs to use their cy" +
-        "berleg\'s AGI when calculating movement rates.");
+			this.tipTooltip.SetToolTip(this.chkCyberlegMovement, "Allows characters with two cyberlegs to use their cyberleg\'s " +
+                                                                 "AGI when calculating movement rates.");
 			this.chkCyberlegMovement.UseVisualStyleBackColor = true;
 			// 
 			// chkIgnoreArt
@@ -2709,8 +2708,8 @@
 			this.chkIgnoreArt.TabIndex = 1;
 			this.chkIgnoreArt.Tag = "Checkbox_Options_IgnoreArt";
 			this.chkIgnoreArt.Text = "Ignore Art Requirements from Street Grimoire";
-			this.tipTooltip.SetToolTip(this.chkIgnoreArt, "Enabling this house rule allows all metamagics, enhancements, enchantments, and r" +
-        "ituals to ignore the Art requirement detailed in Street Grimoire.");
+			this.tipTooltip.SetToolTip(this.chkIgnoreArt, "Allows all metamagics, enhancements, enchantments, and rituals " +
+                                                          "to ignore the Art requirement detailed in Street Grimoire.");
 			this.chkIgnoreArt.UseVisualStyleBackColor = true;
 			// 
 			// cboSetting
@@ -2764,9 +2763,8 @@
 			this.chkAllowCyberwareESSDiscounts.Size = new System.Drawing.Size(258, 17);
 			this.chkAllowCyberwareESSDiscounts.TabIndex = 18;
 			this.chkAllowCyberwareESSDiscounts.Tag = "Checkbox_Options_AllowCyberwareESSDiscounts";
-			this.chkAllowCyberwareESSDiscounts.Text = "Allow Cyberware Essence costs to be discounted";
-			this.tipTooltip.SetToolTip(this.chkAllowCyberwareESSDiscounts, "Enabling this house rule will allow Skill Points to be spent on skills belonging " +
-        "to a broken skill group.");
+			this.chkAllowCyberwareESSDiscounts.Text = "Allow Cyber/Bioware Essence costs to be customized";
+			this.tipTooltip.SetToolTip(this.chkAllowCyberwareESSDiscounts, "Permits adjustment of essence costs on a per-item basis.");
 			this.chkAllowCyberwareESSDiscounts.UseVisualStyleBackColor = true;
 			// 
 			// frmOptions

--- a/Chummer/frmSelectCyberware.cs
+++ b/Chummer/frmSelectCyberware.cs
@@ -1451,8 +1451,8 @@ namespace Chummer
 
 			lblSource.Left = lblSourceLabel.Left + lblSourceLabel.Width + 6;
 			lblTest.Left = lblTestLabel.Left + lblTestLabel.Width + 6;
-			nudESSDiscount.Left = lblESSDiscountLabel.Left = lblESSDiscountLabel.Width + 6;
-			lblESSDiscountPercentLabel.Left = nudESSDiscount.Left + nudESSDiscount.Width;
+            nudESSDiscount.Left = lblESSDiscountLabel.Left + lblESSDiscountLabel.Width + 6;
+            lblESSDiscountPercentLabel.Left = nudESSDiscount.Left + nudESSDiscount.Width;
 
 			lblSearchLabel.Left = txtSearch.Left - 6 - lblSearchLabel.Width;
 		}

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -3282,35 +3282,35 @@ Only one attribute may be at its Maximum value during character creation.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsKnucks</key>
-			<text>Enabling this house rule allows Knucks to benefit from bonuses that apply to unarmed attacks including DV bonuses.</text>
+			<text>Allows Knucks to benefit from bonuses that apply to unarmed attacks including DV bonuses.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsIgnoreArt</key>
-			<text>Enabling this house rule allows all metamagics, enhancements, enchantments, and rituals to ignore the Art requirement detailed in Street Grimoire.</text>
+			<text>Allows all metamagics, enhancements, enchantments, and rituals to ignore the Art requirement detailed in Street Grimoire.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsCyberlegMovement</key>
-			<text>Enabling this house rule allows characters with two Cyberlegs to use the Cyberlegs Agility to calculate movement rates.</text>
+			<text>Allows characters with two Cyberlegs to use the Cyberlegs Agility to calculate movement rates.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsDontDoubleQualities</key>
-			<text>Enabling this house rule will allow characters in Career mode to purchase Positive Qualities and buy off Negative at their normal price instead of doubling them.</text>
+			<text>Allows characters in Career mode to purchase Positive Qualities and buy off Negative at their normal price instead of doubling them.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsExceptionalAttribute</key>
-			<text>Enabling this house rule will allow Attribute Points to be spent on the bonus point granted by the Exceptional Attributes quality.</text>
+			<text>Allows Attribute Points to be spent on the bonus point granted by the Exceptional Attributes quality.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsExceptionalNotMaxed</key>
-			<text>Enabling this house rule will allow two attributes to be at the metatype maximum rather than one if one of those attributes is improved by Exceptional Attribute.</text>
+			<text>Allows two attributes to be at the metatype maximum rather than one if one of those attributes is improved by Exceptional Attribute.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsUsePointsOnBrokenGroups</key>
-			<text>Enabling this house rule will allow Skill Points to be spent on skills belonging to a broken skill group.</text>
+			<text>Allows Skill Points to be spent on skills belonging to a broken skill group.</text>
 		</string>
 		<string>
 			<key>Tip_OptionsAllowInitiation</key>
-			<text>Enabling this house rule will allow Initiation/Submersion in Create mode.</text>
+			<text>Allows Initiation/Submersion using Karma in Create mode.</text>
 		</string>
 		<string>
 			<key>Tip_CommonAttributesAug</key>
@@ -6097,7 +6097,7 @@ Only one attribute may be at its Maximum value during character creation.</text>
 		</string>
 		<string>
 			<key>Checkbox_Options_AllowCyberwareESSDiscounts</key>
-			<text>Allow Cyberware Essence costs to be discounted</text>
+			<text>Allow Cyber/Bioware Essence costs to be customized</text>
 		</string>
 		<string>
 			<key>Checkbox_Options_StrengthAffectsRecoil</key>


### PR DESCRIPTION
en-us.xml
 - changed Essence Discount house rule text to include Bioware
 - updated thumbnail texts to be more descriptive

frmOptions.Designer.cs
 - changed Essence Discount house rule text to include Bioware
 - updated thumbnail texts to be more descriptive

bioware.xml
 - added missing note for Large Tusks

frmSelectCyberware.cs
 - fat-finger fix: replaced = with + so that Essence discount dialog positioning is correct