### PR TITLE
Refactored System.IO.Path usage

### DIFF
--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -2303,14 +2303,16 @@ namespace Chummer
             string strMugshotPath = "";
             if (_strMugshot != "")
             {
-                if (!Directory.Exists(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "mugshots"))
-                    Directory.CreateDirectory(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "mugshots");
+				string mugshotsDirectoryPath = Path.Combine(Environment.CurrentDirectory, "mugshots");
+                if (!Directory.Exists(mugshotsDirectoryPath))
+                    Directory.CreateDirectory(mugshotsDirectoryPath);
                 byte[] bytImage = Convert.FromBase64String(_strMugshot);
                 MemoryStream objImageStream = new MemoryStream(bytImage, 0, bytImage.Length);
                 objImageStream.Write(bytImage, 0, bytImage.Length);
                 Image imgMugshot = Image.FromStream(objImageStream, true);
-                imgMugshot.Save(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "mugshots" + Path.DirectorySeparatorChar + guiImage.ToString() + ".img");
-                strMugshotPath = "file://" + (Environment.CurrentDirectory + Path.DirectorySeparatorChar + "mugshots" + Path.DirectorySeparatorChar + guiImage.ToString() + ".img").Replace(Path.DirectorySeparatorChar, '/');
+	            string imgMugshotPath = Path.Combine(mugshotsDirectoryPath, guiImage + ".img");
+                imgMugshot.Save(imgMugshotPath);
+                strMugshotPath = "file://" + imgMugshotPath.Replace(Path.DirectorySeparatorChar, '/');
             }
             // <mugshot />
             objWriter.WriteElementString("mugshot", strMugshotPath);

--- a/Chummer/Classes/clsCrashreport.cs
+++ b/Chummer/Classes/clsCrashreport.cs
@@ -29,7 +29,7 @@ namespace Chummer
 
 				try
 				{
-					string strFile = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "chummerlog.txt";
+					string strFile = Path.Combine(Environment.CurrentDirectory, "chummerlog.txt");
 					report.AddData("chummerlog.txt", new StreamReader(strFile).BaseStream);
 				}
 				catch(Exception ex)
@@ -46,9 +46,7 @@ namespace Chummer
 				//try to include default settings file
 				try
 				{
-					string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings");
-					strFilePath = Path.Combine(strFilePath, "default.xml");
-
+					string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings", "default.xml");
 					report.AddData("default.xml", new StreamReader(strFilePath).BaseStream);
 				}
 				catch (Exception ex)

