### PR TITLE
Fixes to Jack of all Trades, Master of None quality

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -15818,12 +15818,12 @@ namespace Chummer
 	                    {
 		                    intPointsUsed += ((Convert.ToInt32(objSkillControl.SkillBase) + i) * _objOptions.KarmaImproveActiveSkill); 
 	                    }
-						//Jack of All Trades gives a 1 point karma discount for skills below rank 6, but costs 2 extra above that.
-	                    if (_objCharacter.JackOfAllTrades)
+						//Jack of All Trades gives a 1 point karma discount for skills below rank 6, but costs 2 extra above that, minimum cost of 1
+                        if (_objCharacter.Created && _objCharacter.JackOfAllTrades)
 	                    {
 		                    if (i <= 5)
 		                    {
-			                    intPointsUsed -= 1;
+			                    if (intPointsUsed > 1) intPointsUsed -= 1;
 		                    }
 		                    else
 		                    {
@@ -15859,7 +15859,7 @@ namespace Chummer
                             intPointsRemain -= _objOptions.KarmaNewActiveSkill;
                             intPointsUsed += _objOptions.KarmaNewActiveSkill;
                         }
-	                    if (_objCharacter.JackOfAllTrades && (_objOptions.KarmaNewActiveSkill > 1))
+	                    if (_objCharacter.Created && _objCharacter.JackOfAllTrades && (_objOptions.KarmaNewActiveSkill > 1))
 	                    {
 							intPointsRemain += 1;
 							intPointsUsed -= 1;
@@ -15878,7 +15878,7 @@ namespace Chummer
                                 intPointsUsed += i * _objOptions.KarmaImproveActiveSkill;
                             }
 
-							if (_objCharacter.JackOfAllTrades)
+							if (_objCharacter.Created && _objCharacter.JackOfAllTrades)
 							{
 								if (objSkillControl.SkillRating <= 5)
 								{
@@ -15993,7 +15993,7 @@ namespace Chummer
 							{
 								intPointsUsed += i * _objOptions.KarmaImproveKnowledgeSkill;
 							}
-							if (_objCharacter.JackOfAllTrades)
+							if (_objCharacter.Created && _objCharacter.JackOfAllTrades)
 							{
 								if (objSkillControl.SkillRating <= 5)
 								{

--- a/Chummer/Controls/SkillControl.cs
+++ b/Chummer/Controls/SkillControl.cs
@@ -158,23 +158,6 @@ namespace Chummer
                         else
                             intKarmaCost = (_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill;
 					}
-					//Jack of All Trades reduces the cost by 1 for skills below 5, and increases them by 2 for skills at rank 6 or higher.
-					if (_objSkill.CharacterObject.JackOfAllTrades)
-					{
-						if (_objSkill.Rating <= 5)
-						{
-							intKarmaCost -= 1;
-							//Jack of All Trades cannot go below 1 Karma cost. 
-							if (intKarmaCost < 1)
-							{
-								intKarmaCost = 1;
-							}
-						}
-						else
-						{
-							intKarmaCost += 2;
-						}
-					}
 
 					// Double the Karma cost if the character is Uneducated and is a Technical Active, Academic, or Professional Skill.
 					if (_objSkill.CharacterObject.Uneducated && (SkillCategory == "Technical Active" || SkillCategory == "Academic" || SkillCategory == "Professional"))
@@ -184,6 +167,21 @@ namespace Chummer
                     {
                         intKarmaCost *= 2;
                     }
+
+                    //Jack of All Trades reduces the cost by 1 for skills below 5, and increases them by 2 for skills at rank 6 or higher, minimum cost of 1
+                    if (_objSkill.CharacterObject.JackOfAllTrades)
+                    {
+                        if (_objSkill.Rating <= 5)
+                        {
+                            //Jack of All Trades cannot go below 1 Karma cost. 
+                            if (intKarmaCost > 1) intKarmaCost -= 1;
+                        }
+                        else
+                        {
+                            intKarmaCost += 2;
+                        }
+                    }
+
 					strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", intNewRating.ToString()).Replace("{1}", intKarmaCost.ToString());
 					tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
 				}
@@ -739,6 +737,21 @@ namespace Chummer
                     {
                         intKarmaCost *= 2;
                     }
+
+                    // Jack of all trades lowers cost of skill by 1 up through rank 5, but adds 2 for ranks 6+, cant lower cost below 1
+                    if (_objSkill.CharacterObject.Created && _objSkill.CharacterObject.JackOfAllTrades)
+                    {
+                        if (_objSkill.Rating + 1 <= 5)
+                        {
+                            //Jack of All Trades cannot go below 1 Karma cost.
+                            if (intKarmaCost > 1) intKarmaCost -= 1;
+                        }
+                        else
+                        {
+                            intKarmaCost += 2;
+                        }
+                    }
+
 					strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", intNewRating.ToString()).Replace("{1}", intKarmaCost.ToString());
 					tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
 					cmdImproveSkill.Enabled = true;

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -4148,8 +4148,18 @@ namespace Chummer
 			    (_objCharacter.Infirm && objSkillControl.SkillCategory == "Physical Active"))
             {
 				intKarmaCost *= 2;
-                }
+            }
 
+            // Jack of all trades lowers cost of skill by 1 up through rank 5, but adds 2 for ranks 6+, cant lower cost below 1
+            if (_objCharacter.JackOfAllTrades)
+            {
+                if (objSkillControl.SkillRating + 1 <= 5) {
+                    //Jack of All Trades cannot go below 1 Karma cost.
+                    if (intKarmaCost > 1) intKarmaCost -= 1;
+                } else {
+                    intKarmaCost += 2;
+                }
+            }
 
 			if (intKarmaCost > _objCharacter.Karma)
 			{
@@ -4256,6 +4266,18 @@ namespace Chummer
 			// If the character is Uneducated and the Skill is an Academic or Professional Skill, double its cost.
 			if (_objCharacter.Uneducated && (objSkillControl.SkillCategory == "Academic" || objSkillControl.SkillCategory == "Professional"))
 				intKarmaCost *= 2;
+
+            // Jack of all trades lowers cost of skill by 1 up through rank 5, but adds 2 for ranks 6+, cant lower cost below 1
+            if (_objCharacter.JackOfAllTrades)
+            {
+                if (objSkillControl.SkillRating + 1 <= 5)
+                {
+                    //Jack of All Trades cannot go below 1 Karma cost.
+                    if (intKarmaCost > 1) intKarmaCost -= 1;
+                } else {
+                    intKarmaCost += 2;
+                }
+            }
 
 			// The Karma Cost for improving a Language Knowledge Skill to Rating 1 is free for characters with the Linguistics Adept Power.
 			if (_objImprovementManager.ValueOf(Improvement.ImprovementType.AdeptLinguistics) > 0 && objSkillControl.SkillCategory == "Language" && objSkillControl.SkillRating == 0)


### PR DESCRIPTION
Jack of all Trades was implemented backwards -- it was being applied during character creation, but not during career mode.  Correct implementation is the reverse.

Also tweaked the logic order a bit so JOATMON would stack correctly with Adept Linguistics (apply JOATMON before) and with Uneducated/Uncouth (apply JOATMON after).
