### PR TITLE
Adept power Linguistics + Tooltip karma costs

### DIFF
--- a/Chummer/Controls/SkillControl.Designer.cs
+++ b/Chummer/Controls/SkillControl.Designer.cs
@@ -129,8 +129,8 @@
 			this.cboKnowledgeSkillCategory.Size = new System.Drawing.Size(162, 21);
 			this.cboKnowledgeSkillCategory.TabIndex = 8;
 			this.cboKnowledgeSkillCategory.Visible = false;
-			this.cboKnowledgeSkillCategory.SelectedIndexChanged += new System.EventHandler(this.cboKnonwledgeSkillCategory_SelectedIndexChanged);
-			// 
+			this.cboKnowledgeSkillCategory.SelectedIndexChanged += new System.EventHandler(this.cboKnowledgeSkillCategory_SelectedIndexChanged);
+            // 
 			// cboSkillName
 			// 
 			this.cboSkillName.DropDownWidth = 250;
@@ -290,7 +290,6 @@
 			((System.ComponentModel.ISupportInitialize)(this.nudKarma)).EndInit();
 			this.ResumeLayout(false);
 			this.PerformLayout();
-
         }
         #endregion
 

--- a/Chummer/Controls/SkillControl.cs
+++ b/Chummer/Controls/SkillControl.cs
@@ -325,12 +325,14 @@ namespace Chummer
 			DeleteSkill(this);
         }
 
-		private void cboKnonwledgeSkillCategory_SelectedIndexChanged(object sender, EventArgs e)
+		private void cboKnowledgeSkillCategory_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			// Raise the RatingChanged Event when the user has changed the Knowledge Skill's Category.
 			// The entire SkillControl is passed as an argument so the handling event can evaluate its contents.
 			SkillCategory = cboKnowledgeSkillCategory.SelectedValue.ToString();
 			RatingChanged(this);
+            // recalculate skill costs
+            SkillRating = SkillRating;
 		}
 
 		private void lblSkillName_Click(object sender, EventArgs e)