--- a/Chummer/Classes/clsLanguageManager.cs
+++ b/Chummer/Classes/clsLanguageManager.cs
@@ -130,8 +130,7 @@ namespace Chummer
 			{
 				_objDictionary.Clear();
 				XmlDocument objEnglishDocument = new XmlDocument();
-				string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang");
-				strFilePath = Path.Combine(strFilePath, "en-us.xml");
+				string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang", "en-us.xml");
 				objEnglishDocument.Load(strFilePath);
 				foreach (XmlNode objNode in objEnglishDocument.SelectNodes("/chummer/strings/string"))
 				{
@@ -164,8 +163,7 @@ namespace Chummer
 				{
 					_strLanguage = strLanguage;
 					XmlDocument objLanguageDocument = new XmlDocument();
-					strFilePath = Path.Combine(Environment.CurrentDirectory, "lang");
-					strFilePath = Path.Combine(strFilePath, strLanguage + ".xml");
+					strFilePath = Path.Combine(Environment.CurrentDirectory, "lang", strLanguage + ".xml");
 					objLanguageDocument.Load(strFilePath);
 					_objXmlDocument.Load(strFilePath);
 					foreach (XmlNode objNode in objLanguageDocument.SelectNodes("/chummer/strings/string"))
@@ -190,8 +188,7 @@ namespace Chummer
 				}
 
 				// Check to see if the data translation file for the selected language exists.
-				string strDataPath = Path.Combine(Environment.CurrentDirectory, "lang");
-				strDataPath = Path.Combine(strDataPath, strLanguage + "_data.xml");
+				string strDataPath = Path.Combine(Environment.CurrentDirectory, "lang", strLanguage + "_data.xml");
 				if (File.Exists(strDataPath))
 				{
 					try
@@ -507,8 +504,7 @@ namespace Chummer
 			// Load the English version.
 			List<LanguageString> lstEnglish = new List<LanguageString>();
 			XmlDocument objEnglishDocument = new XmlDocument();
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang");
-			strFilePath = Path.Combine(strFilePath, "en-us.xml");
+			string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang", "en-us.xml");
 			objEnglishDocument.Load(strFilePath);
 			foreach (XmlNode objNode in objEnglishDocument.SelectNodes("/chummer/strings/string"))
 			{
@@ -521,8 +517,7 @@ namespace Chummer
 			// Load the selected language version.
 			List<LanguageString> lstLanguage = new List<LanguageString>();
 			XmlDocument objLanguageDocument = new XmlDocument();
-			string strLangPath = Path.Combine(Environment.CurrentDirectory, "lang");
-			strLangPath = Path.Combine(strLangPath, strLanguage + ".xml");
+			string strLangPath = Path.Combine(Environment.CurrentDirectory, "lang", strLanguage + ".xml");
 			objLanguageDocument.Load(strLangPath);
 			foreach (XmlNode objNode in objLanguageDocument.SelectNodes("/chummer/strings/string"))
 			{

--- a/Chummer/Classes/clsLog.cs
+++ b/Chummer/Classes/clsLog.cs
@@ -20,7 +20,7 @@ namespace Chummer
 			if (GlobalOptions.Instance.UseLogging)
 			{
 				//TODO: Add listner to UseLogging to be able to start it mid run
-				string strFile = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "chummerlog.txt";
+				string strFile = Path.Combine(Environment.CurrentDirectory, "chummerlog.txt");
 				logWriter = new StreamWriter(strFile);
 				stringBuilder = new StringBuilder();
 				logEnabled = true;

--- a/Chummer/Classes/clsOmaeHelper.cs
+++ b/Chummer/Classes/clsOmaeHelper.cs
@@ -214,7 +214,7 @@ namespace Chummer
 
 			foreach (string strFile in lstFiles)
 			{
-				Uri objUri = new Uri("/" + System.IO.Path.GetFileName(strFile).Replace(' ', '_'), UriKind.Relative);
+				Uri objUri = new Uri("/" + Path.GetFileName(strFile).Replace(' ', '_'), UriKind.Relative);
 				PackagePart objPart = objPackage.CreatePart(objUri, System.Net.Mime.MediaTypeNames.Application.Zip, CompressionOption.Maximum);
 				byte[] bytBuffer = File.ReadAllBytes(strFile);
 				objPart.GetStream().Write(bytBuffer, 0, bytBuffer.Length);
@@ -235,8 +235,8 @@ namespace Chummer
 
 			foreach (string strFile in lstFiles)
 			{
-				string[] strPath = System.IO.Path.GetDirectoryName(strFile).Replace(' ', '_').Split('\\');
-				string strPackFile = "/" + strPath[strPath.Length - 2] + "/" + strPath[strPath.Length - 1] + "/" + System.IO.Path.GetFileName(strFile).Replace(' ', '_');
+				string[] strPath = Path.GetDirectoryName(strFile).Replace(' ', '_').Split('\\');
+				string strPackFile = "/" + strPath[strPath.Length - 2] + "/" + strPath[strPath.Length - 1] + "/" + Path.GetFileName(strFile).Replace(' ', '_');
 				if (strPackFile.StartsWith("/saves"))
 					strPackFile = strPackFile.Replace("/saves", string.Empty);
 				Uri objUri = new Uri(strPackFile, UriKind.Relative);
@@ -286,8 +286,7 @@ namespace Chummer
 		/// /// <param name="bytBuffer">Byte array that contains the zip file.</param>
 		public void DecompressCharacterSheet(byte[] bytBuffer)
 		{
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "sheets");
-			strFilePath = Path.Combine(strFilePath, "omae");
+			string strFilePath = Path.Combine(Environment.CurrentDirectory, "sheets", "omae");
 			MemoryStream objStream = new MemoryStream();
 			objStream.Write(bytBuffer, 0, bytBuffer.Length);
 			Package objPackage = ZipPackage.Open(objStream, FileMode.Open, FileAccess.Read);

--- a/Chummer/Classes/clsOptions.cs
+++ b/Chummer/Classes/clsOptions.cs
@@ -115,8 +115,9 @@ namespace Chummer
 		#region Constructor and Instance
 		static GlobalOptions()
 		{
-			if (!Directory.Exists(Path.Combine(Environment.CurrentDirectory, "settings")))
-				Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, "settings"));
+			string settingsDirectoryPath = Path.Combine(Environment.CurrentDirectory, "settings");
+            if (!Directory.Exists(settingsDirectoryPath))
+				Directory.CreateDirectory(settingsDirectoryPath);
 
 			// Automatic Update.
 			try
@@ -962,12 +963,12 @@ namespace Chummer
 		public CharacterOptions()
 		{
 			// Create the settings directory if it does not exist.
-			if (!Directory.Exists(Path.Combine(Environment.CurrentDirectory, "settings")))
-				Directory.CreateDirectory(Path.Combine(Environment.CurrentDirectory, "settings"));
+			string settingsDirectoryPath = Path.Combine(Environment.CurrentDirectory, "settings");
+			if (!Directory.Exists(settingsDirectoryPath))
+				Directory.CreateDirectory(settingsDirectoryPath);
 
 			// If the default.xml settings file does not exist, attempt to read the settings from the Registry (old storage format), then save them to the default.xml file.
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings");
-			strFilePath = Path.Combine(strFilePath, "default.xml");
+			string strFilePath = Path.Combine(settingsDirectoryPath, "default.xml");
 			if (!File.Exists(strFilePath))
 			{
 				_strFileName = "default.xml";
@@ -988,8 +989,7 @@ namespace Chummer
 		/// </summary>
 		public void Save()
 		{
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings");
-			strFilePath = Path.Combine(strFilePath, _strFileName);
+			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings", _strFileName);
 			FileStream objStream = new FileStream(strFilePath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
 			XmlTextWriter objWriter = new XmlTextWriter(objStream, Encoding.Unicode);
 			objWriter.Formatting = Formatting.Indented;
@@ -1313,8 +1313,7 @@ namespace Chummer
 		public bool Load(string strFileName)
 		{
 			_strFileName = strFileName;
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings");
-			strFilePath = Path.Combine(strFilePath, _strFileName);
+			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings", _strFileName);
 			XmlDocument objXmlDocument = new XmlDocument();
 			try
 			{

--- a/Chummer/Classes/clsXmlManager.cs
+++ b/Chummer/Classes/clsXmlManager.cs
@@ -96,8 +96,7 @@ namespace Chummer
 		/// <param name="strFileName">Name of the XML file to load.</param>
 		public XmlDocument Load(string strFileName)
 		{
-			string strPath = Path.Combine(Environment.CurrentDirectory, "data");
-			strPath = Path.Combine(strPath, strFileName);
+			string strPath = Path.Combine(Environment.CurrentDirectory, "data", strFileName);
 			DateTime datDate = File.GetLastWriteTime(strPath);
 
 			// Look to see if this XmlDocument is already loaded.
@@ -381,12 +380,11 @@ namespace Chummer
 		public void Verify(string strLanguage, List<string> lstBooks)
 		{
 			XmlDocument objLanguageDoc = new XmlDocument();
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang");
-			strFilePath = Path.Combine(strFilePath, strLanguage + "_data.xml");
+			string languageDirectoryPath = Path.Combine(Environment.CurrentDirectory, "lang");
+            string strFilePath = Path.Combine(languageDirectoryPath, strLanguage + "_data.xml");
 			objLanguageDoc.Load(strFilePath);
 
-			string strLangPath = Path.Combine(Environment.CurrentDirectory, "lang");
-			strLangPath = Path.Combine(strLangPath, "results_" + strLanguage + ".xml");
+			string strLangPath = Path.Combine(languageDirectoryPath, "results_" + strLanguage + ".xml");
 			FileStream objStream = new FileStream(strLangPath, FileMode.Create, FileAccess.Write, FileShare.ReadWrite);
 			XmlTextWriter objWriter = new XmlTextWriter(objStream, Encoding.Unicode);
 			objWriter.Formatting = Formatting.Indented;
@@ -400,15 +398,14 @@ namespace Chummer
 			string strPath = Path.Combine(Environment.CurrentDirectory, "data");
 			foreach (string strFile in Directory.GetFiles(strPath, "*.xml"))
 			{
-				string strPathReplace = strPath + Path.DirectorySeparatorChar;
-				string strFileName = strFile.Replace(strPathReplace, string.Empty);
+				string strFileName = Path.GetFileName(strFile);
 
 				// Do not bother to check custom files.
 				if (!strFileName.StartsWith("custom") && !strFile.StartsWith("override") && !strFile.Contains("packs.xml") && !strFile.Contains("ranges.xml"))
 				{
 					// Load the current English file.
 					XmlDocument objEnglishDoc = new XmlDocument();
-					objEnglishDoc = Load(strFile.Replace(strPathReplace, string.Empty));
+					objEnglishDoc = Load(strFileName);
 					XmlNode objEnglishRoot = objEnglishDoc.SelectSingleNode("/chummer");
 
 					// First pass: make sure the document exists.

--- a/Chummer/Omae/frmOmae.cs
+++ b/Chummer/Omae/frmOmae.cs
@@ -256,12 +256,12 @@ namespace Chummer
 					string strSavePath = Path.Combine(Environment.CurrentDirectory, "saves");
 					if (!Directory.Exists(strSavePath))
 						Directory.CreateDirectory(strSavePath);
-					if (!Directory.Exists(Path.Combine(strSavePath, "omae")))
-						Directory.CreateDirectory(Path.Combine(strSavePath, "omae"));
+					string omaeDirectoryPath = Path.Combine(strSavePath, "omae");
+                    if (!Directory.Exists(omaeDirectoryPath))
+						Directory.CreateDirectory(omaeDirectoryPath);
 
 					// See if there is already a file with the character's name in the Downloads directory.
-					string strFullPath = Path.Combine(strSavePath, "omae");
-					strFullPath = Path.Combine(strFullPath, strFileName);
+					string strFullPath = Path.Combine(omaeDirectoryPath, strFileName);
 					if (File.Exists(strFullPath))
 					{
 						if (MessageBox.Show(LanguageManager.Instance.GetString("Message_Omae_FileExists").Replace("{0}", strFileName), LanguageManager.Instance.GetString("MessageTitle_Omae_FileExists"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
@@ -282,11 +282,9 @@ namespace Chummer
 
 						// Decompress the byte array and write it to a file.
 						bytFile = _objOmaeHelper.Decompress(bytFile);
-						string strWritePath = Path.Combine(strSavePath, "omae");
-						strWritePath = Path.Combine(strWritePath, strFileName);
-						File.WriteAllBytes(strWritePath, bytFile);
+						File.WriteAllBytes(strFullPath, bytFile);
 						if (MessageBox.Show(LanguageManager.Instance.GetString("Message_Omae_CharacterDownloaded"), LanguageManager.Instance.GetString("MessageTitle_Omae_CharacterDownloaded"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
-							_frmMain.LoadCharacter(strWritePath);
+							_frmMain.LoadCharacter(strFullPath);
 					}
 					catch (EndpointNotFoundException)
 					{
@@ -353,9 +351,9 @@ namespace Chummer
 			else if (_objMode == OmaeMode.Sheets)
 			{
 				// If the Omae sheets directory does not yet exist, create it.
-				string strSheetsPath = Path.Combine(Environment.CurrentDirectory, "sheets");
-				if (!Directory.Exists(Path.Combine(strSheetsPath, "omae")))
-					Directory.CreateDirectory(Path.Combine(strSheetsPath, "omae"));
+				string strSheetsPath = Path.Combine(Environment.CurrentDirectory, "sheets", "omae");
+				if (!Directory.Exists(strSheetsPath))
+					Directory.CreateDirectory(strSheetsPath);
 
 				try
 				{

--- a/Chummer/Omae/frmOmaeUploadData.cs
+++ b/Chummer/Omae/frmOmaeUploadData.cs
@@ -43,7 +43,7 @@ namespace Chummer
 			{
 				TreeNode objNode = new TreeNode();
 				objNode.Tag = strFile;
-				objNode.Text = strFile.Replace(strFilePath + Path.DirectorySeparatorChar, string.Empty);
+				objNode.Text = Path.GetFileName(strFile);
 				treFiles.Nodes.Add(objNode);
 			}
 
@@ -51,7 +51,7 @@ namespace Chummer
 			{
 				TreeNode objNode = new TreeNode();
 				objNode.Tag = strFile;
-				objNode.Text = strFile.Replace(strFilePath + Path.DirectorySeparatorChar, string.Empty);
+				objNode.Text = Path.GetFileName(strFile);
 				treFiles.Nodes.Add(objNode);
 			}
 		}
@@ -88,9 +88,9 @@ namespace Chummer
 			
 			bool blnSuccess = false;
 
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "data");
+			string strFilePath = Path.Combine(Environment.CurrentDirectory, "data", "books.xml");
 			XmlDocument objXmlBooks = new XmlDocument();
-			objXmlBooks.Load(Path.Combine(strFilePath, "books.xml"));
+			objXmlBooks.Load(strFilePath);
 
 			List<string> lstSource = new List<string>();
 

--- a/Chummer/Omae/frmOmaeUploadLanguage.cs
+++ b/Chummer/Omae/frmOmaeUploadLanguage.cs
@@ -86,8 +86,7 @@ namespace Chummer
 			}
 
 			byte[] bytFile = File.ReadAllBytes(txtFilePath.Text);
-			string[] strFileParts = txtFilePath.Text.Split(Path.DirectorySeparatorChar);
-			string strFileName = strFileParts[strFileParts.Length - 1];
+			string strFileName = Path.GetFileName(txtFilePath.Text);
 
 			translationSoapClient objService = _objOmaeHelper.GetTranslationService();
 			try

--- a/Chummer/Utilities/frmUpdate.cs
+++ b/Chummer/Utilities/frmUpdate.cs
@@ -336,7 +336,7 @@ namespace Chummer
                     else
                     {
                         objFunctions.LogWrite(CommonFunctions.LogType.Message, "frmUpdate", "File is another EXE");
-                        FileVersionInfo myFileVersionInfo = FileVersionInfo.GetVersionInfo(Environment.CurrentDirectory + Path.DirectorySeparatorChar + objXmlNode["name"].InnerText);
+                        FileVersionInfo myFileVersionInfo = FileVersionInfo.GetVersionInfo(Path.Combine(Environment.CurrentDirectory, objXmlNode["name"].InnerText));
                         string strVersion = myFileVersionInfo.FileVersion.ToString().Replace(".", "");
                         int intVersion = Convert.ToInt32(strVersion);
                         objFunctions.LogWrite(CommonFunctions.LogType.Content, "frmUpdate", "Existing Version = " + intVersion.ToString());
@@ -355,7 +355,7 @@ namespace Chummer
                     objFunctions.LogWrite(CommonFunctions.LogType.Message, "frmUpdate", "File is XML");
                     try
 					{
-						objXmlFileDocument.Load(Environment.CurrentDirectory + Path.DirectorySeparatorChar + objXmlNode["name"].InnerText.Replace('/', Path.DirectorySeparatorChar));
+						objXmlFileDocument.Load(Path.Combine(Environment.CurrentDirectory, objXmlNode["name"].InnerText.Replace('/', Path.DirectorySeparatorChar)));
 						objXmlFileNode = objXmlFileDocument.SelectSingleNode("/chummer/version");
                         objFunctions.LogWrite(CommonFunctions.LogType.Content, "frmUpdate", "Existing Version = " + Convert.ToInt32(objXmlFileNode.InnerText).ToString());
                         objFunctions.LogWrite(CommonFunctions.LogType.Content, "frmUpdate", "New Version = " + Convert.ToInt32(objXmlNode["version"].InnerText).ToString());
@@ -391,7 +391,7 @@ namespace Chummer
                     objFunctions.LogWrite(CommonFunctions.LogType.Message, "frmUpdate", "File is XSL");
                     try
 					{
-						StreamReader objFile = new StreamReader(Environment.CurrentDirectory + Path.DirectorySeparatorChar + objXmlNode["name"].InnerText.Replace('/', Path.DirectorySeparatorChar));
+						StreamReader objFile = new StreamReader(Path.Combine(Environment.CurrentDirectory, objXmlNode["name"].InnerText.Replace('/', Path.DirectorySeparatorChar)));
 						string strLine = "";
 						while ((strLine = objFile.ReadLine()) != null)
 						{

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -2830,9 +2830,7 @@ namespace Chummer
 				SaveFileDialog saveFileDialog = new SaveFileDialog();
 				saveFileDialog.Filter = "Chummer5 Files (*.chum5)|*.chum5|All Files (*.*)|*.*";
 
-				string strShowFileName = "";
-				string[] strFile = _objCharacter.FileName.Split(Path.DirectorySeparatorChar);
-				strShowFileName = strFile[strFile.Length - 1];
+				string strShowFileName = Path.GetFileName(_objCharacter.FileName);
 
 				if (strShowFileName == "")
 					strShowFileName = _objCharacter.Alias;
@@ -23495,9 +23493,7 @@ namespace Chummer
 			SaveFileDialog saveFileDialog = new SaveFileDialog();
 			saveFileDialog.Filter = "Chummer5 Files (*.chum5)|*.chum5|All Files (*.*)|*.*";
 
-			string strShowFileName = "";
-			string[] strFile = _objCharacter.FileName.Split(Path.DirectorySeparatorChar);
-			strShowFileName = strFile[strFile.Length - 1];
+			string strShowFileName = Path.GetFileName(_objCharacter.FileName);
 
 			if (strShowFileName == "")
 				strShowFileName = _objCharacter.Alias;

--- a/Chummer/frmCreateCyberwareSuite.cs
+++ b/Chummer/frmCreateCyberwareSuite.cs
@@ -68,8 +68,7 @@ namespace Chummer
 				}
 			}
 
-			string strPath = Path.Combine(Environment.CurrentDirectory, "data");
-			strPath = Path.Combine(strPath, txtFileName.Text);
+			string strPath = Path.Combine(strCustomPath, txtFileName.Text);
 			bool blnNewFile = !File.Exists(strPath);
 
 			// If this is not a new file, read in the existing contents.

--- a/Chummer/frmCreatePACKSKit.cs
+++ b/Chummer/frmCreatePACKSKit.cs
@@ -56,8 +56,7 @@ namespace Chummer
 				}
 			}
 
-			string strPath = Path.Combine(Environment.CurrentDirectory, "data");
-			strPath = Path.Combine(strPath, txtFileName.Text);
+			string strPath = Path.Combine(strCustomPath, txtFileName.Text);
 			bool blnNewFile = !File.Exists(strPath);
 
 			// If this is not a new file, read in the existing contents.

--- a/Chummer/frmExport.cs
+++ b/Chummer/frmExport.cs
@@ -21,12 +21,13 @@ namespace Chummer
 		private void frmExport_Load(object sender, EventArgs e)
 		{
 			// Populate the XSLT list with all of the XSL files found in the sheets directory.
-			foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "export"))
+			string exportDirectoryPath = Path.Combine(Environment.CurrentDirectory, "export");
+			foreach (string strFile in Directory.GetFiles(exportDirectoryPath))
 			{
 				// Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
 				if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
 				{
-					string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "export" + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+					string strFileName = Path.GetFileNameWithoutExtension(strFile);
 					cboXSLT.Items.Add(strFileName);
 				}
 			}
@@ -48,7 +49,8 @@ namespace Chummer
 			// Look for the file extension information.
 			string strLine = "";
 			string strExtension = "xml";
-			StreamReader objFile = new StreamReader(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "export" + Path.DirectorySeparatorChar + cboXSLT.Text + ".xsl");
+			string exportSheetPath = Path.Combine(Environment.CurrentDirectory, "export", cboXSLT.Text + ".xsl");
+			StreamReader objFile = new StreamReader(exportSheetPath);
 			while ((strLine = objFile.ReadLine()) != null)
 			{
 				if (strLine.StartsWith("<!-- ext:"))
@@ -66,7 +68,7 @@ namespace Chummer
 				return;
 
 			XslCompiledTransform objXSLTransform = new XslCompiledTransform();
-			objXSLTransform.Load(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "export" + Path.DirectorySeparatorChar + cboXSLT.Text + ".xsl"); // Use the path for the export sheet.
+			objXSLTransform.Load(exportSheetPath); // Use the path for the export sheet.
 
 			XmlWriterSettings objSettings = objXSLTransform.OutputSettings.Clone();
 			objSettings.CheckCharacters = false;

--- a/Chummer/frmHistory.cs
+++ b/Chummer/frmHistory.cs
@@ -18,7 +18,7 @@ namespace Chummer
 			// Display the contents of the changelog.txt file in the TextBox.
 			try
 			{
-				txtRevisionHistory.Text = File.ReadAllText(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "changelog.txt");
+				txtRevisionHistory.Text = File.ReadAllText(Path.Combine(Environment.CurrentDirectory, "changelog.txt"));
 				txtRevisionHistory.SelectionStart = 0;
 				txtRevisionHistory.SelectionLength = 0;
 			}

--- a/Chummer/frmMain.cs
+++ b/Chummer/frmMain.cs
@@ -169,8 +169,10 @@ namespace Chummer
 		private void mnuNewCritter_Click(object sender, EventArgs e)
 		{
 			Character objCharacter = new Character();
+			string settingsPath = Path.Combine(Environment.CurrentDirectory, "settings");
+			string[] settingsFiles = Directory.GetFiles(settingsPath, "*.xml");
 
-			if (Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "settings"), "*.xml").Count() > 1)
+			if (settingsFiles.Length > 1)
 			{
 				frmSelectSetting frmPickSetting = new frmSelectSetting();
 				frmPickSetting.ShowDialog(this);
@@ -182,10 +184,8 @@ namespace Chummer
 			}
 			else
 			{
-				string strSettingsFile = Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "settings"), "*.xml")[0];
-				strSettingsFile = strSettingsFile.Replace(Path.Combine(Environment.CurrentDirectory, "settings"), string.Empty);
-				strSettingsFile = strSettingsFile.Replace(Path.DirectorySeparatorChar, ' ').Trim();
-				objCharacter.SettingsFile = strSettingsFile;
+				string strSettingsFile = settingsFiles[0];
+				objCharacter.SettingsFile = Path.GetFileName(strSettingsFile);
 			}
 
 			// Override the defaults for the setting.
@@ -491,8 +491,7 @@ namespace Chummer
         /// </summary>
         private void ShowNewForm(object sender, EventArgs e)
 		{
-			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings");
-			strFilePath = Path.Combine(strFilePath, "default.xml");
+			string strFilePath = Path.Combine(Environment.CurrentDirectory, "settings", "default.xml");
 			if (!File.Exists(strFilePath))
 			{
 				if (MessageBox.Show(LanguageManager.Instance.GetString("Message_CharacterOptions_OpenOptions"), LanguageManager.Instance.GetString("MessageTitle_CharacterOptions_OpenOptions"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
@@ -502,8 +501,10 @@ namespace Chummer
 				}
 			}
 			Character objCharacter = new Character();
+			string settingsPath = Path.Combine(Environment.CurrentDirectory, "settings");
+			string[] settingsFiles = Directory.GetFiles(settingsPath, "*.xml");
 
-			if (Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "settings"), "*.xml").Count() > 1)
+			if (settingsFiles.Length > 1)
 			{
 				frmSelectSetting frmPickSetting = new frmSelectSetting();
 				frmPickSetting.ShowDialog(this);
@@ -515,12 +516,10 @@ namespace Chummer
 			}
 			else
 			{
-				string strSettingsFile = Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "settings"), "*.xml")[0];
-				strSettingsFile = strSettingsFile.Replace(Path.Combine(Environment.CurrentDirectory, "settings"), string.Empty);
-				strSettingsFile = strSettingsFile.Replace(Path.DirectorySeparatorChar, ' ').Trim();
-				objCharacter.SettingsFile = strSettingsFile;
+				string strSettingsFile = settingsFiles[0];
+				objCharacter.SettingsFile = Path.GetFileName(strSettingsFile);
 			}
-			
+
 			// Show the BP selection window.
 			frmSelectBP frmBP = new frmSelectBP(objCharacter);
 			frmBP.ShowDialog();

--- a/Chummer/frmOptions.cs
+++ b/Chummer/frmOptions.cs
@@ -97,13 +97,12 @@ namespace Chummer
         private void frmOptions_Load(object sender, EventArgs e)
         {
             // Populate the list of Settings.
+            string strPath = Path.Combine(Environment.CurrentDirectory, "settings");
             List<ListItem> lstSettings = new List<ListItem>();
-            foreach (string strFileName in Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "settings"), "*.xml"))
+            foreach (string strFileName in Directory.GetFiles(strPath, "*.xml"))
             {
                 // Remove the path from the file name.
-                string strSettingsFile = strFileName;
-                strSettingsFile = strSettingsFile.Replace(Path.Combine(Environment.CurrentDirectory, "settings"), string.Empty);
-                strSettingsFile = strSettingsFile.Replace(Path.DirectorySeparatorChar, ' ').Trim();
+                string strSettingsFile = Path.GetFileName(strFileName);
 
                 // Load the file so we can get the Setting name.
                 XmlDocument objXmlSetting = new XmlDocument();
@@ -221,7 +220,7 @@ namespace Chummer
             txtURLAppPath.Text = GlobalOptions.Instance.URLAppPath;
 
             // Populate the Language List.
-            string strPath = Path.Combine(Environment.CurrentDirectory, "lang");
+            strPath = Path.Combine(Environment.CurrentDirectory, "lang");
             List<ListItem> lstLanguages = new List<ListItem>();
             foreach (string strFile in Directory.GetFiles(strPath, "*.xml"))
             {
@@ -230,7 +229,7 @@ namespace Chummer
                 {
                     objXmlDocument.Load(strFile);
                     ListItem objItem = new ListItem();
-                    string strFileName = strFile.Replace(strPath, string.Empty).Replace(".xml", string.Empty).Replace(Path.DirectorySeparatorChar, ' ').Trim();
+                    string strFileName = Path.GetFileNameWithoutExtension(strFile);
                     objItem.Value = strFileName;
                     objItem.Name = objXmlDocument.SelectSingleNode("/chummer/name").InnerText;
                     lstLanguages.Add(objItem);
@@ -255,14 +254,15 @@ namespace Chummer
             if (cboLanguage.SelectedIndex == -1)
                 cboLanguage.SelectedValue = "en-us";
 
-            List<ListItem> lstFiles = new List<ListItem>();
             // Populate the XSLT list with all of the XSL files found in the sheets directory.
-            foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets"))
+            strPath = Path.Combine(Environment.CurrentDirectory, "sheets");
+            List<ListItem> lstFiles = new List<ListItem>();
+            foreach (string strFile in Directory.GetFiles(strPath))
             {
                 // Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
                 if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
                 {
-                    string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+                    string strFileName = Path.GetFileNameWithoutExtension(strFile);
                     ListItem objItem = new ListItem();
                     objItem.Value = strFileName;
                     objItem.Name = strFileName;
@@ -279,15 +279,16 @@ namespace Chummer
                 {
                     XmlDocument objLanguageDocument = LanguageManager.Instance.XmlDoc;
                     string strLanguage = objLanguageDocument.SelectSingleNode("/chummer/name").InnerText;
+                    strPath = Path.Combine(Environment.CurrentDirectory, "sheets", GlobalOptions.Instance.Language);
 
-                    foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + GlobalOptions.Instance.Language))
+                    foreach (string strFile in Directory.GetFiles(strPath))
                     {
                         // Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
                         if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
                         {
-                            string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + GlobalOptions.Instance.Language + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+                            string strFileName = Path.GetFileNameWithoutExtension(strFile);
                             ListItem objItem = new ListItem();
-                            objItem.Value = GlobalOptions.Instance.Language + Path.DirectorySeparatorChar + strFileName;
+                            objItem.Value = Path.Combine(GlobalOptions.Instance.Language, strFileName);
                             objItem.Name = strLanguage + ": " + strFileName;
                             lstFiles.Add(objItem);
                         }
@@ -301,14 +302,15 @@ namespace Chummer
             try
             {
                 // Populate the XSLT list with all of the XSL files found in the sheets\omae directory.
-                foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + "omae"))
+                strPath = Path.Combine(Environment.CurrentDirectory, "sheets", "omae");
+                foreach (string strFile in Directory.GetFiles(strPath))
                 {
                     // Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
                     if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
                     {
-                        string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + "omae" + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+                        string strFileName = Path.GetFileNameWithoutExtension(strFile);
                         ListItem objItem = new ListItem();
-                        objItem.Value = "omae" + Path.DirectorySeparatorChar + strFileName;
+                        objItem.Value = Path.Combine("omae", strFileName);
                         objItem.Name = LanguageManager.Instance.GetString("Menu_Main_Omae") + ": " + strFileName;
                         lstFiles.Add(objItem);
                     }
@@ -562,8 +564,7 @@ namespace Chummer
 
             XmlManager.Instance.Verify(cboLanguage.SelectedValue.ToString(), lstBooks);
 
-            string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang");
-            strFilePath = Path.Combine(strFilePath, "results_" + cboLanguage.SelectedValue + ".xml");
+            string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang", "results_" + cboLanguage.SelectedValue + ".xml");
             MessageBox.Show("Results were written to " + strFilePath, "Validation Results", MessageBoxButtons.OK, MessageBoxIcon.Information);
         }
 

--- a/Chummer/frmPrintMultiple.cs
+++ b/Chummer/frmPrintMultiple.cs
@@ -23,9 +23,8 @@ namespace Chummer
 			{
 				foreach (string strFileName in dlgOpenFile.FileNames)
 				{
-					string[] strLongName = strFileName.Split(Path.DirectorySeparatorChar);
 					TreeNode objNode = new TreeNode();
-					objNode.Text = strLongName[strLongName.Length - 1];
+					objNode.Text = Path.GetFileName(strFileName);
 					objNode.Tag = strFileName;
 					treCharacters.Nodes.Add(objNode);
 				}

--- a/Chummer/frmSelectSetting.cs
+++ b/Chummer/frmSelectSetting.cs
@@ -22,20 +22,16 @@ namespace Chummer
 		{
 			// Build the list of XML files found in the settings directory.
 			List<ListItem> lstSettings = new List<ListItem>();
-			foreach (string strFileName in Directory.GetFiles(Path.Combine(Environment.CurrentDirectory, "settings"), "*.xml"))
+			string settingsDirectoryPath = Path.Combine(Environment.CurrentDirectory, "settings");
+            foreach (string strFileName in Directory.GetFiles(settingsDirectoryPath, "*.xml"))
 			{
-				// Remove the path from the file name.
-				string strSettingsFile = strFileName;
-				strSettingsFile = strSettingsFile.Replace(Path.Combine(Environment.CurrentDirectory, "settings"), string.Empty);
-				strSettingsFile = strSettingsFile.Replace(Path.DirectorySeparatorChar, ' ').Trim();
-
 				// Load the file so we can get the Setting name.
 				XmlDocument objXmlDocument = new XmlDocument();
 				objXmlDocument.Load(strFileName);
 				string strSettingsName = objXmlDocument.SelectSingleNode("/settings/name").InnerText;
 
 				ListItem objItem = new ListItem();
-				objItem.Value = strSettingsFile;
+				objItem.Value = Path.GetFileName(strFileName);
 				objItem.Name = strSettingsName;
 
 				lstSettings.Add(objItem);

--- a/Chummer/frmViewer.cs
+++ b/Chummer/frmViewer.cs
@@ -32,12 +32,13 @@ namespace Chummer
 			_blnLoading = true;
 			List<ListItem> lstFiles = new List<ListItem>();
 			// Populate the XSLT list with all of the XSL files found in the sheets directory.
-			foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets"))
+			string sheetsDirectoryPath = Path.Combine(Environment.CurrentDirectory, "sheets");
+			foreach (string strFile in Directory.GetFiles(sheetsDirectoryPath))
 			{
 				// Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
 				if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
 				{
-					string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+					string strFileName = Path.GetFileNameWithoutExtension(strFile);
 					ListItem objItem = new ListItem();
 					objItem.Value = strFileName;
 					objItem.Name = strFileName;
@@ -54,15 +55,16 @@ namespace Chummer
 				{
 					XmlDocument objLanguageDocument = LanguageManager.Instance.XmlDoc;
 					string strLanguage = objLanguageDocument.SelectSingleNode("/chummer/name").InnerText;
+					string languageDirectoryPath = Path.Combine(Environment.CurrentDirectory, "sheets", GlobalOptions.Instance.Language);
 
-					foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + GlobalOptions.Instance.Language))
+					foreach (string strFile in Directory.GetFiles(languageDirectoryPath))
 					{
 						// Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
 						if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
 						{
-							string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + GlobalOptions.Instance.Language + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+							string strFileName = Path.GetFileNameWithoutExtension(strFile);
 							ListItem objItem = new ListItem();
-							objItem.Value = GlobalOptions.Instance.Language + Path.DirectorySeparatorChar + strFileName;
+							objItem.Value = Path.Combine(GlobalOptions.Instance.Language, strFileName);
 							objItem.Name = strLanguage + ": " + strFileName;
 							lstFiles.Add(objItem);
 						}
@@ -76,14 +78,15 @@ namespace Chummer
 			try
 			{
 				// Populate the XSLT list with all of the XSL files found in the sheets\omae directory.
-				foreach (string strFile in Directory.GetFiles(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + "omae"))
+				string omaeDirectoryPath = Path.Combine(Environment.CurrentDirectory, "sheets", "omae");
+				foreach (string strFile in Directory.GetFiles(omaeDirectoryPath))
 				{
 					// Only show files that end in .xsl. Do not include files that end in .xslt since they are used as "hidden" reference sheets (hidden because they are partial templates that cannot be used on their own).
 					if (!strFile.EndsWith(".xslt") && strFile.EndsWith(".xsl"))
 					{
-						string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + "omae" + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);
+						string strFileName = Path.GetFileNameWithoutExtension(strFile);
 						ListItem objItem = new ListItem();
-						objItem.Value = "omae" + Path.DirectorySeparatorChar + strFileName;
+						objItem.Value = Path.Combine("omae", strFileName);
 						objItem.Name = LanguageManager.Instance.GetString("Menu_Main_Omae") + ": " + strFileName;
 						lstFiles.Add(objItem);
 					}
@@ -158,7 +161,8 @@ namespace Chummer
 			// Remove the mugshots directory when the form closes.
 			try
 			{
-				Directory.Delete(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "mugshots", true);
+				string mugshotsDirectoryPath = Path.Combine(Environment.CurrentDirectory, "mugshots");
+                Directory.Delete(mugshotsDirectoryPath, true);
 			}
 			catch
 			{
@@ -180,7 +184,7 @@ namespace Chummer
 		private void GenerateOutput()
 		{
 			XslCompiledTransform objXSLTransform = new XslCompiledTransform();
-			objXSLTransform.Load(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "sheets" + Path.DirectorySeparatorChar + _strSelectedSheet + ".xsl");
+			objXSLTransform.Load(Path.Combine(Environment.CurrentDirectory, "sheets", _strSelectedSheet + ".xsl"));
 
 			MemoryStream objStream = new MemoryStream();
 			XmlTextWriter objWriter = new XmlTextWriter(objStream, Encoding.UTF8);


### PR DESCRIPTION
Hello chummer5a,

I have refactored the usage of the System.IO.Path class. Here are some common patterns:

1) Use Path.Combine() instead of string concatenation:
```c#
// Before:
string strFile = Environment.CurrentDirectory + Path.DirectorySeparatorChar + "chummerlog.txt";

// After:
string strFile = Path.Combine(Environment.CurrentDirectory, "chummerlog.txt");
```
2) Use Path.Combine(string path1, string path2, string path3) once instead of Path.Combine(string path1, string path2) twice:
```c#
// Before:
string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang");
strFilePath = Path.Combine(strFilePath, "en-us.xml");

// After:
string strFilePath = Path.Combine(Environment.CurrentDirectory, "lang", "en-us.xml");
```
3) Use Path.GetFileName() instead of String.Split():
```c#
// Before:
string[] strLongName = strFileName.Split(Path.DirectorySeparatorChar);
objNode.Text = strLongName[strLongName.Length - 1];

// After:
objNode.Text = Path.GetFileName(strFileName);
```
4) Use Path.GetFileNameWithoutExtension() instead of String.Replace():
```c#
// Before:
string strFileName = strFile.Replace(Environment.CurrentDirectory + Path.DirectorySeparatorChar + "export" + Path.DirectorySeparatorChar, string.Empty).Replace(".xsl", string.Empty);

// After:
string strFileName = Path.GetFileNameWithoutExtension(strFile);
```