### PR TITLE
Adept Power control fix

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -13879,15 +13879,46 @@ namespace Chummer
                     {
                         if (objPower.BonusSource == objGear.InternalId)
                         {
+                            //Remove the Bonus Source since this object will not be giving a bonus
+                            objPower.BonusSource = "";
+
                             if (objPower.Free)
                                 _objCharacter.Powers.Remove(objPower);
-                            else if (objPower.FreeLevels < objPower.Rating)
+                            else if (objPower.FreeLevels > 0)
                             {
-                                objPower.Rating -= objPower.FreeLevels;
-                                objPower.FreeLevels = 0;
+                                int freeLevelsByThisFocus = (int)(Math.Min(objFocus.Rating * .25M, objPower.FreeLevels * objPower.PointsPerLevel) / objPower.PointsPerLevel);
+                                if (objPower.Rating > freeLevelsByThisFocus)
+                                {
+                                    objPower.Rating -= freeLevelsByThisFocus;
+                                    objPower.FreeLevels -= freeLevelsByThisFocus;
+                                }
+                                else
+                                {
+                                    _objCharacter.Powers.Remove(objPower);
+                                }
                             }
                             else if (objPower.FreePoints > 0)
-                                objPower.FreePoints = 0;
+                            {
+                                // For complete robustness, a way should be implemented to allow to switch
+                                // between Improved Reflexes I/II/III, with Foci, according to the force
+                                // of the focus.
+
+                                //In the meantime, calculate if the free points of the focus are equal
+                                //to the point cost of the power, and remove it if it is
+                                decimal freePointsByThisFocus = Math.Min(objFocus.Rating * .25M, objPower.FreePoints);
+
+                                //This should be the case, always as implemented currently.
+                                if (objPower.PointsPerLevel * objPower.Rating == freePointsByThisFocus)
+                                {
+                                    _objCharacter.Powers.Remove(objPower);
+                                }
+                                else
+                                {
+                                    //Should never happen currently.
+                                    objPower.FreePoints -= freePointsByThisFocus;
+                                    objPower.Rating -= freePointsByThisFocus * objPower.PointsPerLevel;
+                                }
+                            }
                             else
                                 _objCharacter.Powers.Remove(objPower);
 

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -3499,7 +3499,10 @@ namespace Chummer
 					Log.Info("_strSelectedValue = " + _strSelectedValue);
 					Log.Info("_strForcedValue = " + _strForcedValue);
 
-					bool blnExistingPower = false;
+                    //Gerry: These unfortunately did not work in any case of multiple bonuses
+                    // Switched the setting of powerpoints and levels to ADDING them
+                    // Remove resetting powerpoints.
+                    bool blnExistingPower = false;
 					foreach (Power objExistingPower in _objCharacter.Powers)
 					{
 						if (objExistingPower.BonusSource == strSourceName)
@@ -3509,29 +3512,29 @@ namespace Chummer
 									if (objExistingPower.Name.EndsWith("1"))
 									{
 										if (intRating >= 6)
-											objExistingPower.FreePoints = 1.5M;
-										else
-											objExistingPower.FreePoints = 0;
+											objExistingPower.FreePoints += 1.5M;
+										//else
+										//	objExistingPower.FreePoints = 0;
 									}
 									else if (objExistingPower.Name.EndsWith("2"))
 									{
 										if (intRating >= 10)
-											objExistingPower.FreePoints = 2.5M;
+											objExistingPower.FreePoints += 2.5M;
 										else if (intRating >= 4)
-											objExistingPower.FreePoints = 1.0M;
-										else
-											objExistingPower.FreePoints = 0;
+											objExistingPower.FreePoints += 1.0M;
+										//else
+										//	objExistingPower.FreePoints = 0;
 									}
 									else
 									{
 										if (intRating >= 14)
-											objExistingPower.FreePoints = 3.5M;
+											objExistingPower.FreePoints += 3.5M;
 										else if (intRating >= 8)
-											objExistingPower.FreePoints = 2.0M;
+											objExistingPower.FreePoints += 2.0M;
 										else if (intRating >= 4)
-											objExistingPower.FreePoints = 1.0M;
-										else
-											objExistingPower.FreePoints = 0;
+											objExistingPower.FreePoints += 1.0M;
+										//else
+										//	objExistingPower.FreePoints = 0;
 									}
 								}
 								else
@@ -3539,7 +3542,7 @@ namespace Chummer
 									// we have to adjust the number of free levels.
 									decimal decLevels = Convert.ToDecimal(intRating)/4;
 									decLevels = Math.Floor(decLevels/objExistingPower.PointsPerLevel);
-									objExistingPower.FreeLevels = Convert.ToInt32(decLevels);
+									objExistingPower.FreeLevels += Convert.ToInt32(decLevels);
 									if (objExistingPower.Rating < intRating)
 										objExistingPower.Rating = objExistingPower.FreeLevels;
 									break;

--- a/Chummer/Controls/PowerControl.cs
+++ b/Chummer/Controls/PowerControl.cs
@@ -55,22 +55,18 @@ namespace Chummer
 			nudRating.Maximum = _objPower.MaxLevels;
             nudRating.Minimum = _objPower.FreeLevels;
 
-			if (newRating > Convert.ToDecimal(_objPower.CharacterObject.MAG.Value))
-			{
-				nudRating.Value = Convert.ToDecimal(_objPower.CharacterObject.MAG.Value);
-			}
-			else
-			{
-				if (actualRating > _objPower.FreeLevels)
-				{
-					nudRating.Value = newRating;
-				}
-				else
-				{
-					nudRating.Value = _objPower.FreeLevels;
-				}
-			}
-		}
+            if (newRating < _objPower.FreeLevels)
+            {
+                newRating = _objPower.FreeLevels;
+            }
+
+            if (newRating > Convert.ToDecimal(_objPower.CharacterObject.MAG.Value))
+            {
+                newRating = Convert.ToDecimal(_objPower.CharacterObject.MAG.Value);
+            }
+
+            nudRating.Value = newRating;
+        }
         
 		private void nudRating_ValueChanged(object sender, EventArgs e)
         {

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -19749,8 +19749,20 @@ namespace Chummer
                     _objCharacter.Foci.Remove(objFocus);
                     foreach (Power objPower in _objCharacter.Powers)
                     {
+                        // Known issues: 
+                        // 1) If freelevels > MAG, AND multiple sources give free levels, the calculation for the left-over free levels
+                        // will not be correct
+                        // Foci give their rating / 4 in power points - use power points per level to calculate the amount of levels this
+                        // focus is worth. May be troublesome in foci of non-integer power levels, but as foci should not be created
+                        // with such, this will be better handled in the focus rating itself.
                         if (objPower.BonusSource == objGear.InternalId)
                         {
+
+                            // If we do not remove the bonus source, foci completely break when binding-unbinding-rebinding, because their 
+                            // bonus is calculated twice in the improvement manager.
+                            // TODO - Clean up the improvement manager power management.
+                            objPower.BonusSource = "";
+
                             foreach (Improvement objImprovement in _objCharacter.Improvements.ToList())
                             {
                                 if (objImprovement.SourceName == objPower.InternalId) 
@@ -19760,13 +19772,41 @@ namespace Chummer
                             }
                             if (objPower.Free)
                                 _objCharacter.Powers.Remove(objPower);
-                            else if (objPower.FreeLevels < objPower.Rating)
+                            else if (objPower.FreeLevels > 0)
                             {
-                                objPower.Rating -= objPower.FreeLevels;
-                                objPower.FreeLevels = 0;
+                                int freeLevelsByThisFocus = (int)(Math.Min(objFocus.Rating * .25M, objPower.FreeLevels * objPower.PointsPerLevel) / objPower.PointsPerLevel);
+                                if (objPower.Rating > freeLevelsByThisFocus)
+                                {
+                                    objPower.Rating -= freeLevelsByThisFocus;
+                                    objPower.FreeLevels -= freeLevelsByThisFocus;
+                                }
+                                else
+                                {
+                                    _objCharacter.Powers.Remove(objPower);
+                                }
                             }
                             else if (objPower.FreePoints > 0)
-                                objPower.FreePoints = 0;
+                            {
+                                // For complete robustness, a way should be implemented to allow to switch
+                                // between Improved Reflexes I/II/III, with Foci, according to the force
+                                // of the focus.
+
+                                //In the meantime, calculate if the free points of the focus are equal
+                                //to the point cost of the power, and remove it if it is
+                                decimal freePointsByThisFocus = Math.Min(objFocus.Rating * .25M, objPower.FreePoints);
+
+                                //This should be the case, always as implemented currently.
+                                if (objPower.PointsPerLevel * objPower.Rating == freePointsByThisFocus)
+                                {
+                                    _objCharacter.Powers.Remove(objPower);
+                                }
+                                else
+                                {
+                                    //Should never happen currently.
+                                    objPower.FreePoints -= freePointsByThisFocus;
+                                    objPower.Rating -= freePointsByThisFocus * objPower.PointsPerLevel;
+                                }
+                            }
                             else
                                 _objCharacter.Powers.Remove(objPower);
 


### PR DESCRIPTION
On the initial PowerControl loading, fixed the power level calculation to include both FreeLevels and actual PowerRating (Issue #766)