### PR TITLE
Fixes to enemies and contacts

### DIFF
--- a/Chummer/Classes/clsOptions.cs
+++ b/Chummer/Classes/clsOptions.cs
@@ -911,6 +911,7 @@ namespace Chummer
         private int _intKarmaComplexFormOption = 2;
         private int _intKarmaComplexFormSkillfot = 1;
         private int _intKarmaContact = 1;
+        private int _intKarmaEnemy = 1;
         private int _intKarmaEnhancement = 2;
         private int _intKarmaImproveActiveSkill = 2;
         private int _intKarmaImproveComplexForm = 1;
@@ -1225,7 +1226,9 @@ namespace Chummer
 			objWriter.WriteElementString("karmanuyenper", _intKarmaNuyenPer.ToString());
 			// <karmacontact />
 			objWriter.WriteElementString("karmacontact", _intKarmaContact.ToString());
-			// <karmacarryover />
+            // <karmaenemy />
+            objWriter.WriteElementString("karmaenemy", _intKarmaEnemy.ToString());
+            // <karmacarryover />
 			objWriter.WriteElementString("karmacarryover", _intKarmaCarryover.ToString());
 			// <karmaspirit />
 			objWriter.WriteElementString("karmaspirit", _intKarmaSpirit.ToString());
@@ -1904,6 +1907,7 @@ namespace Chummer
 			_intKarmaImproveComplexForm = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmaimprovecomplexform").InnerText);
 			_intKarmaNuyenPer = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmanuyenper").InnerText);
 			_intKarmaContact = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmacontact").InnerText);
+            _intKarmaEnemy = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmaenemy").InnerText);
 			_intKarmaCarryover = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmacarryover").InnerText);
 			_intKarmaSpirit = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmaspirit").InnerText);
 			_intKarmaManeuver = Convert.ToInt32(objXmlDocument.SelectSingleNode("/settings/karmacost/karmamaneuver").InnerText);
@@ -2193,6 +2197,7 @@ namespace Chummer
 				_intKarmaImproveComplexForm = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmaimprovecomplexform").ToString());
 				_intKarmaNuyenPer = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmanuyenper").ToString());
 				_intKarmaContact = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmacontact").ToString());
+                _intKarmaEnemy = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmaenemy").ToString());
 				_intKarmaCarryover = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmacarryover").ToString());
 				_intKarmaSpirit = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmaspirit").ToString());
 				_intKarmaManeuver = Convert.ToInt32(Registry.CurrentUser.CreateSubKey("Software\\Chummer5").GetValue("karmamaneuver").ToString());
@@ -4041,6 +4046,21 @@ namespace Chummer
 				_intKarmaContact = value;
 			}
 		}
+
+        /// <summary>
+        /// Karma cost for an Enemy = (Connection + Loyalty) x this value.
+        /// </summary>
+        public int KarmaEnemy
+        {
+            get
+            {
+                return _intKarmaEnemy;
+            }
+            set
+            {
+                _intKarmaEnemy = value;
+            }
+        }
 
 		/// <summary>
 		/// Maximum amount of remaining Karma that is carried over to the character once they are created.

--- a/Chummer/Controls/ContactControl.cs
+++ b/Chummer/Controls/ContactControl.cs
@@ -10,6 +10,8 @@ using System.Xml;
 public delegate void ConnectionRatingChangedHandler(Object sender);
 // GroupRatingChanged Event Handler.
 public delegate void ConnectionGroupRatingChangedHandler(Object sender);
+// FreeRatingChanged Event Handler.
+public delegate void FreeRatingChangedHandler(Object sender);
 // LoyaltyRatingChanged Event Handler.
 public delegate void LoyaltyRatingChangedHandler(Object sender);
 // DeleteContact Event Handler.
@@ -34,8 +36,9 @@ namespace Chummer
 
         // Events.
         public event ConnectionRatingChangedHandler ConnectionRatingChanged;
-        public event ConnectionRatingChangedHandler GroupStatusChanged;
+        public event ConnectionGroupRatingChangedHandler GroupStatusChanged;
 		public event LoyaltyRatingChangedHandler LoyaltyRatingChanged;
+        public event FreeRatingChangedHandler FreeRatingChanged;
         public event DeleteContactHandler DeleteContact;
         public event FileNameChangedHandler FileNameChanged;
 
