### PR TITLE
Fix #791

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -17609,8 +17609,8 @@ namespace Chummer
 				}
 				else
 				{
-					nudArmorRating.Value = objArmor.Rating;
 					nudArmorRating.Maximum = objArmor.MaxRating;
+					nudArmorRating.Value = objArmor.Rating;
 					nudArmorRating.Enabled = true;
 				}
 

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -4089,6 +4089,18 @@
 			<source>SR5</source>
 			<page>446</page>
 		</gear>
+    <gear>
+      <id>884a5995-a6ff-4f46-b717-9de1ac677af8</id>
+      <name>Radar Sensor</name>
+      <category>Sensor Functions</category>
+      <rating>4</rating>
+      <capacity>[Rating]</capacity>
+      <armorcapacity>[1]</armorcapacity>
+      <avail>Rating * 3</avail>
+      <cost>Rating * 4000</cost>
+      <source>CF</source>
+      <page>81</page>
+    </gear>
 		<gear>
 			<id>4d12e4a1-edd3-4abf-830f-aa95874b7531</id>
 			<name>Radio Signal Scanner</name>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -4089,18 +4089,18 @@
 			<source>SR5</source>
 			<page>446</page>
 		</gear>
-    <gear>
-      <id>884a5995-a6ff-4f46-b717-9de1ac677af8</id>
-      <name>Radar Sensor</name>
-      <category>Sensor Functions</category>
-      <rating>4</rating>
-      <capacity>[Rating]</capacity>
-      <armorcapacity>[1]</armorcapacity>
-      <avail>Rating * 3</avail>
-      <cost>Rating * 4000</cost>
-      <source>CF</source>
-      <page>81</page>
-    </gear>
+		<gear>
+			<id>884a5995-a6ff-4f46-b717-9de1ac677af8</id>
+			<name>Radar Sensor</name>
+			<category>Sensor Functions</category>
+			<rating>4</rating>
+			<capacity>[Rating]</capacity>
+			<armorcapacity>[1]</armorcapacity>
+			<avail>Rating * 3</avail>
+			<cost>Rating * 4000</cost>
+			<source>CF</source>
+			<page>81</page>
+		</gear>
 		<gear>
 			<id>4d12e4a1-edd3-4abf-830f-aa95874b7531</id>
 			<name>Radio Signal Scanner</name>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -4090,18 +4090,6 @@
 			<page>446</page>
 		</gear>
 		<gear>
-			<id>884a5995-a6ff-4f46-b717-9de1ac677af8</id>
-			<name>Radar Sensor</name>
-			<category>Sensor Functions</category>
-			<rating>4</rating>
-			<capacity>[Rating]</capacity>
-			<armorcapacity>[1]</armorcapacity>
-			<avail>Rating * 3</avail>
-			<cost>Rating * 4000</cost>
-			<source>CF</source>
-			<page>81</page>
-		</gear>
-		<gear>
 			<id>4d12e4a1-edd3-4abf-830f-aa95874b7531</id>
 			<name>Radio Signal Scanner</name>
 			<category>Sensor Functions</category>


### PR DESCRIPTION
Apply fix for #791. Included cost in this sensor as it's special/expensive. Most people I see include costs for sensor upgrades like Thermographic Vision on a Camera, and this is kinda/sorta similar? Especially since it has relevant Rating levels that determine performance unlike the other 0 cost ones.

(My first Pull Request, please let me know if I did anything wrong/weird.)