### PR TITLE
Fixes to Positive and Negative Quality limits

### DIFF
--- a/Chummer/Classes/clsCrashreport.cs
+++ b/Chummer/Classes/clsCrashreport.cs
@@ -131,7 +131,6 @@ namespace Chummer
 				}
 				catch (Exception ex)
 				{
-					
 				}
 
 				report.AppendFormat("CommandLine={0}", Environment.CommandLine);

--- a/Chummer/Classes/clsOptions.cs
+++ b/Chummer/Classes/clsOptions.cs
@@ -3064,7 +3064,7 @@ namespace Chummer
 		}
 
 		/// <summary>
-		/// Whether or not characters can have more than 35 BP in Positive Qualities.
+		/// Whether or not characters can have more than 25 BP in Positive Qualities.
 		/// </summary>
 		public bool ExceedPositiveQualities
 		{
@@ -3079,7 +3079,7 @@ namespace Chummer
 		}
 
 		/// <summary>
-		/// Whether or not characters can have more than 35 BP in Negative Qualities.
+		/// Whether or not characters can have more than 25 BP in Negative Qualities.
 		/// </summary>
 		public bool ExceedNegativeQualities
 		{
@@ -3094,8 +3094,7 @@ namespace Chummer
 		}
 
 		/// <summary>
-		/// Whether or not character can still only receive up to 35 BP from Negative Qualities. This means they can take as many Negative Qualities as they'd like but will never receive more than
-		/// 35 additional BP from selecting them.
+		/// If true, the character will not receive additional BP from Negative Qualities past the initial 25
 		/// </summary>
 		public bool ExceedNegativeQualitiesLimit
 		{


### PR DESCRIPTION
Fixed the ExceedNegativeQualities option
Fixed the ExceedPositiveQualities option
Fixed the ExceedNegativeQualitesLimit option

CalculateBP() was incorrectly summing over multiple enemies - 1st enemy would be correct, 2nd enemy would add iteratively to first (1+1+2), 3rd would add in both the other two (1+1+1+2+2+3) etc.

So was ValidateCharacter()

These two functions BP cost calculation for Enemies sometimes used karma cost multiplier of qualities, sometimes using karma cost multiplier for contacts -- it is unclear which to use, but they definitely need to be consistent -- so I made a command decision use karma multiplier for contacts.

Further comment for future changes:
The entire Enemy system is a holdover from 4th ed, and doesn't actually exist in 5th.  So I didn't do a full cleanup of all the enemy code -- just the parts in the CalculateBP() and ValidateCharacter() functions.
Note: the enemy system apparently uses karma cost multiplier for qualities, so it is currently inconsistent with CalculateBP() and ValidateCharacter().  Rather than go through and change it all around, I figured I'd leave it to be done all at once when Enemies gets a cleanup pass.