--- a/Chummer/Controls/SkillControl.cs
+++ b/Chummer/Controls/SkillControl.cs
@@ -119,59 +119,63 @@ namespace Chummer
 
 				if (_objSkill.Rating < _objSkill.RatingMaximum)
 				{
+                    // active skill
 					if (KnowledgeSkill == false)
 					{
 						if (_objSkill.Rating == 0)
 							intKarmaCost = _objSkill.CharacterObject.Options.KarmaNewActiveSkill;
 						else
-						{
 							intKarmaCost = (_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveActiveSkill;
-						}
+
+                        // Double the Karma cost if the character is Uneducated and is a Technical Active, Academic, or Professional Skill.
+                        if (_objSkill.CharacterObject.Uneducated && (SkillCategory == "Technical Active"))
+                            intKarmaCost *= 2;
+                        //Double the Karma cost if the character is Uncouth and is a Social Active Skill.
+                        if (_objSkill.CharacterObject.Uncouth && (SkillCategory == "Social Active"))
+                            intKarmaCost *= 2;
 					}
+
+                    // knowledge skill
 					else
 					{
                         if (_objSkill.Rating == 0)
                             intKarmaCost = _objSkill.CharacterObject.Options.KarmaNewKnowledgeSkill;
-                        else if (_objSkill.Rating >= 3)
+                        else 
+                            intKarmaCost = (_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill;
+
+                        // Double the Karma cost if the character is Uneducated and is an Academic, or Professional Skill.
+                        if (_objSkill.CharacterObject.Uneducated && (SkillCategory == "Academic" || SkillCategory == "Professional"))
+                            intKarmaCost *= 2;
+
+                        if (_objSkill.Rating >= 3)
                         {
                             //Street Knowledge Skills > Rank 2 gain a 1 karma discount with the School of Hard Knocks quality.
                             if (_objSkill.CharacterObject.SchoolOfHardKnocks && _objSkill.SkillCategory == "Street")
                             {
-                                intKarmaCost = ((_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill) - 1;
+                                intKarmaCost -= 1;
                             }
                             //Academic Knowledge Skills > Rank 2 gain a 1 karma discount with the College Education quality.
                             else if (_objSkill.CharacterObject.CollegeEducation && _objSkill.SkillCategory == "Academic")
                             {
-                                intKarmaCost = ((_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill) - 1;
+                                intKarmaCost -= 1;
                             }
                             //Professional Knowledge Skills > Rank 2 gain a 1 karma discount with the Tech School quality.
                             else if (_objSkill.CharacterObject.TechSchool && _objSkill.SkillCategory == "Professional")
                             {
-                                intKarmaCost = ((_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill) - 1;
+                                intKarmaCost -= 1;
                             }
                             //Linguist Skills > Rank 2 gain a 1 karma discount with the Linguist quality.
                             else if (_objSkill.CharacterObject.Linguist && _objSkill.SkillCategory == "Language")
                             {
-                                intKarmaCost = ((_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill) - 1;
+                                intKarmaCost -= 1;
                             }
                         }
-                        else
-                            intKarmaCost = (_objSkill.Rating + 1) * _objSkill.CharacterObject.Options.KarmaImproveKnowledgeSkill;
 					}
-
-					// Double the Karma cost if the character is Uneducated and is a Technical Active, Academic, or Professional Skill.
-					if (_objSkill.CharacterObject.Uneducated && (SkillCategory == "Technical Active" || SkillCategory == "Academic" || SkillCategory == "Professional"))
-						intKarmaCost *= 2;
-                    //Double the Karma cost if the character is Uncouth and is a Social Active Skill.
-                    if (_objSkill.CharacterObject.Uncouth && (SkillCategory == "Social Active"))
-                    {
-                        intKarmaCost *= 2;
-                    }
 
                     //Jack of All Trades reduces the cost by 1 for skills below 5, and increases them by 2 for skills at rank 6 or higher, minimum cost of 1
                     if (_objSkill.CharacterObject.Created && _objSkill.CharacterObject.JackOfAllTrades)
                     {
-                        if (_objSkill.Rating <= 5)
+                        if (_objSkill.Rating < 5)
                         {
                             //Jack of All Trades cannot go below 1 Karma cost. 
                             if (intKarmaCost > 1) intKarmaCost -= 1;
@@ -251,10 +255,6 @@ namespace Chummer
 
             chkKarma.Checked = _objSkill.BuyWithKarma;
 			lblAttribute.Text = _objSkill.DisplayAttribute;
-
-	        
-
-
 
 			RefreshControl();
 			_blnSkipRefresh = false;
@@ -712,15 +712,16 @@ namespace Chummer
                     int intNewRating = value + 1;
 					int intKarmaCost = 0;
 
+                    // active skill
 					if (KnowledgeSkill == false)
 					{
 						if (value == 0)
 							intKarmaCost = _objSkill.CharacterObject.Options.KarmaNewActiveSkill;
 						else
-						{
 							intKarmaCost = (value + 1) * _objSkill.CharacterObject.Options.KarmaImproveActiveSkill;
-						}
 					}
+
+                    // knowledge skill
 					else
 					{
 						if (value == 0)
@@ -752,6 +753,30 @@ namespace Chummer
                         else
                         {
                             intKarmaCost += 2;
+                        }
+                    }
+
+                    if (_objSkill.Rating >= 3)
+                    {
+                        //Street Knowledge Skills > Rank 2 gain a 1 karma discount with the School of Hard Knocks quality.
+                        if (_objSkill.CharacterObject.SchoolOfHardKnocks && _objSkill.SkillCategory == "Street")
+                        {
+                            intKarmaCost -= 1;
+                        }
+                        //Academic Knowledge Skills > Rank 2 gain a 1 karma discount with the College Education quality.
+                        else if (_objSkill.CharacterObject.CollegeEducation && _objSkill.SkillCategory == "Academic")
+                        {
+                            intKarmaCost -= 1;
+                        }
+                        //Professional Knowledge Skills > Rank 2 gain a 1 karma discount with the Tech School quality.
+                        else if (_objSkill.CharacterObject.TechSchool && _objSkill.SkillCategory == "Professional")
+                        {
+                            intKarmaCost -= 1;
+                        }
+                        //Linguist Skills > Rank 2 gain a 1 karma discount with the Linguist quality.
+                        else if (_objSkill.CharacterObject.Linguist && _objSkill.SkillCategory == "Language")
+                        {
+                            intKarmaCost -= 1;
                         }
                     }
 

--- a/Chummer/Controls/SkillControl.cs
+++ b/Chummer/Controls/SkillControl.cs
@@ -169,7 +169,7 @@ namespace Chummer
                     }
 
                     //Jack of All Trades reduces the cost by 1 for skills below 5, and increases them by 2 for skills at rank 6 or higher, minimum cost of 1
-                    if (_objSkill.CharacterObject.JackOfAllTrades)
+                    if (_objSkill.CharacterObject.Created && _objSkill.CharacterObject.JackOfAllTrades)
                     {
                         if (_objSkill.Rating <= 5)
                         {
@@ -182,14 +182,17 @@ namespace Chummer
                         }
                     }
 
-					strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", intNewRating.ToString()).Replace("{1}", intKarmaCost.ToString());
-					tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
-				}
+                    // check for free intial point from adept linguistics
+                    ImprovementManager objImprovementManager = new ImprovementManager(_objSkill.CharacterObject);
+                    if (objImprovementManager.ValueOf(Improvement.ImprovementType.AdeptLinguistics) > 0 && SkillCategory == "Language" && SkillRating == 0)
+                        intKarmaCost = 0;
 
-				ImprovementManager objImprovementManager = new ImprovementManager(_objSkill.CharacterObject);
-				if (objImprovementManager.ValueOf(Improvement.ImprovementType.AdeptLinguistics) > 0 && SkillCategory == "Language" && SkillRating == 0)
-					strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", "1").Replace("{1}", "0");
-				tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
+					strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", intNewRating.ToString()).Replace("{1}", intKarmaCost.ToString());
+                    tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
+				    cmdImproveSkill.Enabled = true;
+				} 
+                else
+					cmdImproveSkill.Enabled = false;
 
 				nudSkill.Visible = false;
                 nudKarma.Visible = false;
@@ -752,8 +755,13 @@ namespace Chummer
                         }
                     }
 
+                    // check for adept linguistics initial free point
+                    ImprovementManager objImprovementManager = new ImprovementManager(_objSkill.CharacterObject);
+                    if (objImprovementManager.ValueOf(Improvement.ImprovementType.AdeptLinguistics) > 0 && SkillCategory == "Language" && SkillRating == 0)
+                        intKarmaCost = 0;
+
 					strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", intNewRating.ToString()).Replace("{1}", intKarmaCost.ToString());
-					tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
+                    tipTooltip.SetToolTip(cmdImproveSkill, strTooltip);
 					cmdImproveSkill.Enabled = true;
 				}
 				else

--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -638,6 +638,9 @@
       <adeptway>0</adeptway>
       <levels>no</levels>
       <limit>1</limit>
+      <bonus>
+        <adeptlinguistics />
+      </bonus>
       <source>SG</source>
       <page>172</page>
     </power>


### PR DESCRIPTION
Added missing bonus tag to the linguistics power in powers.xml
Fixed logic checks for linguistics power when determining language karma costs

Fixed logic checks for various qualities when determining knowledge skill karma costs.
Minor tweak to correctly hide karma cost tooltip when a knowledge skill is maxxed.
Changed knowledge skill category dropdown callback to force karma cost recalculation.

