### PR TITLE
fixed troll reduction not removing armor for trolls

### DIFF
--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -936,6 +936,7 @@
 					<name>CHA</name>
 					<max>Rating</max>
 				</specificattribute>
+				<armor>-1</armor>
 			</bonus>
 			<source>CF</source>
 			<page>108</page>


### PR DESCRIPTION
In Chromeflesh is describes troll reduction as "removing the dermal-plates" thus the troll would lose the armor bonus from this. Hero Lab removes the armor value when troll reduction is taken 