### PR TITLE
Astral Beacon update

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -1220,6 +1220,10 @@
 					<quality>Aspected Magician</quality>
 					<quality>Magician</quality>
 					<quality>Mystic Adept</quality>
+					<metatype>Centaur</metatype>
+					<metatype>Naga</metatype>
+					<metatype>Pixie</metatype>
+					<metatype>Sasquatch</metatype>
 				</oneof>
 			</required>
 			<forbidden>


### PR DESCRIPTION
Updated to include Metasapient metatypes. Currently lacking Infected characters, but right now, Infected qualities don't always work, so that'd be trying to implement something for something that crashes.