@@ -525,22 +528,24 @@ namespace Chummer
             _objContact.IsGroup = chkGroup.Checked;
             chkGroup.Enabled = !_objContact.MadeMan;
 
-	        if (GroupStatusChanged != null)
-		        GroupStatusChanged(this);
+	        if (GroupStatusChanged != null)  GroupStatusChanged(this);
 
             //Loyalty can be changed by event above
             nudLoyalty.Enabled = !_objContact.IsGroup;
             nudLoyalty.Value = _objContact.Loyalty;
             UpdateQuickText();
         }
+
         public void UpdateQuickText()
         {
             lblQuickStats.Text = String.Format("({0}/{1})", _objContact.Connection, _objContact.IsGroup ? (_objContact.MadeMan ? "M" : "G") : _objContact.Loyalty.ToString());
 
         }
+
         private void chkFree_CheckedChanged(object sender, EventArgs e)
         {
             _objContact.Free = chkFree.Checked;
+            if (FreeRatingChanged != null) FreeRatingChanged(this);
         }
     }
 }

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -708,6 +708,7 @@ namespace Chummer
 					objContactControl.LoyaltyRatingChanged += objContact_LoyaltyRatingChanged;
 					objContactControl.DeleteContact += objContact_DeleteContact;
 					objContactControl.FileNameChanged += objContact_FileNameChanged;
+                    objContactControl.FreeRatingChanged += objContact_OtherCostChanged;
 					
 					objContactControl.ContactObject = objContact;
 					objContactControl.ContactName = objContact.Name;
@@ -735,6 +736,7 @@ namespace Chummer
 					objContactControl.LoyaltyRatingChanged += objEnemy_LoyaltyRatingChanged;
 					objContactControl.DeleteContact += objEnemy_DeleteContact;
 					objContactControl.FileNameChanged += objEnemy_FileNameChanged;
+                    objContactControl.FreeRatingChanged += objEnemy_FreeStatusChanged;
 
                     objContactControl.IsEnemy = true;
 					objContactControl.ContactObject = objContact;
@@ -1529,6 +1531,7 @@ namespace Chummer
 					objContactControl.LoyaltyRatingChanged -= objContact_LoyaltyRatingChanged;
 					objContactControl.DeleteContact -= objContact_DeleteContact;
 					objContactControl.FileNameChanged -= objContact_FileNameChanged;
+                    objContactControl.FreeRatingChanged -= objContact_OtherCostChanged;
 				}
 
 				foreach (ContactControl objContactControl in panEnemies.Controls.OfType<ContactControl>())
@@ -1537,6 +1540,7 @@ namespace Chummer
 					objContactControl.LoyaltyRatingChanged -= objEnemy_LoyaltyRatingChanged;
 					objContactControl.DeleteContact -= objEnemy_DeleteContact;
 					objContactControl.FileNameChanged -= objEnemy_FileNameChanged;
+                    objContactControl.FreeRatingChanged += objEnemy_FreeStatusChanged;
 				}
 
 				foreach (PetControl objContactControl in panPets.Controls.OfType<PetControl>())
@@ -4604,6 +4608,16 @@ namespace Chummer
 			UpdateWindowTitle();
 		}
 
+        private void objContact_OtherCostChanged(Object sender)
+        {
+            //Handle any other kind of change that changes contact cost
+            //mostly a free contact but a few details in run faster changes it too
+            UpdateCharacterInfo();
+
+            _blnIsDirty = true;
+            UpdateWindowTitle();
+        }
+
 		private void objContact_DeleteContact(Object sender)
 		{
 			objContact_DeleteContact(sender, false);
@@ -4674,6 +4688,14 @@ namespace Chummer
 			_blnIsDirty = true;
 			UpdateWindowTitle();
 		}
