### PR TITLE
Fancy Blocks charsheet fixes

### DIFF
--- a/Chummer/Classes/clsEquipment.cs
+++ b/Chummer/Classes/clsEquipment.cs
@@ -9821,7 +9821,9 @@ namespace Chummer
 			objWriter.WriteStartElement("lifestyle");
 			objWriter.WriteElementString("name", DisplayNameShort);
 			objWriter.WriteElementString("cost", _intCost.ToString());
-			objWriter.WriteElementString("dice", _intDice.ToString());
+            objWriter.WriteElementString("totalmonthlycost", TotalMonthlyCost.ToString());
+            objWriter.WriteElementString("totalcost", TotalCost.ToString());
+            objWriter.WriteElementString("dice", _intDice.ToString());
 			objWriter.WriteElementString("multiplier", _intMultiplier.ToString());
 			objWriter.WriteElementString("months", _intMonths.ToString());
 			objWriter.WriteElementString("purchased", _blnPurchased.ToString());


### PR DESCRIPTION
* Minor display fixes for locations
* 'Extra' field for 'Custom Fit (Stack)' is printed on new line now to avoid unnecessary table stretching
* Fix weapons that doubled as ammunition were not displayed correctly
* Built-in metatype qualities now greyed out
* Reduced spacing in Gear section
* Fixed vehicle section layout

Code changes:
* Print method for lifestyle now provides total cost and total monthly cost