### PR TITLE
Cleansing art fix

### DIFF
--- a/Chummer/data/metamagic.xml
+++ b/Chummer/data/metamagic.xml
@@ -343,7 +343,7 @@
       <magician>yes</magician>
       <required>
         <allof>
-          <art>Centering</art>
+          <art>Cleansing</art>
         </allof>
       </required>
       <source>SG</source>

--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -3010,7 +3010,7 @@
       <dv>Special</dv>
       <required>
         <allof>
-          <art>Centering</art>
+          <art>Cleansing</art>
         </allof>
       </required>
       <source>SG</source>
@@ -3398,7 +3398,7 @@
       <dv>Special</dv>
       <required>
         <allof>
-          <art>Centering</art>
+          <art>Cleansing</art>
         </allof>
       </required>
       <source>SG</source>


### PR DESCRIPTION
 Cleansing art rituals and metamagic required Centering. Now they require cleansing.