### PR TITLE
Pull down some error handling into the Main fork

### DIFF
--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -769,7 +769,14 @@ namespace Chummer
 			{
                 XmlNode objXmlMetavariant = objXmlDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + lstMetatypes.SelectedValue.ToString() + "\"]/metavariants/metavariant[name = \"" + cboMetavariant.SelectedValue.ToString() + "\"]");
                 XmlNode objXmlMetavariantBP = objXmlDocumentPriority.SelectSingleNode("/chummer/priorities/priority[category = \"Heritage\" and value = \"" + cboHeritage.SelectedValue.ToString() + "\"]/metatypes/metatype[name = \"" + lstMetatypes.SelectedValue.ToString() + "\"]/metavariants/metavariant[name = \"" + cboMetavariant.SelectedValue.ToString() + "\"]");
-                lblMetavariantBP.Text = objXmlMetavariantBP["karma"].InnerText;
+                try
+                {
+                    lblMetavariantBP.Text = objXmlMetavariantBP["karma"].InnerText;
+                }
+                catch (NullReferenceException nr)
+                {
+                    MessageBox.Show("This Race/Metavariant combination is incomplete and will be completed in a future release. Attempting to create a character with this combination may result in unexpected results."); 
+                }
                 lblBOD.Text = string.Format("{0}/{1} ({2})", objXmlMetavariant["bodmin"].InnerText, objXmlMetavariant["bodmax"].InnerText, objXmlMetavariant["bodaug"].InnerText);
                 lblAGI.Text = string.Format("{0}/{1} ({2})", objXmlMetavariant["agimin"].InnerText, objXmlMetavariant["agimax"].InnerText, objXmlMetavariant["agiaug"].InnerText);
                 lblREA.Text = string.Format("{0}/{1} ({2})", objXmlMetavariant["reamin"].InnerText, objXmlMetavariant["reamax"].InnerText, objXmlMetavariant["reaaug"].InnerText);

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -769,13 +769,15 @@ namespace Chummer
 			{
                 XmlNode objXmlMetavariant = objXmlDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + lstMetatypes.SelectedValue.ToString() + "\"]/metavariants/metavariant[name = \"" + cboMetavariant.SelectedValue.ToString() + "\"]");
                 XmlNode objXmlMetavariantBP = objXmlDocumentPriority.SelectSingleNode("/chummer/priorities/priority[category = \"Heritage\" and value = \"" + cboHeritage.SelectedValue.ToString() + "\"]/metatypes/metatype[name = \"" + lstMetatypes.SelectedValue.ToString() + "\"]/metavariants/metavariant[name = \"" + cboMetavariant.SelectedValue.ToString() + "\"]");
-                try
-                {
-                    lblMetavariantBP.Text = objXmlMetavariantBP["karma"].InnerText;
+                if (objXmlMetavariantBP == null)
+                { 
+                    MessageBox.Show("This Race/Metavariant combination is incomplete and will be completed in a future release. Attempting to create a character with this combination may result in unexpected results.", "Chummer5",
+                        MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    cmdOK.Enabled = false;
                 }
-                catch (NullReferenceException nr)
+                else
                 {
-                    MessageBox.Show("This Race/Metavariant combination is incomplete and will be completed in a future release. Attempting to create a character with this combination may result in unexpected results."); 
+                    cmdOK.Enabled = true;
                 }
                 lblBOD.Text = string.Format("{0}/{1} ({2})", objXmlMetavariant["bodmin"].InnerText, objXmlMetavariant["bodmax"].InnerText, objXmlMetavariant["bodaug"].InnerText);
                 lblAGI.Text = string.Format("{0}/{1} ({2})", objXmlMetavariant["agimin"].InnerText, objXmlMetavariant["agimax"].InnerText, objXmlMetavariant["agiaug"].InnerText);
@@ -865,6 +867,7 @@ namespace Chummer
                 // Set the special attributes label.
                 if (lstMetatypes.SelectedItem != null)
                 {
+                    cmdOK.Enabled = true;
                     XmlNodeList objXmlMetatypeList = objXmlDocumentPriority.SelectNodes("/chummer/priorities/priority[category = \"Heritage\" and value = \"" + cboHeritage.SelectedValue.ToString() + "\"]/metatypes/metatype[name = \"" + lstMetatypes.SelectedValue.ToString() + "\"]");
 					XmlNode objXmlMetatype = objXmlDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + lstMetatypes.SelectedValue + "\"]");
                     lblBOD.Text = string.Format("{0}/{1} ({2})", objXmlMetatype["bodmin"].InnerText, objXmlMetatype["bodmax"].InnerText, objXmlMetatype["bodaug"].InnerText);


### PR DESCRIPTION
When a metavariant doesn't have an entry in priorities.xml, objXmlMetavariantBP will be null. This will cause a null reference exception (which is unhandled) and cause the program to crash. This change handles that error more gracefully, displaying a friendly error and graying out OK until the user picks a metavariant that does have an entry.

As we fix priorities.xml this will require no changes, as the null exception will simply not happen anymore.