### PR TITLE
Corrected Ingram Smartgun X

### DIFF
--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -6275,6 +6275,7 @@
 			<accessories>
 				<accessory><name>Smartgun System, Internal</name></accessory>
 				<accessory><name>Sound Suppressor</name></accessory>
+				<accessory><name>Gas-Vent 2 System</name></accessory>
 			</accessories>
 			<source>SR5</source>
 			<page>427</page>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -6263,7 +6263,7 @@
 			<damage>8P</damage>
 			<ap>-</ap>
 			<mode>BF/FA</mode>
-			<rc>2</rc>
+			<rc>0</rc>
 			<ammo>32(c)</ammo>
 			<avail>6R</avail>
 			<cost>800</cost>


### PR DESCRIPTION
Added Gas-Vent 2 system as standard addon to Ingram Smartgun X, as per it's description in the core rulebook, p. 427.