+
+        private void objEnemy_FreeStatusChanged(Object sender)
+        {
+            UpdateCharacterInfo();
+
+            _blnIsDirty = true;
+            UpdateWindowTitle();
+        }
 
 		private void objEnemy_DeleteContact(Object sender)
 		{
@@ -5077,6 +5099,7 @@ namespace Chummer
 			objContactControl.LoyaltyRatingChanged += objContact_LoyaltyRatingChanged;
 			objContactControl.DeleteContact += objContact_DeleteContact;
 			objContactControl.FileNameChanged += objContact_FileNameChanged;
+            objContactControl.FreeRatingChanged += objContact_OtherCostChanged;
 
 			panContacts.Controls.Add(objContactControl);
 			UpdateCharacterInfo();
@@ -5101,6 +5124,7 @@ namespace Chummer
 			objContactControl.LoyaltyRatingChanged += objEnemy_LoyaltyRatingChanged;
 			objContactControl.DeleteContact += objEnemy_DeleteContact;
 			objContactControl.FileNameChanged += objEnemy_FileNameChanged;
+            objContactControl.FreeRatingChanged += objEnemy_FreeStatusChanged;
             objContactControl.IsEnemy = true;
 
 			panEnemies.Controls.Add(objContactControl);

--- a/Chummer/frmOptions.Designer.cs
+++ b/Chummer/frmOptions.Designer.cs
@@ -52,6 +52,9 @@
 			this.lblKarmaContactExtra = new System.Windows.Forms.Label();
 			this.nudKarmaContact = new System.Windows.Forms.NumericUpDown();
 			this.lblKarmaContact = new System.Windows.Forms.Label();
+            this.lblKarmaEnemyExtra = new System.Windows.Forms.Label();
+            this.nudKarmaEnemy = new System.Windows.Forms.NumericUpDown();
+            this.lblKarmaEnemy = new System.Windows.Forms.Label();
 			this.lblKarmaNuyenPerExtra = new System.Windows.Forms.Label();
 			this.nudKarmaNuyenPer = new System.Windows.Forms.NumericUpDown();
 			this.lblKarmaNuyenPer = new System.Windows.Forms.Label();
@@ -369,7 +372,7 @@
 			this.nudKarmaMetamagic.Location = new System.Drawing.Point(560, 4);
 			this.nudKarmaMetamagic.Name = "nudKarmaMetamagic";
 			this.nudKarmaMetamagic.Size = new System.Drawing.Size(47, 20);
-			this.nudKarmaMetamagic.TabIndex = 55;
+			this.nudKarmaMetamagic.TabIndex = 58;
 			// 
 			// lblKarmaMetamagic
 			// 
@@ -377,43 +380,43 @@
 			this.lblKarmaMetamagic.Location = new System.Drawing.Point(402, 6);
 			this.lblKarmaMetamagic.Name = "lblKarmaMetamagic";
 			this.lblKarmaMetamagic.Size = new System.Drawing.Size(154, 13);
-			this.lblKarmaMetamagic.TabIndex = 54;
+			this.lblKarmaMetamagic.TabIndex = 57;
 			this.lblKarmaMetamagic.Tag = "Label_Options_Metamagics";
 			this.lblKarmaMetamagic.Text = "Additional Metamagics/Echoes";
 			// 
 			// lblKarmaInitiationBracket
 			// 
 			this.lblKarmaInitiationBracket.AutoSize = true;
-			this.lblKarmaInitiationBracket.Location = new System.Drawing.Point(158, 500);
+			this.lblKarmaInitiationBracket.Location = new System.Drawing.Point(158, 526);
 			this.lblKarmaInitiationBracket.Name = "lblKarmaInitiationBracket";
 			this.lblKarmaInitiationBracket.Size = new System.Drawing.Size(10, 13);
-			this.lblKarmaInitiationBracket.TabIndex = 51;
+			this.lblKarmaInitiationBracket.TabIndex = 54;
 			this.lblKarmaInitiationBracket.Text = "(";
 			// 
 			// lblKarmaInitiationExtra
 			// 
 			this.lblKarmaInitiationExtra.AutoSize = true;
-			this.lblKarmaInitiationExtra.Location = new System.Drawing.Point(219, 500);
+			this.lblKarmaInitiationExtra.Location = new System.Drawing.Point(219, 526);
 			this.lblKarmaInitiationExtra.Name = "lblKarmaInitiationExtra";
 			this.lblKarmaInitiationExtra.Size = new System.Drawing.Size(98, 13);
-			this.lblKarmaInitiationExtra.TabIndex = 53;
+			this.lblKarmaInitiationExtra.TabIndex = 56;
 			this.lblKarmaInitiationExtra.Tag = "Label_Options_NewRatingTen";
 			this.lblKarmaInitiationExtra.Text = "x New Rating) + 10";
 			// 
 			// nudKarmaInitiation
 			// 
-			this.nudKarmaInitiation.Location = new System.Drawing.Point(166, 498);
+			this.nudKarmaInitiation.Location = new System.Drawing.Point(166, 524);
 			this.nudKarmaInitiation.Name = "nudKarmaInitiation";
 			this.nudKarmaInitiation.Size = new System.Drawing.Size(47, 20);
-			this.nudKarmaInitiation.TabIndex = 52;
+			this.nudKarmaInitiation.TabIndex = 55;
 			// 
 			// lblKarmaInitiation
 			// 
 			this.lblKarmaInitiation.AutoSize = true;
-			this.lblKarmaInitiation.Location = new System.Drawing.Point(8, 500);
+			this.lblKarmaInitiation.Location = new System.Drawing.Point(8, 526);
 			this.lblKarmaInitiation.Name = "lblKarmaInitiation";
 			this.lblKarmaInitiation.Size = new System.Drawing.Size(112, 13);
-			this.lblKarmaInitiation.TabIndex = 50;
+			this.lblKarmaInitiation.TabIndex = 53;
 			this.lblKarmaInitiation.Tag = "Label_Options_Initiation";
 			this.lblKarmaInitiation.Text = "Initiation / Submersion";
 			// 
@@ -464,29 +467,56 @@
 			// lblKarmaCarryoverExtra
 			// 
 			this.lblKarmaCarryoverExtra.AutoSize = true;
-			this.lblKarmaCarryoverExtra.Location = new System.Drawing.Point(219, 474);
+			this.lblKarmaCarryoverExtra.Location = new System.Drawing.Point(219, 500);
 			this.lblKarmaCarryoverExtra.Name = "lblKarmaCarryoverExtra";
 			this.lblKarmaCarryoverExtra.Size = new System.Drawing.Size(51, 13);
-			this.lblKarmaCarryoverExtra.TabIndex = 49;
+			this.lblKarmaCarryoverExtra.TabIndex = 52;
 			this.lblKarmaCarryoverExtra.Tag = "Label_Options_Maximum";
 			this.lblKarmaCarryoverExtra.Text = "Maximum";
 			// 
 			// nudKarmaCarryover
 			// 
-			this.nudKarmaCarryover.Location = new System.Drawing.Point(166, 472);
+			this.nudKarmaCarryover.Location = new System.Drawing.Point(166, 498);
 			this.nudKarmaCarryover.Name = "nudKarmaCarryover";
 			this.nudKarmaCarryover.Size = new System.Drawing.Size(47, 20);
-			this.nudKarmaCarryover.TabIndex = 48;
+			this.nudKarmaCarryover.TabIndex = 51;
 			// 
 			// lblKarmaCarryover
 			// 
 			this.lblKarmaCarryover.AutoSize = true;
-			this.lblKarmaCarryover.Location = new System.Drawing.Point(8, 474);
+			this.lblKarmaCarryover.Location = new System.Drawing.Point(8, 500);
 			this.lblKarmaCarryover.Name = "lblKarmaCarryover";
 			this.lblKarmaCarryover.Size = new System.Drawing.Size(141, 13);
-			this.lblKarmaCarryover.TabIndex = 47;
+			this.lblKarmaCarryover.TabIndex = 50;
 			this.lblKarmaCarryover.Tag = "Label_Options_Carryover";
 			this.lblKarmaCarryover.Text = "Carryover for New Character";
+            // 
+            // lblKarmaEnemyExtra
+            // 
+            this.lblKarmaEnemyExtra.AutoSize = true;
+            this.lblKarmaEnemyExtra.Location = new System.Drawing.Point(219, 474);
+            this.lblKarmaEnemyExtra.Name = "lblKarmaEnemyExtra";
+            this.lblKarmaEnemyExtra.Size = new System.Drawing.Size(120, 13);
+            this.lblKarmaEnemyExtra.TabIndex = 49;
+            this.lblKarmaEnemyExtra.Tag = "Label_Options_ConnectionLoyalty";
+            this.lblKarmaEnemyExtra.Text = "x (Connection + Loyalty)";
+            // 
+            // nudKarmaEnemy
+            // 
+            this.nudKarmaEnemy.Location = new System.Drawing.Point(166, 472);
+            this.nudKarmaEnemy.Name = "nudKarmaEnemy";
+            this.nudKarmaEnemy.Size = new System.Drawing.Size(47, 20);
+            this.nudKarmaEnemy.TabIndex = 48;
+            // 
+            // lblKarmaEnemy
+            // 
+            this.lblKarmaEnemy.AutoSize = true;
+            this.lblKarmaEnemy.Location = new System.Drawing.Point(8, 474);
+            this.lblKarmaEnemy.Name = "lblKarmaEnemy";
+            this.lblKarmaEnemy.Size = new System.Drawing.Size(49, 13);
+            this.lblKarmaEnemy.TabIndex = 47;
+            this.lblKarmaEnemy.Tag = "Label_Options_Enemies";
+            this.lblKarmaEnemy.Text = "Enemies";
 			// 
 			// lblKarmaContactExtra
 			// 
@@ -1644,11 +1674,14 @@
 			this.tabKarmaCosts.Controls.Add(this.lblKarmaImproveSkillGroup);
 			this.tabKarmaCosts.Controls.Add(this.lblKarmaCarryover);
 			this.tabKarmaCosts.Controls.Add(this.nudKarmaImproveSkillGroup);
-			this.tabKarmaCosts.Controls.Add(this.lblKarmaContactExtra);
-			this.tabKarmaCosts.Controls.Add(this.lblKarmaImproveSkillGroupExtra);
-			this.tabKarmaCosts.Controls.Add(this.nudKarmaContact);
+            this.tabKarmaCosts.Controls.Add(this.lblKarmaContact);
+            this.tabKarmaCosts.Controls.Add(this.nudKarmaContact); 
+            this.tabKarmaCosts.Controls.Add(this.lblKarmaContactExtra);
+            this.tabKarmaCosts.Controls.Add(this.lblKarmaEnemy); 
+            this.tabKarmaCosts.Controls.Add(this.nudKarmaEnemy);
+            this.tabKarmaCosts.Controls.Add(this.lblKarmaEnemyExtra);
+            this.tabKarmaCosts.Controls.Add(this.lblKarmaImproveSkillGroupExtra);
 			this.tabKarmaCosts.Controls.Add(this.lblKarmaAttribute);
-			this.tabKarmaCosts.Controls.Add(this.lblKarmaContact);
 			this.tabKarmaCosts.Controls.Add(this.nudKarmaAttribute);
 			this.tabKarmaCosts.Controls.Add(this.lblKarmaNuyenPerExtra);
 			this.tabKarmaCosts.Controls.Add(this.lblKarmaAttributeExtra);
@@ -2876,8 +2909,11 @@
 		private System.Windows.Forms.NumericUpDown nudKarmaCarryover;
 		private System.Windows.Forms.Label lblKarmaCarryover;
 		private System.Windows.Forms.Label lblKarmaContactExtra;
+        private System.Windows.Forms.Label lblKarmaEnemyExtra;
 		private System.Windows.Forms.NumericUpDown nudKarmaContact;
+        private System.Windows.Forms.NumericUpDown nudKarmaEnemy;
 		private System.Windows.Forms.Label lblKarmaContact;
+        private System.Windows.Forms.Label lblKarmaEnemy;
 		private System.Windows.Forms.Label lblKarmaNuyenPerExtra;
 		private System.Windows.Forms.NumericUpDown nudKarmaNuyenPer;
 		private System.Windows.Forms.Label lblKarmaNuyenPer;

--- a/Chummer/frmOptions.cs
+++ b/Chummer/frmOptions.cs
@@ -449,6 +449,7 @@ namespace Chummer
             _objOptions.KarmaMetamagic = Convert.ToInt32(nudKarmaMetamagic.Value);
             _objOptions.KarmaNuyenPer = Convert.ToInt32(nudKarmaNuyenPer.Value);
             _objOptions.KarmaContact = Convert.ToInt32(nudKarmaContact.Value);
+            _objOptions.KarmaEnemy = Convert.ToInt32(nudKarmaEnemy.Value);
             _objOptions.KarmaCarryover = Convert.ToInt32(nudKarmaCarryover.Value);
             _objOptions.KarmaSpirit = Convert.ToInt32(nudKarmaSpirit.Value);
             _objOptions.KarmaManeuver = Convert.ToInt32(nudKarmaManeuver.Value);
@@ -624,6 +625,7 @@ namespace Chummer
             nudKarmaManeuver.Value = 4;
             nudKarmaNuyenPer.Value = 2000;
             nudKarmaContact.Value = 1;
+            nudKarmaEnemy.Value = 1;
             nudKarmaCarryover.Value = 7;
             nudKarmaInitiation.Value = 3;
             nudKarmaMetamagic.Value = 15;
@@ -830,6 +832,8 @@ namespace Chummer
             lblKarmaNuyenPerExtra.Left = nudKarmaNuyenPer.Left + nudKarmaNuyenPer.Width + 6;
             nudKarmaContact.Left = lblKarmaImproveKnowledgeSkill.Left + lblKarmaImproveKnowledgeSkill.Width + 6;
             lblKarmaContactExtra.Left = nudKarmaContact.Left + nudKarmaContact.Width + 6;
+            nudKarmaEnemy.Left = lblKarmaImproveKnowledgeSkill.Left + lblKarmaImproveKnowledgeSkill.Width + 6;
+            lblKarmaEnemyExtra.Left = nudKarmaEnemy.Left + nudKarmaEnemy.Width + 6;
             nudKarmaCarryover.Left = lblKarmaImproveKnowledgeSkill.Left + lblKarmaImproveKnowledgeSkill.Width + 6;
             lblKarmaCarryoverExtra.Left = nudKarmaCarryover.Left + nudKarmaCarryover.Width + 6;
             nudKarmaInitiation.Left = lblKarmaImproveKnowledgeSkill.Left + lblKarmaImproveKnowledgeSkill.Width + 6;
@@ -1698,6 +1702,7 @@ namespace Chummer
             nudKarmaComplexFormSkillsoft.Value = _objOptions.KarmaComplexFormSkillsoft;
             nudKarmaNuyenPer.Value = _objOptions.KarmaNuyenPer;
             nudKarmaContact.Value = _objOptions.KarmaContact;
+            nudKarmaEnemy.Value = _objOptions.KarmaEnemy;
             nudKarmaCarryover.Value = _objOptions.KarmaCarryover;
             nudKarmaSpirit.Value = _objOptions.KarmaSpirit;
             nudKarmaManeuver.Value = _objOptions.KarmaManeuver;

--- a/Chummer/lang/de.xml
+++ b/Chummer/lang/de.xml
@@ -4272,6 +4272,10 @@
       <text>Connections:</text>
     </string>
     <string>
+      <key>Label_Options_Enemies</key>
+      <text>Enemies</text>
+    </string>
+    <string>
       <key>Label_Options_Carryover</key>
       <text>Übertragen für neuen Charakter</text>
     </string>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -5931,6 +5931,10 @@ Only one attribute may be at its Maximum value during character creation.</text>
 			<key>Label_Options_Contacts</key>
 			<text>Contacts</text>
 		</string>
+    <string>
+      <key>Label_Options_Enemies</key>
+      <text>Enemies</text>
+    </string>
 		<string>
 			<key>Label_Options_Carryover</key>
 			<text>Carryover for New Character</text>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -5133,6 +5133,10 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
       <text>Contacts</text>
     </string>
     <string>
+      <key>Label_Options_Enemies</key>
+      <text>Enemies</text>
+    </string>
+    <string>
       <key>Label_Options_Carryover</key>
       <text>Karma transféré à la carrière</text>
     </string>

--- a/Chummer/lang/jp.xml
+++ b/Chummer/lang/jp.xml
@@ -5154,6 +5154,10 @@
       <text>コンタクト</text>
     </string>
     <string>
+      <key>Label_Options_Enemies</key>
+      <text>Enemies</text>
+    </string>
+    <string>
       <key>Label_Options_Carryover</key>
       <text>作成時の持ち越し</text>
     </string>


### PR DESCRIPTION
Reworked Enemies module to make it mostly work again.  Group checkbox still does nothing, but the rest is all working -- since we don't have any enemies rules for 5th edition anyway, not a big loss.

Free checkbox now works correctly to zero out karma cost for both contacts and enemies.

Added a new option to the options menu to allow setting enemies karma cost multiplier separately from contacts.