### PR TITLE
Corrected capacity usage of Responsive Interface Gear

### DIFF
--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -2929,7 +2929,7 @@
       <category>General</category>
       <armor>0</armor>
       <maxrating>1</maxrating>
-      <armorcapacity>[2]</armorcapacity>
+      <armorcapacity>[4]</armorcapacity>
       <avail>8</avail>
       <cost>2500</cost>
       <source>RG</source>
@@ -2941,7 +2941,7 @@
       <category>General</category>
       <armor>0</armor>
       <maxrating>1</maxrating>
-      <armorcapacity>[1]</armorcapacity>
+      <armorcapacity>[2]</armorcapacity>
       <avail>8</avail>
       <cost>2500</cost>
       <source>RG</source>


### PR DESCRIPTION
As per Run and Gun (p.86) errata:
Change the clause reading “takes up 2 Capacity slots in the armor and 1 Capacity slot in the helmet” to “takes up 4 Capacity slots in the armor and 2 Capacity slots in the helmet.”