### PR TITLE
Delnar's Bunch 'o' Changes

### DIFF
--- a/Chummer/Backend/Equipment/Vehicle.cs
+++ b/Chummer/Backend/Equipment/Vehicle.cs
@@ -317,11 +317,14 @@ namespace Chummer.Backend.Equipment
 							XmlNode objXmlAccessoryNode = objXmlWeaponDocument.SelectSingleNode("/chummer/accessories/accessory[name = \"" + objXmlAccessory["name"].InnerText + "\"]");
 							WeaponAccessory objMod = new WeaponAccessory(_objCharacter);
 							TreeNode objModNode = new TreeNode();
-							string strMount = "";
+							string strMount = "Internal";
 							int intRating = 0;
 							if (objXmlAccessory["mount"] != null)
 								strMount = objXmlAccessory["mount"].InnerText;
-							objMod.Create(objXmlAccessoryNode, objModNode, strMount,intRating);
+                            string strExtraMount = "None";
+                            if (objXmlAccessory.InnerXml.Contains("<extramount>"))
+                                strMount = objXmlAccessory["extramount"].InnerText;
+                            objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount },intRating);
 							objMod.Cost = "0";
 							objModNode.ContextMenuStrip = cmsVehicleWeaponAccessory;
 

--- a/Chummer/Backend/Equipment/Vehicle.cs
+++ b/Chummer/Backend/Equipment/Vehicle.cs
@@ -73,7 +73,7 @@ namespace Chummer.Backend.Equipment
 		/// <param name="cmsVehicleWeapon">ContextMenuStrip to attach to Vehicle Weapons.</param>
 		/// <param name="cmsVehicleWeaponAccessory">ContextMenuStrip to attach to Weapon Accessories.</param>
 		/// <param name="blnCreateChildren">Whether or not child items should be created.</param>
-		public void Create(XmlNode objXmlVehicle, TreeNode objNode, ContextMenuStrip cmsVehicle, ContextMenuStrip cmsVehicleGear, ContextMenuStrip cmsVehicleWeapon, ContextMenuStrip cmsVehicleWeaponAccessory, bool blnCreateChildren = true)
+		public void Create(XmlNode objXmlVehicle, TreeNode objNode, ContextMenuStrip cmsVehicle, ContextMenuStrip cmsVehicleGear, ContextMenuStrip cmsVehicleWeapon, ContextMenuStrip cmsVehicleWeaponAccessory, ContextMenuStrip cmsVehicleWeaponAccessoryGear = null, bool blnCreateChildren = true)
 		{
 			_strName = objXmlVehicle["name"].InnerText;
 			_strCategory = objXmlVehicle["category"].InnerText;
@@ -260,7 +260,7 @@ namespace Chummer.Backend.Equipment
 					Weapon objWeapon = new Weapon(_objCharacter);
 
 					XmlNode objXmlWeaponNode = objXmlWeaponDocument.SelectSingleNode("/chummer/weapons/weapon[name = \"" + objXmlWeapon["name"].InnerText + "\"]");
-					objWeapon.Create(objXmlWeaponNode, _objCharacter, objWeaponNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory);
+					objWeapon.Create(objXmlWeaponNode, _objCharacter, objWeaponNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear);
 					objWeapon.Cost = 0;
 					objWeapon.VehicleMounted = true;
 
@@ -323,9 +323,10 @@ namespace Chummer.Backend.Equipment
 								strMount = objXmlAccessory["mount"].InnerText;
                             string strExtraMount = "None";
                             if (objXmlAccessory.InnerXml.Contains("<extramount>"))
-                                strMount = objXmlAccessory["extramount"].InnerText;
-                            objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount },intRating);
-							objMod.Cost = "0";
+                                strMount = objXmlAccessory["extramount"].InnerText;      
+                            objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount },intRating, cmsVehicleGear, false, blnCreateChildren);
+
+                            objMod.Cost = "0";
 							objModNode.ContextMenuStrip = cmsVehicleWeaponAccessory;
 
 							objWeapon.WeaponAccessories.Add(objMod);

--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -1862,9 +1862,10 @@ namespace Chummer.Backend.Equipment
 						bool blnFound = false;
 						foreach (WeaponAccessory objAccessory in _lstAccessories)
 						{
-							if (objAccessory.Mount == objXmlMount.InnerText)
+							if ((objAccessory.Mount == objXmlMount.InnerText) || (objAccessory.ExtraMount == objXmlMount.InnerText))
 							{
 								blnFound = true;
+								break;
 							}
 						}
 						if (!blnFound)

--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -82,7 +82,7 @@ namespace Chummer.Backend.Equipment
 		/// <param name="cmsWeapon">ContextMenuStrip to use for Weapons.</param>
 		/// <param name="cmsWeaponAccessory">ContextMenuStrip to use for Accessories.</param>
 		/// <param name="blnCreateChildren">Whether or not child items should be created.</param>
-		public void Create(XmlNode objXmlWeapon, Character objCharacter, TreeNode objNode, ContextMenuStrip cmsWeapon, ContextMenuStrip cmsWeaponAccessory, bool blnCreateChildren = true)
+		public void Create(XmlNode objXmlWeapon, Character objCharacter, TreeNode objNode, ContextMenuStrip cmsWeapon, ContextMenuStrip cmsWeaponAccessory, ContextMenuStrip cmsWeaponAccessoryGear = null, bool blnCreateChildren = true)
 		{
 			_strName = objXmlWeapon["name"].InnerText;
 			_strCategory = objXmlWeapon["category"].InnerText;
@@ -205,7 +205,7 @@ namespace Chummer.Backend.Equipment
 					TreeNode objUnderbarrelNode = new TreeNode();
 					XmlNode objXmlWeaponNode =
 						objXmlDocument.SelectSingleNode("/chummer/weapons/weapon[name = \"" + objXmlUnderbarrel.InnerText + "\"]");
-					objUnderbarrelWeapon.Create(objXmlWeaponNode, _objCharacter, objUnderbarrelNode, cmsWeapon, cmsWeaponAccessory);
+					objUnderbarrelWeapon.Create(objXmlWeaponNode, _objCharacter, objUnderbarrelNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear);
 					objUnderbarrelWeapon.IncludedInWeapon = true;
 					objUnderbarrelWeapon.IsUnderbarrelWeapon = true;
 					_lstUnderbarrel.Add(objUnderbarrelWeapon);
@@ -232,22 +232,23 @@ namespace Chummer.Backend.Equipment
 					{
 						intAccessoryRating = Convert.ToInt32(objXmlAccessory["rating"].InnerText);
 					}
-					if (objXmlWeaponAccessory.InnerXml.Contains("mount"))
+                    if (objXmlWeaponAccessory.InnerXml.Contains("mount"))
 					{
                         if (objXmlWeaponAccessory.InnerXml.Contains("<extramount>"))
                         {
-                            objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { objXmlAccessory["mount"].InnerText, objXmlAccessory["extramount"].InnerText }, intAccessoryRating);
+                            objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { objXmlAccessory["mount"].InnerText, objXmlAccessory["extramount"].InnerText }, intAccessoryRating, cmsWeaponAccessoryGear, false, blnCreateChildren);
                         }
                         else
                         {
-                            objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { objXmlAccessory["mount"].InnerText, "None" }, intAccessoryRating);
+                            objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { objXmlAccessory["mount"].InnerText, "None" }, intAccessoryRating, cmsWeaponAccessoryGear, false, blnCreateChildren);
                         }
 					}
 					else
 					{
-						objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { "Internal" , "None" }, intAccessoryRating);
+						objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { "Internal" , "None" }, intAccessoryRating, cmsWeaponAccessoryGear, false, blnCreateChildren);
 					}
-					objAccessory.IncludedInWeapon = true;
+
+                    objAccessory.IncludedInWeapon = true;
 					objAccessory.Parent = this;
 					objAccessoryNode.ContextMenuStrip = cmsWeaponAccessory;
 					_lstAccessories.Add(objAccessory);

--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -234,11 +234,18 @@ namespace Chummer.Backend.Equipment
 					}
 					if (objXmlWeaponAccessory.InnerXml.Contains("mount"))
 					{
-						objAccessory.Create(objXmlAccessory, objAccessoryNode, objXmlAccessory["mount"].InnerText, intAccessoryRating);
+                        if (objXmlWeaponAccessory.InnerXml.Contains("<extramount>"))
+                        {
+                            objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { objXmlAccessory["mount"].InnerText, objXmlAccessory["extramount"].InnerText }, intAccessoryRating);
+                        }
+                        else
+                        {
+                            objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { objXmlAccessory["mount"].InnerText, "None" }, intAccessoryRating);
+                        }
 					}
 					else
 					{
-						objAccessory.Create(objXmlAccessory, objAccessoryNode, "Internal", intAccessoryRating);
+						objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { "Internal" , "None" }, intAccessoryRating);
 					}
 					objAccessory.IncludedInWeapon = true;
 					objAccessory.Parent = this;

--- a/Chummer/Backend/Equipment/WeaponAccessory.cs
+++ b/Chummer/Backend/Equipment/WeaponAccessory.cs
@@ -18,6 +18,7 @@ namespace Chummer.Backend.Equipment
 		private Weapon _objParent;
 		private string _strName = "";
 		private string _strMount = "";
+		private string _strExtraMount = "";
 		private string _strRC = "";
 		private string _strDamage = "";
 		private string _strDamageType = "";
@@ -98,6 +99,7 @@ namespace Chummer.Backend.Equipment
 			objXmlAccessory.TryGetField("extra", out _strExtra, "");
 			objXmlAccessory.TryGetField("ammobonus", out _intAmmoBonus);
 			objXmlAccessory.TryGetField("accessorycostmultiplier", out _intAccessoryCostMultiplier);
+			objXmlAccessory.TryGetField("extramount", out _strExtraMount);
 
 			if (GlobalOptions.Instance.Language != "en-us")
 			{
@@ -126,6 +128,7 @@ namespace Chummer.Backend.Equipment
 			objWriter.WriteElementString("guid", _guiID.ToString());
 			objWriter.WriteElementString("name", _strName);
 			objWriter.WriteElementString("mount", _strMount);
+			objWriter.WriteElementString("extramount", _strExtraMount);
 			objWriter.WriteElementString("rc", _strRC);
 			objWriter.WriteElementString("rating", _intRating.ToString());
 			objWriter.WriteElementString("rcgroup", _intRCGroup.ToString());
@@ -191,6 +194,7 @@ namespace Chummer.Backend.Equipment
 			_guiID = Guid.Parse(objNode["guid"].InnerText);
 			_strName = objNode["name"].InnerText;
 			_strMount = objNode["mount"].InnerText;
+			objNode.TryGetField("extramount", out _strExtraMount,0);
 			_strRC = objNode["rc"].InnerText;
 			objNode.TryGetField("rating", out _intRating,0);
 			objNode.TryGetField("rcgroup", out _intRCGroup, 0);
@@ -311,6 +315,7 @@ namespace Chummer.Backend.Equipment
 			objWriter.WriteStartElement("accessory");
 			objWriter.WriteElementString("name", DisplayName);
 			objWriter.WriteElementString("mount", _strMount);
+			objWriter.WriteElementString("extramount", _strExtraMount);
 			objWriter.WriteElementString("rc", _strRC);
 			objWriter.WriteElementString("conceal", _strConceal);
 			objWriter.WriteElementString("avail", TotalAvail);
@@ -554,6 +559,21 @@ namespace Chummer.Backend.Equipment
 			set
 			{
 				_strMount = value;
+			}
+		}
+		
+		/// <summary>
+		/// Additional mount slot used (if any).
+		/// </summary>
+		public string ExtraMount
+		{
+			get
+			{
+				return _strExtraMount;
+			}
+			set
+			{
+				_strExtraMount = value;
 			}
 		}
 

--- a/Chummer/Backend/Equipment/WeaponAccessory.cs
+++ b/Chummer/Backend/Equipment/WeaponAccessory.cs
@@ -67,11 +67,12 @@ namespace Chummer.Backend.Equipment
 		/// <param name="objNode">TreeNode to populate a TreeView.</param>
 		/// <param name="strMount">Mount slot that the Weapon Accessory will consume.</param>
 		/// <param name="intRating">Rating of the Weapon Accessory.</param>
-		public void Create(XmlNode objXmlAccessory, TreeNode objNode, string strMount, int intRating)
+		public void Create(XmlNode objXmlAccessory, TreeNode objNode, string[] strMount, int intRating)
 		{
 			_strName = objXmlAccessory["name"].InnerText;
-			_strMount = strMount;
-			_intRating = intRating;
+			_strMount = strMount[0];
+            _strExtraMount = strMount[1];
+            _intRating = intRating;
 			_strAvail = objXmlAccessory["avail"].InnerText;
 			_strCost = objXmlAccessory["cost"].InnerText;
 			_strSource = objXmlAccessory["source"].InnerText;
@@ -99,7 +100,6 @@ namespace Chummer.Backend.Equipment
 			objXmlAccessory.TryGetField("extra", out _strExtra, "");
 			objXmlAccessory.TryGetField("ammobonus", out _intAmmoBonus);
 			objXmlAccessory.TryGetField("accessorycostmultiplier", out _intAccessoryCostMultiplier);
-			objXmlAccessory.TryGetField("extramount", out _strExtraMount);
 
 			if (GlobalOptions.Instance.Language != "en-us")
 			{
@@ -194,7 +194,7 @@ namespace Chummer.Backend.Equipment
 			_guiID = Guid.Parse(objNode["guid"].InnerText);
 			_strName = objNode["name"].InnerText;
 			_strMount = objNode["mount"].InnerText;
-			objNode.TryGetField("extramount", out _strExtraMount,0);
+			objNode.TryGetField("extramount", out _strExtraMount, "");
 			_strRC = objNode["rc"].InnerText;
 			objNode.TryGetField("rating", out _intRating,0);
 			objNode.TryGetField("rcgroup", out _intRCGroup, 0);

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -7830,11 +7830,12 @@ namespace Chummer
 					bool blnFound = false;
 					foreach (WeaponAccessory objMod in objWeapon.WeaponAccessories)
 					{
-						if (objMod.Mount == objXmlMount.InnerText)
-						{
-							blnFound = true;
-						}
-					}
+                        if ((objMod.Mount == objXmlMount.InnerText) || (objMod.ExtraMount == objXmlMount.InnerText))
+                        {
+                            blnFound = true;
+                            break;
+                        }
+                    }
 					if (!blnFound)
 					{
 						strMounts += objXmlMount.InnerText + "/";
@@ -8186,8 +8187,11 @@ namespace Chummer
                     bool blnFound = false;
                     foreach (WeaponAccessory objCurrentAccessory in objWeapon.WeaponAccessories)
                     {
-                        if (objCurrentAccessory.Mount == objXmlMount.InnerText)
+                        if ((objCurrentAccessory.Mount == objXmlMount.InnerText) || (objCurrentAccessory.ExtraMount == objXmlMount.InnerText))
+                        {
                             blnFound = true;
+                            break;
+                        }
                     }
                     if (!blnFound)
                         strMounts += objXmlMount.InnerText + "/";

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -5489,7 +5489,7 @@ namespace Chummer
             TreeNode objNode = new TreeNode();
             Weapon objWeapon = new Weapon(_objCharacter);
 	        objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
-            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory);
+            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear);
 	        objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
             _objCharacter.Weapons.Add(objWeapon);
 
@@ -5821,7 +5821,7 @@ namespace Chummer
 
             TreeNode objNode = new TreeNode();
             Vehicle objVehicle = new Vehicle(_objCharacter);
-            objVehicle.Create(objXmlVehicle, objNode, cmsVehicle, cmsVehicleGear, cmsVehicleWeapon, cmsVehicleWeaponAccessory);
+            objVehicle.Create(objXmlVehicle, objNode, cmsVehicle, cmsVehicleGear, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear);
             // Update the Used Vehicle information if applicable.
             if (frmPickVehicle.UsedVehicle)
             {
@@ -7888,7 +7888,7 @@ namespace Chummer
 
             TreeNode objNode = new TreeNode();
             WeaponAccessory objAccessory = new WeaponAccessory(_objCharacter);
-            objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount,Convert.ToInt32(frmPickWeaponAccessory.SelectedRating));
+            objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount,Convert.ToInt32(frmPickWeaponAccessory.SelectedRating), cmsWeaponAccessoryGear);
             objAccessory.Parent = objWeapon;
 
             if (objAccessory.Cost.StartsWith("Variable"))
@@ -8154,7 +8154,7 @@ namespace Chummer
 
             TreeNode objNode = new TreeNode();
             Weapon objWeapon = new Weapon(_objCharacter);
-            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory);
+            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear);
 	        objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
             objWeapon.VehicleMounted = true;
 
@@ -8238,7 +8238,7 @@ namespace Chummer
 
             TreeNode objNode = new TreeNode();
             WeaponAccessory objAccessory = new WeaponAccessory(_objCharacter);
-            objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount, Convert.ToInt32(frmPickWeaponAccessory.SelectedRating));
+            objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount, Convert.ToInt32(frmPickWeaponAccessory.SelectedRating), cmsVehicleWeaponAccessoryGear);
 			objAccessory.Parent = objWeapon;
             objWeapon.WeaponAccessories.Add(objAccessory);
 
@@ -8281,7 +8281,7 @@ namespace Chummer
 
             TreeNode objNode = new TreeNode();
             Weapon objWeapon = new Weapon(_objCharacter);
-            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory);
+            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear);
 	        objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
             objWeapon.VehicleMounted = true;
             objWeapon.IsUnderbarrelWeapon = true;
@@ -8851,7 +8851,7 @@ namespace Chummer
 
             TreeNode objNode = new TreeNode();
             Weapon objWeapon = new Weapon(_objCharacter);
-            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory);
+            objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear);
 	        objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
             objWeapon.IsUnderbarrelWeapon = true;
             objSelectedWeapon.UnderbarrelWeapons.Add(objWeapon);
@@ -20513,7 +20513,7 @@ namespace Chummer
 
                     Weapon objWeapon = new Weapon(_objCharacter);
                     TreeNode objNode = new TreeNode();
-                    objWeapon.Create(objXmlWeaponNode, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, blnCreateChildren);
+                    objWeapon.Create(objXmlWeaponNode, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear, blnCreateChildren);
                     _objCharacter.Weapons.Add(objWeapon);
 
                     // Look for Weapon Accessories.
@@ -20531,7 +20531,7 @@ namespace Chummer
                             string strExtraMount = "None";
                             if (objXmlAccessory.InnerXml.Contains("<extramount>"))
                                 strMount = objXmlAccessory["extramount"].InnerText;
-                            objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount }, intRating);
+                            objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount }, intRating, cmsWeaponAccessoryGear, false, blnCreateChildren);
                             objModNode.ContextMenuStrip = cmsWeaponAccessory;
                             objMod.Parent = objWeapon;
 
@@ -20553,7 +20553,7 @@ namespace Chummer
 
                         Weapon objUnderbarrelWeapon = new Weapon(_objCharacter);
                         TreeNode objUnderbarrelNode = new TreeNode();
-                        objUnderbarrelWeapon.Create(objXmlUnderbarrelNode, _objCharacter, objUnderbarrelNode, cmsWeapon, cmsWeaponAccessory, blnCreateChildren);
+                        objUnderbarrelWeapon.Create(objXmlUnderbarrelNode, _objCharacter, objUnderbarrelNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear, blnCreateChildren);
                         objWeapon.UnderbarrelWeapons.Add(objUnderbarrelWeapon);
                         objNode.Nodes.Add(objUnderbarrelNode);
                         objNode.Expand();
@@ -20765,7 +20765,7 @@ namespace Chummer
                     Vehicle objVehicle = new Vehicle(_objCharacter);
 
                     XmlNode objXmlVehicleNode = objXmlVehicleDocument.SelectSingleNode("/chummer/vehicles/vehicle[name = \"" + objXmlVehicle["name"].InnerText + "\"]");
-                    objVehicle.Create(objXmlVehicleNode, objNode, cmsVehicle, cmsVehicleGear, cmsVehicleWeapon, cmsVehicleWeaponAccessory, blnCreateChildren);
+                    objVehicle.Create(objXmlVehicleNode, objNode, cmsVehicle, cmsVehicleGear, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear, blnCreateChildren);
                     _objCharacter.Vehicles.Add(objVehicle);
 
                     // Grab the default Sensor that comes with the Vehicle.
@@ -20868,7 +20868,7 @@ namespace Chummer
                             Weapon objWeapon = new Weapon(_objCharacter);
 
                             XmlNode objXmlWeaponNode = objXmlWeaponDocument.SelectSingleNode("/chummer/weapons/weapon[name = \"" + objXmlWeapon["name"].InnerText + "\"]");
-                            objWeapon.Create(objXmlWeaponNode, _objCharacter, objWeaponNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory, blnCreateChildren);
+                            objWeapon.Create(objXmlWeaponNode, _objCharacter, objWeaponNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear, blnCreateChildren);
                             objWeapon.VehicleMounted = true;
 
                             // Find the first Weapon Mount in the Vehicle.
@@ -20906,7 +20906,7 @@ namespace Chummer
                                     string strExtraMount = "None";
                                     if (objXmlAccessory.InnerXml.Contains("<extramount>"))
                                         strMount = objXmlAccessory["extramount"].InnerText;
-                                    objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount }, intRating);
+                                    objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount }, intRating, cmsWeaponAccessoryGear, false, blnCreateChildren);
                                     objModNode.ContextMenuStrip = cmsWeaponAccessory;
                                     objMod.Parent = objWeapon;
 

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -15954,6 +15954,27 @@ namespace Chummer
                         if (strMount != "" && strMount.Contains('/'))
                             strMount = strMount.Substring(0, strMount.Length - 1);
 
+                        if ((objSelectedAccessory.ExtraMount != "") && (objSelectedAccessory.ExtraMount != "None"))
+                        {
+                            bool boolHaveAddedItem = false;
+                            string[] strExtraMounts = objSelectedAccessory.ExtraMount.Split('/');
+                            foreach (string strCurrentExtraMount in strExtraMounts)
+                            {
+                                if (strCurrentExtraMount != "")
+                                {
+                                    if (!boolHaveAddedItem)
+                                    {
+                                        strMount += " + ";
+                                        boolHaveAddedItem = true;
+                                    }
+                                    strMount += LanguageManager.Instance.GetString("String_Mount" + strCurrentExtraMount) + "/";
+                                }
+                            }
+                            // Remove the trailing /
+                            if (boolHaveAddedItem)
+                                strMount = strMount.Substring(0, strMount.Length - 1);
+                        }
+
                         lblWeaponSlots.Text = strMount;
                         string strBook = _objOptions.LanguageBookShort(objSelectedAccessory.Source);
                         string strPage = objSelectedAccessory.Page;
@@ -18407,6 +18428,26 @@ namespace Chummer
                         // Remove the trailing /
                         if (strMount != "" && strMount.Contains('/'))
                             strMount = strMount.Substring(0, strMount.Length - 1);
+                        if ((objAccessory.ExtraMount != "") && (objAccessory.ExtraMount != "None"))
+                        {
+                            bool boolHaveAddedItem = false;
+                            string[] strExtraMounts = objAccessory.ExtraMount.Split('/');
+                            foreach (string strCurrentExtraMount in strExtraMounts)
+                            {
+                                if (strCurrentExtraMount != "")
+                                {
+                                    if (!boolHaveAddedItem)
+                                    {
+                                        strMount += " + ";
+                                        boolHaveAddedItem = true;
+                                    }
+                                    strMount += LanguageManager.Instance.GetString("String_Mount" + strCurrentExtraMount) + "/";
+                                }
+                            }
+                            // Remove the trailing /
+                            if (boolHaveAddedItem)
+                                strMount = strMount.Substring(0, strMount.Length - 1);
+                        }
 
                         lblVehicleSlots.Text = strMount;
                         string strBook = _objOptions.LanguageBookShort(objAccessory.Source);
@@ -18513,8 +18554,28 @@ namespace Chummer
 					// Remove the trailing /
 					if (strMount != "" && strMount.Contains('/'))
 						strMount = strMount.Substring(0, strMount.Length - 1);
+                    if ((objAccessory.ExtraMount != "") && (objAccessory.ExtraMount != "None"))
+                    {
+                        bool boolHaveAddedItem = false;
+                        string[] strExtraMounts = objAccessory.ExtraMount.Split('/');
+                        foreach (string strCurrentExtraMount in strExtraMounts)
+                        {
+                            if (strCurrentExtraMount != "")
+                            {
+                                if (!boolHaveAddedItem)
+                                {
+                                    strMount += " + ";
+                                    boolHaveAddedItem = true;
+                                }
+                                strMount += LanguageManager.Instance.GetString("String_Mount" + strCurrentExtraMount) + "/";
+                            }
+                        }
+                        // Remove the trailing /
+                        if (boolHaveAddedItem)
+                            strMount = strMount.Substring(0, strMount.Length - 1);
+                    }
 
-					lblVehicleSlots.Text = strMount;
+                    lblVehicleSlots.Text = strMount;
 					string strBook = _objOptions.LanguageBookShort(objAccessory.Source);
 					string strPage = objAccessory.Page;
 					lblVehicleSource.Text = strBook + " " + strPage;
@@ -20410,11 +20471,14 @@ namespace Chummer
                             XmlNode objXmlAccessoryNode = objXmlWeaponDocument.SelectSingleNode("/chummer/accessories/accessory[name = \"" + objXmlAccessory["name"].InnerText + "\"]");
                             WeaponAccessory objMod = new WeaponAccessory(_objCharacter);
                             TreeNode objModNode = new TreeNode();
-                            string strMount = "";
+                            string strMount = "Internal";
 							int intRating = 0;
                             if (objXmlAccessory["mount"] != null)
                                 strMount = objXmlAccessory["mount"].InnerText;
-                            objMod.Create(objXmlAccessoryNode, objModNode, strMount, intRating);
+                            string strExtraMount = "None";
+                            if (objXmlAccessory.InnerXml.Contains("<extramount>"))
+                                strMount = objXmlAccessory["extramount"].InnerText;
+                            objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount }, intRating);
                             objModNode.ContextMenuStrip = cmsWeaponAccessory;
                             objMod.Parent = objWeapon;
 
@@ -20758,11 +20822,14 @@ namespace Chummer
                                     XmlNode objXmlAccessoryNode = objXmlWeaponDocument.SelectSingleNode("/chummer/accessories/accessory[name = \"" + objXmlAccessory["name"].InnerText + "\"]");
                                     WeaponAccessory objMod = new WeaponAccessory(_objCharacter);
                                     TreeNode objModNode = new TreeNode();
-                                    string strMount = "";
+                                    string strMount = "Internal";
 									int intRating = 0;
 									if (objXmlAccessory["mount"] != null)
                                         strMount = objXmlAccessory["mount"].InnerText;
-                                    objMod.Create(objXmlAccessoryNode, objModNode, strMount,intRating);
+                                    string strExtraMount = "None";
+                                    if (objXmlAccessory.InnerXml.Contains("<extramount>"))
+                                        strMount = objXmlAccessory["extramount"].InnerText;
+                                    objMod.Create(objXmlAccessoryNode, objModNode, new string[] { strMount, strExtraMount }, intRating);
                                     objModNode.ContextMenuStrip = cmsWeaponAccessory;
                                     objMod.Parent = objWeapon;
 

--- a/Chummer/Selection Forms/frmSelectCyberwareSuite.cs
+++ b/Chummer/Selection Forms/frmSelectCyberwareSuite.cs
@@ -234,8 +234,10 @@ namespace Chummer
 				TreeNode objTreeNode = new TreeNode();
 				List<Weapon> lstWeapons = new List<Weapon>();
 				List<TreeNode> lstWeaponNodes = new List<TreeNode>();
-				Cyberware objCyberware = new Cyberware(_objCharacter);
-				objCyberware.Create(objXmlCyberware, _objCharacter, objGrade, _objSource, intRating, objTreeNode, lstWeapons, lstWeaponNodes, false, false);
+                List<Vehicle> objVehicles = new List<Vehicle>();
+                List<TreeNode> objVehicleNodes = new List<TreeNode>();
+                Cyberware objCyberware = new Cyberware(_objCharacter);
+				objCyberware.Create(objXmlCyberware, _objCharacter, objGrade, _objSource, intRating, objTreeNode, lstWeapons, lstWeaponNodes, objVehicles, objVehicleNodes, false, false);
 				objCyberware.Suite = true;
 
 				if (objParent == null)

--- a/Chummer/Selection Forms/frmSelectGear.cs
+++ b/Chummer/Selection Forms/frmSelectGear.cs
@@ -235,7 +235,9 @@ namespace Chummer
 
 			foreach (XmlNode objXmlGear in objXmlGearList)
 			{
-				ListItem objItem = new ListItem();
+                if (objXmlGear["hidden"] != null)
+                    continue;
+                ListItem objItem = new ListItem();
 				objItem.Value = objXmlGear["name"].InnerText;
 				if (objXmlGear["translate"] != null)
 					objItem.Name = objXmlGear["translate"].InnerText;
@@ -361,7 +363,9 @@ namespace Chummer
 			bool blnAddToList;
 			foreach (XmlNode objXmlGear in objXmlGearList)
 			{
-				blnAddToList = true;
+                if (objXmlGear["hidden"] != null)
+                    continue;
+                blnAddToList = true;
 				if (_blnShowArmorCapacityOnly)
 				{
 					if (objXmlGear["armorcapacity"] == null)

--- a/Chummer/Selection Forms/frmSelectLifestyle.cs
+++ b/Chummer/Selection Forms/frmSelectLifestyle.cs
@@ -99,7 +99,7 @@ namespace Chummer
             
 
 			// Fill the Options list.
-			foreach (XmlNode objXmlOption in _objXmlDocument.SelectNodes("/chummer/qualities/quality[source = \"" + "SR5" + "\"]"))
+			foreach (XmlNode objXmlOption in _objXmlDocument.SelectNodes("/chummer/qualities/quality[source = \"" + "SR5" + "\" or category = \"" + "Contracts" + "\"]"))
 			{
 				TreeNode nodOption = new TreeNode();
 

--- a/Chummer/Selection Forms/frmSelectVehicle.cs
+++ b/Chummer/Selection Forms/frmSelectVehicle.cs
@@ -106,6 +106,8 @@ namespace Chummer
 			XmlNodeList objXmlVehicleList = _objXmlDocument.SelectNodes("/chummer/vehicles/vehicle[category = \"" + cboCategory.SelectedValue + "\" and (" + _objCharacter.Options.BookXPath() + ")]");
 			foreach (XmlNode objXmlVehicle in objXmlVehicleList)
 			{
+                if (objXmlVehicle["hidden"] != null)
+                    continue;
 				ListItem objItem = new ListItem();
 				objItem.Value = objXmlVehicle["name"].InnerText;
 				if (objXmlVehicle["translate"] != null)
@@ -153,7 +155,9 @@ namespace Chummer
 			List<ListItem> lstVehicles = new List<ListItem>();
 			foreach (XmlNode objXmlVehicle in objXmlVehicleList)
 			{
-				ListItem objItem = new ListItem();
+                if (objXmlVehicle["hidden"] != null)
+                    continue;
+                ListItem objItem = new ListItem();
 				objItem.Value = objXmlVehicle["name"].InnerText;
 				if (objXmlVehicle["translate"] != null)
 					objItem.Name = objXmlVehicle["translate"].InnerText;

--- a/Chummer/Selection Forms/frmSelectVehicleMod.cs
+++ b/Chummer/Selection Forms/frmSelectVehicleMod.cs
@@ -152,7 +152,9 @@ namespace Chummer
 			}
 			foreach (XmlNode objXmlMod in objXmlModList)
 			{
-					ListItem objItem = new ListItem();
+                if (objXmlMod["hidden"] != null)
+                    continue;
+                ListItem objItem = new ListItem();
 					objItem.Value = objXmlMod["name"].InnerText;
 					if (objXmlMod["translate"] != null)
 						objItem.Name = objXmlMod["translate"].InnerText;

--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.Designer.cs
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.Designer.cs
@@ -28,328 +28,352 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.lblMountLabel = new System.Windows.Forms.Label();
-			this.lblCost = new System.Windows.Forms.Label();
-			this.lblCostLabel = new System.Windows.Forms.Label();
-			this.lblAvail = new System.Windows.Forms.Label();
-			this.lblAvailLabel = new System.Windows.Forms.Label();
-			this.lblRC = new System.Windows.Forms.Label();
-			this.lblRCLabel = new System.Windows.Forms.Label();
-			this.cmdCancel = new System.Windows.Forms.Button();
-			this.cmdOK = new System.Windows.Forms.Button();
-			this.lstAccessory = new System.Windows.Forms.ListBox();
-			this.cmdOKAdd = new System.Windows.Forms.Button();
-			this.lblSource = new System.Windows.Forms.Label();
-			this.lblSourceLabel = new System.Windows.Forms.Label();
-			this.chkFreeItem = new System.Windows.Forms.CheckBox();
-			this.nudMarkup = new System.Windows.Forms.NumericUpDown();
-			this.lblMarkupLabel = new System.Windows.Forms.Label();
-			this.lblMarkupPercentLabel = new System.Windows.Forms.Label();
-			this.lblTest = new System.Windows.Forms.Label();
-			this.lblTestLabel = new System.Windows.Forms.Label();
-			this.tipTooltip = new System.Windows.Forms.ToolTip(this.components);
-			this.nudRating = new System.Windows.Forms.NumericUpDown();
-			this.lblRatingLabel = new System.Windows.Forms.Label();
-			this.cboMount = new System.Windows.Forms.ComboBox();
-			this.chkBlackMarketDiscount = new System.Windows.Forms.CheckBox();
-			((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.nudRating)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// lblMountLabel
-			// 
-			this.lblMountLabel.AutoSize = true;
-			this.lblMountLabel.Location = new System.Drawing.Point(258, 35);
-			this.lblMountLabel.Name = "lblMountLabel";
-			this.lblMountLabel.Size = new System.Drawing.Size(40, 13);
-			this.lblMountLabel.TabIndex = 3;
-			this.lblMountLabel.Tag = "Label_Mount";
-			this.lblMountLabel.Text = "Mount:";
-			// 
-			// lblCost
-			// 
-			this.lblCost.AutoSize = true;
-			this.lblCost.Location = new System.Drawing.Point(315, 81);
-			this.lblCost.Name = "lblCost";
-			this.lblCost.Size = new System.Drawing.Size(34, 13);
-			this.lblCost.TabIndex = 10;
-			this.lblCost.Text = "[Cost]";
-			// 
-			// lblCostLabel
-			// 
-			this.lblCostLabel.AutoSize = true;
-			this.lblCostLabel.Location = new System.Drawing.Point(258, 81);
-			this.lblCostLabel.Name = "lblCostLabel";
-			this.lblCostLabel.Size = new System.Drawing.Size(31, 13);
-			this.lblCostLabel.TabIndex = 9;
-			this.lblCostLabel.Tag = "Label_Cost";
-			this.lblCostLabel.Text = "Cost:";
-			// 
-			// lblAvail
-			// 
-			this.lblAvail.AutoSize = true;
-			this.lblAvail.Location = new System.Drawing.Point(315, 58);
-			this.lblAvail.Name = "lblAvail";
-			this.lblAvail.Size = new System.Drawing.Size(36, 13);
-			this.lblAvail.TabIndex = 6;
-			this.lblAvail.Text = "[Avail]";
-			// 
-			// lblAvailLabel
-			// 
-			this.lblAvailLabel.AutoSize = true;
-			this.lblAvailLabel.Location = new System.Drawing.Point(258, 58);
-			this.lblAvailLabel.Name = "lblAvailLabel";
-			this.lblAvailLabel.Size = new System.Drawing.Size(33, 13);
-			this.lblAvailLabel.TabIndex = 5;
-			this.lblAvailLabel.Tag = "Label_Avail";
-			this.lblAvailLabel.Text = "Avail:";
-			// 
-			// lblRC
-			// 
-			this.lblRC.AutoSize = true;
-			this.lblRC.Location = new System.Drawing.Point(315, 12);
-			this.lblRC.Name = "lblRC";
-			this.lblRC.Size = new System.Drawing.Size(28, 13);
-			this.lblRC.TabIndex = 2;
-			this.lblRC.Text = "[RC]";
-			// 
-			// lblRCLabel
-			// 
-			this.lblRCLabel.AutoSize = true;
-			this.lblRCLabel.Location = new System.Drawing.Point(258, 12);
-			this.lblRCLabel.Name = "lblRCLabel";
-			this.lblRCLabel.Size = new System.Drawing.Size(25, 13);
-			this.lblRCLabel.TabIndex = 1;
-			this.lblRCLabel.Tag = "Label_RC";
-			this.lblRCLabel.Text = "RC:";
-			// 
-			// cmdCancel
-			// 
-			this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cmdCancel.Location = new System.Drawing.Point(339, 357);
-			this.cmdCancel.Name = "cmdCancel";
-			this.cmdCancel.Size = new System.Drawing.Size(75, 23);
-			this.cmdCancel.TabIndex = 19;
-			this.cmdCancel.Tag = "String_Cancel";
-			this.cmdCancel.Text = "Cancel";
-			this.cmdCancel.UseVisualStyleBackColor = true;
-			this.cmdCancel.Click += new System.EventHandler(this.cmdCancel_Click);
-			// 
-			// cmdOK
-			// 
-			this.cmdOK.Location = new System.Drawing.Point(420, 357);
-			this.cmdOK.Name = "cmdOK";
-			this.cmdOK.Size = new System.Drawing.Size(75, 23);
-			this.cmdOK.TabIndex = 17;
-			this.cmdOK.Tag = "String_OK";
-			this.cmdOK.Text = "OK";
-			this.cmdOK.UseVisualStyleBackColor = true;
-			this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
-			// 
-			// lstAccessory
-			// 
-			this.lstAccessory.FormattingEnabled = true;
-			this.lstAccessory.Location = new System.Drawing.Point(12, 12);
-			this.lstAccessory.Name = "lstAccessory";
-			this.lstAccessory.Size = new System.Drawing.Size(240, 368);
-			this.lstAccessory.TabIndex = 0;
-			this.lstAccessory.SelectedIndexChanged += new System.EventHandler(this.lstAccessory_SelectedIndexChanged);
-			this.lstAccessory.DoubleClick += new System.EventHandler(this.lstAccessory_DoubleClick);
-			// 
-			// cmdOKAdd
-			// 
-			this.cmdOKAdd.Location = new System.Drawing.Point(420, 328);
-			this.cmdOKAdd.Name = "cmdOKAdd";
-			this.cmdOKAdd.Size = new System.Drawing.Size(75, 23);
-			this.cmdOKAdd.TabIndex = 18;
-			this.cmdOKAdd.Tag = "String_AddMore";
-			this.cmdOKAdd.Text = "&Add && More";
-			this.cmdOKAdd.UseVisualStyleBackColor = true;
-			this.cmdOKAdd.Click += new System.EventHandler(this.cmdOKAdd_Click);
-			// 
-			// lblSource
-			// 
-			this.lblSource.AutoSize = true;
-			this.lblSource.Location = new System.Drawing.Point(309, 178);
-			this.lblSource.Name = "lblSource";
-			this.lblSource.Size = new System.Drawing.Size(47, 13);
-			this.lblSource.TabIndex = 16;
-			this.lblSource.Text = "[Source]";
-			this.lblSource.Click += new System.EventHandler(this.lblSource_Click);
-			// 
-			// lblSourceLabel
-			// 
-			this.lblSourceLabel.AutoSize = true;
-			this.lblSourceLabel.Location = new System.Drawing.Point(258, 178);
-			this.lblSourceLabel.Name = "lblSourceLabel";
-			this.lblSourceLabel.Size = new System.Drawing.Size(44, 13);
-			this.lblSourceLabel.TabIndex = 15;
-			this.lblSourceLabel.Tag = "Label_Source";
-			this.lblSourceLabel.Text = "Source:";
-			// 
-			// chkFreeItem
-			// 
-			this.chkFreeItem.AutoSize = true;
-			this.chkFreeItem.Location = new System.Drawing.Point(258, 107);
-			this.chkFreeItem.Name = "chkFreeItem";
-			this.chkFreeItem.Size = new System.Drawing.Size(50, 17);
-			this.chkFreeItem.TabIndex = 11;
-			this.chkFreeItem.Tag = "Checkbox_Free";
-			this.chkFreeItem.Text = "Free!";
-			this.chkFreeItem.UseVisualStyleBackColor = true;
-			this.chkFreeItem.Visible = true;
-			this.chkFreeItem.CheckedChanged += new System.EventHandler(this.chkFreeItem_CheckedChanged);
-			// 
-			// nudMarkup
-			// 
-			this.nudMarkup.Location = new System.Drawing.Point(318, 130);
-			this.nudMarkup.Maximum = new decimal(new int[] {
+            this.components = new System.ComponentModel.Container();
+            this.lblMountLabel = new System.Windows.Forms.Label();
+            this.lblCost = new System.Windows.Forms.Label();
+            this.lblCostLabel = new System.Windows.Forms.Label();
+            this.lblAvail = new System.Windows.Forms.Label();
+            this.lblAvailLabel = new System.Windows.Forms.Label();
+            this.lblRC = new System.Windows.Forms.Label();
+            this.lblRCLabel = new System.Windows.Forms.Label();
+            this.cmdCancel = new System.Windows.Forms.Button();
+            this.cmdOK = new System.Windows.Forms.Button();
+            this.lstAccessory = new System.Windows.Forms.ListBox();
+            this.cmdOKAdd = new System.Windows.Forms.Button();
+            this.lblSource = new System.Windows.Forms.Label();
+            this.lblSourceLabel = new System.Windows.Forms.Label();
+            this.chkFreeItem = new System.Windows.Forms.CheckBox();
+            this.nudMarkup = new System.Windows.Forms.NumericUpDown();
+            this.lblMarkupLabel = new System.Windows.Forms.Label();
+            this.lblMarkupPercentLabel = new System.Windows.Forms.Label();
+            this.lblTest = new System.Windows.Forms.Label();
+            this.lblTestLabel = new System.Windows.Forms.Label();
+            this.tipTooltip = new System.Windows.Forms.ToolTip(this.components);
+            this.nudRating = new System.Windows.Forms.NumericUpDown();
+            this.lblRatingLabel = new System.Windows.Forms.Label();
+            this.cboMount = new System.Windows.Forms.ComboBox();
+            this.chkBlackMarketDiscount = new System.Windows.Forms.CheckBox();
+            this.cboExtraMount = new System.Windows.Forms.ComboBox();
+            this.lblExtraMountLabel = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudRating)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // lblMountLabel
+            // 
+            this.lblMountLabel.AutoSize = true;
+            this.lblMountLabel.Location = new System.Drawing.Point(258, 35);
+            this.lblMountLabel.Name = "lblMountLabel";
+            this.lblMountLabel.Size = new System.Drawing.Size(40, 13);
+            this.lblMountLabel.TabIndex = 3;
+            this.lblMountLabel.Tag = "Label_Mount";
+            this.lblMountLabel.Text = "Mount:";
+            // 
+            // lblCost
+            // 
+            this.lblCost.AutoSize = true;
+            this.lblCost.Location = new System.Drawing.Point(314, 115);
+            this.lblCost.Name = "lblCost";
+            this.lblCost.Size = new System.Drawing.Size(34, 13);
+            this.lblCost.TabIndex = 10;
+            this.lblCost.Text = "[Cost]";
+            // 
+            // lblCostLabel
+            // 
+            this.lblCostLabel.AutoSize = true;
+            this.lblCostLabel.Location = new System.Drawing.Point(257, 115);
+            this.lblCostLabel.Name = "lblCostLabel";
+            this.lblCostLabel.Size = new System.Drawing.Size(31, 13);
+            this.lblCostLabel.TabIndex = 9;
+            this.lblCostLabel.Tag = "Label_Cost";
+            this.lblCostLabel.Text = "Cost:";
+            // 
+            // lblAvail
+            // 
+            this.lblAvail.AutoSize = true;
+            this.lblAvail.Location = new System.Drawing.Point(314, 92);
+            this.lblAvail.Name = "lblAvail";
+            this.lblAvail.Size = new System.Drawing.Size(36, 13);
+            this.lblAvail.TabIndex = 6;
+            this.lblAvail.Text = "[Avail]";
+            // 
+            // lblAvailLabel
+            // 
+            this.lblAvailLabel.AutoSize = true;
+            this.lblAvailLabel.Location = new System.Drawing.Point(257, 92);
+            this.lblAvailLabel.Name = "lblAvailLabel";
+            this.lblAvailLabel.Size = new System.Drawing.Size(33, 13);
+            this.lblAvailLabel.TabIndex = 5;
+            this.lblAvailLabel.Tag = "Label_Avail";
+            this.lblAvailLabel.Text = "Avail:";
+            // 
+            // lblRC
+            // 
+            this.lblRC.AutoSize = true;
+            this.lblRC.Location = new System.Drawing.Point(315, 12);
+            this.lblRC.Name = "lblRC";
+            this.lblRC.Size = new System.Drawing.Size(28, 13);
+            this.lblRC.TabIndex = 2;
+            this.lblRC.Text = "[RC]";
+            // 
+            // lblRCLabel
+            // 
+            this.lblRCLabel.AutoSize = true;
+            this.lblRCLabel.Location = new System.Drawing.Point(258, 12);
+            this.lblRCLabel.Name = "lblRCLabel";
+            this.lblRCLabel.Size = new System.Drawing.Size(25, 13);
+            this.lblRCLabel.TabIndex = 1;
+            this.lblRCLabel.Tag = "Label_RC";
+            this.lblRCLabel.Text = "RC:";
+            // 
+            // cmdCancel
+            // 
+            this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cmdCancel.Location = new System.Drawing.Point(339, 357);
+            this.cmdCancel.Name = "cmdCancel";
+            this.cmdCancel.Size = new System.Drawing.Size(75, 23);
+            this.cmdCancel.TabIndex = 19;
+            this.cmdCancel.Tag = "String_Cancel";
+            this.cmdCancel.Text = "Cancel";
+            this.cmdCancel.UseVisualStyleBackColor = true;
+            this.cmdCancel.Click += new System.EventHandler(this.cmdCancel_Click);
+            // 
+            // cmdOK
+            // 
+            this.cmdOK.Location = new System.Drawing.Point(420, 357);
+            this.cmdOK.Name = "cmdOK";
+            this.cmdOK.Size = new System.Drawing.Size(75, 23);
+            this.cmdOK.TabIndex = 17;
+            this.cmdOK.Tag = "String_OK";
+            this.cmdOK.Text = "OK";
+            this.cmdOK.UseVisualStyleBackColor = true;
+            this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
+            // 
+            // lstAccessory
+            // 
+            this.lstAccessory.FormattingEnabled = true;
+            this.lstAccessory.Location = new System.Drawing.Point(12, 12);
+            this.lstAccessory.Name = "lstAccessory";
+            this.lstAccessory.Size = new System.Drawing.Size(240, 368);
+            this.lstAccessory.TabIndex = 0;
+            this.lstAccessory.SelectedIndexChanged += new System.EventHandler(this.lstAccessory_SelectedIndexChanged);
+            this.lstAccessory.DoubleClick += new System.EventHandler(this.lstAccessory_DoubleClick);
+            // 
+            // cmdOKAdd
+            // 
+            this.cmdOKAdd.Location = new System.Drawing.Point(420, 328);
+            this.cmdOKAdd.Name = "cmdOKAdd";
+            this.cmdOKAdd.Size = new System.Drawing.Size(75, 23);
+            this.cmdOKAdd.TabIndex = 18;
+            this.cmdOKAdd.Tag = "String_AddMore";
+            this.cmdOKAdd.Text = "&Add && More";
+            this.cmdOKAdd.UseVisualStyleBackColor = true;
+            this.cmdOKAdd.Click += new System.EventHandler(this.cmdOKAdd_Click);
+            // 
+            // lblSource
+            // 
+            this.lblSource.AutoSize = true;
+            this.lblSource.Location = new System.Drawing.Point(308, 212);
+            this.lblSource.Name = "lblSource";
+            this.lblSource.Size = new System.Drawing.Size(47, 13);
+            this.lblSource.TabIndex = 16;
+            this.lblSource.Text = "[Source]";
+            this.lblSource.Click += new System.EventHandler(this.lblSource_Click);
+            // 
+            // lblSourceLabel
+            // 
+            this.lblSourceLabel.AutoSize = true;
+            this.lblSourceLabel.Location = new System.Drawing.Point(257, 212);
+            this.lblSourceLabel.Name = "lblSourceLabel";
+            this.lblSourceLabel.Size = new System.Drawing.Size(44, 13);
+            this.lblSourceLabel.TabIndex = 15;
+            this.lblSourceLabel.Tag = "Label_Source";
+            this.lblSourceLabel.Text = "Source:";
+            // 
+            // chkFreeItem
+            // 
+            this.chkFreeItem.AutoSize = true;
+            this.chkFreeItem.Location = new System.Drawing.Point(257, 141);
+            this.chkFreeItem.Name = "chkFreeItem";
+            this.chkFreeItem.Size = new System.Drawing.Size(50, 17);
+            this.chkFreeItem.TabIndex = 11;
+            this.chkFreeItem.Tag = "Checkbox_Free";
+            this.chkFreeItem.Text = "Free!";
+            this.chkFreeItem.UseVisualStyleBackColor = true;
+            this.chkFreeItem.CheckedChanged += new System.EventHandler(this.chkFreeItem_CheckedChanged);
+            // 
+            // nudMarkup
+            // 
+            this.nudMarkup.Location = new System.Drawing.Point(317, 164);
+            this.nudMarkup.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
-			this.nudMarkup.Minimum = new decimal(new int[] {
+            this.nudMarkup.Minimum = new decimal(new int[] {
             99,
             0,
             0,
             -2147483648});
-			this.nudMarkup.Name = "nudMarkup";
-			this.nudMarkup.Size = new System.Drawing.Size(56, 20);
-			this.nudMarkup.TabIndex = 13;
-			this.nudMarkup.ValueChanged += new System.EventHandler(this.nudMarkup_ValueChanged);
-			// 
-			// lblMarkupLabel
-			// 
-			this.lblMarkupLabel.AutoSize = true;
-			this.lblMarkupLabel.Location = new System.Drawing.Point(258, 132);
-			this.lblMarkupLabel.Name = "lblMarkupLabel";
-			this.lblMarkupLabel.Size = new System.Drawing.Size(46, 13);
-			this.lblMarkupLabel.TabIndex = 12;
-			this.lblMarkupLabel.Tag = "Label_SelectGear_Markup";
-			this.lblMarkupLabel.Text = "Markup:";
-			// 
-			// lblMarkupPercentLabel
-			// 
-			this.lblMarkupPercentLabel.AutoSize = true;
-			this.lblMarkupPercentLabel.Location = new System.Drawing.Point(373, 132);
-			this.lblMarkupPercentLabel.Name = "lblMarkupPercentLabel";
-			this.lblMarkupPercentLabel.Size = new System.Drawing.Size(15, 13);
-			this.lblMarkupPercentLabel.TabIndex = 14;
-			this.lblMarkupPercentLabel.Text = "%";
-			// 
-			// lblTest
-			// 
-			this.lblTest.AutoSize = true;
-			this.lblTest.Location = new System.Drawing.Point(424, 58);
-			this.lblTest.Name = "lblTest";
-			this.lblTest.Size = new System.Drawing.Size(19, 13);
-			this.lblTest.TabIndex = 8;
-			this.lblTest.Text = "[0]";
-			// 
-			// lblTestLabel
-			// 
-			this.lblTestLabel.AutoSize = true;
-			this.lblTestLabel.Location = new System.Drawing.Point(373, 58);
-			this.lblTestLabel.Name = "lblTestLabel";
-			this.lblTestLabel.Size = new System.Drawing.Size(31, 13);
-			this.lblTestLabel.TabIndex = 7;
-			this.lblTestLabel.Tag = "Label_Test";
-			this.lblTestLabel.Text = "Test:";
-			// 
-			// tipTooltip
-			// 
-			this.tipTooltip.AutoPopDelay = 10000;
-			this.tipTooltip.InitialDelay = 250;
-			this.tipTooltip.IsBalloon = true;
-			this.tipTooltip.ReshowDelay = 100;
-			this.tipTooltip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
-			this.tipTooltip.ToolTipTitle = "Chummer Help";
-			// 
-			// nudRating
-			// 
-			this.nudRating.Enabled = false;
-			this.nudRating.Location = new System.Drawing.Point(442, 164);
-			this.nudRating.Name = "nudRating";
-			this.nudRating.Size = new System.Drawing.Size(37, 20);
-			this.nudRating.TabIndex = 14;
-			this.nudRating.ValueChanged += new System.EventHandler(this.nudRating_ValueChanged);
-			// 
-			// lblRatingLabel
-			// 
-			this.lblRatingLabel.AutoSize = true;
-			this.lblRatingLabel.Location = new System.Drawing.Point(382, 166);
-			this.lblRatingLabel.Name = "lblRatingLabel";
-			this.lblRatingLabel.Size = new System.Drawing.Size(41, 13);
-			this.lblRatingLabel.TabIndex = 13;
-			this.lblRatingLabel.Tag = "Label_Rating";
-			this.lblRatingLabel.Text = "Rating:";
-			// 
-			// cboMount
-			// 
-			this.cboMount.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboMount.FormattingEnabled = true;
-			this.cboMount.Location = new System.Drawing.Point(312, 32);
-			this.cboMount.Name = "cboMount";
-			this.cboMount.Size = new System.Drawing.Size(131, 21);
-			this.cboMount.TabIndex = 20;
-			// 
-			// chkBlackMarketDiscount
-			// 
-			this.chkBlackMarketDiscount.AutoSize = true;
-			this.chkBlackMarketDiscount.Location = new System.Drawing.Point(318, 107);
-			this.chkBlackMarketDiscount.Name = "chkBlackMarketDiscount";
-			this.chkBlackMarketDiscount.Size = new System.Drawing.Size(163, 17);
-			this.chkBlackMarketDiscount.TabIndex = 39;
-			this.chkBlackMarketDiscount.Tag = "Checkbox_BlackMarketDiscount";
-			this.chkBlackMarketDiscount.Text = "Black Market Discount (10%)";
-			this.chkBlackMarketDiscount.UseVisualStyleBackColor = true;
-			this.chkBlackMarketDiscount.Visible = false;
-			this.chkBlackMarketDiscount.CheckedChanged += new System.EventHandler(this.chkBlackMarketDiscount_CheckedChanged);
-			// 
-			// frmSelectWeaponAccessory
-			// 
-			this.AcceptButton = this.cmdOK;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.cmdCancel;
-			this.ClientSize = new System.Drawing.Size(507, 394);
-			this.Controls.Add(this.chkBlackMarketDiscount);
-			this.Controls.Add(this.cboMount);
-			this.Controls.Add(this.lblTest);
-			this.Controls.Add(this.lblTestLabel);
-			this.Controls.Add(this.nudMarkup);
-			this.Controls.Add(this.lblMarkupLabel);
-			this.Controls.Add(this.lblMarkupPercentLabel);
-			this.Controls.Add(this.chkFreeItem);
-			this.Controls.Add(this.lblSource);
-			this.Controls.Add(this.lblSourceLabel);
-			this.Controls.Add(this.cmdOKAdd);
-			this.Controls.Add(this.lblMountLabel);
-			this.Controls.Add(this.lblCost);
-			this.Controls.Add(this.lblCostLabel);
-			this.Controls.Add(this.lblAvail);
-			this.Controls.Add(this.lblAvailLabel);
-			this.Controls.Add(this.lblRC);
-			this.Controls.Add(this.lblRCLabel);
-			this.Controls.Add(this.nudRating);
-			this.Controls.Add(this.lblRatingLabel);
-			this.Controls.Add(this.cmdCancel);
-			this.Controls.Add(this.cmdOK);
-			this.Controls.Add(this.lstAccessory);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "frmSelectWeaponAccessory";
-			this.ShowInTaskbar = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-			this.Tag = "Title_SelectWeaponAccessory";
-			this.Text = "Select an Accessory";
-			this.Load += new System.EventHandler(this.frmSelectWeaponAccessory_Load);
-			((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.nudRating)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.nudMarkup.Name = "nudMarkup";
+            this.nudMarkup.Size = new System.Drawing.Size(56, 20);
+            this.nudMarkup.TabIndex = 13;
+            this.nudMarkup.ValueChanged += new System.EventHandler(this.nudMarkup_ValueChanged);
+            // 
+            // lblMarkupLabel
+            // 
+            this.lblMarkupLabel.AutoSize = true;
+            this.lblMarkupLabel.Location = new System.Drawing.Point(257, 166);
+            this.lblMarkupLabel.Name = "lblMarkupLabel";
+            this.lblMarkupLabel.Size = new System.Drawing.Size(46, 13);
+            this.lblMarkupLabel.TabIndex = 12;
+            this.lblMarkupLabel.Tag = "Label_SelectGear_Markup";
+            this.lblMarkupLabel.Text = "Markup:";
+            // 
+            // lblMarkupPercentLabel
+            // 
+            this.lblMarkupPercentLabel.AutoSize = true;
+            this.lblMarkupPercentLabel.Location = new System.Drawing.Point(372, 166);
+            this.lblMarkupPercentLabel.Name = "lblMarkupPercentLabel";
+            this.lblMarkupPercentLabel.Size = new System.Drawing.Size(15, 13);
+            this.lblMarkupPercentLabel.TabIndex = 14;
+            this.lblMarkupPercentLabel.Text = "%";
+            // 
+            // lblTest
+            // 
+            this.lblTest.AutoSize = true;
+            this.lblTest.Location = new System.Drawing.Point(423, 92);
+            this.lblTest.Name = "lblTest";
+            this.lblTest.Size = new System.Drawing.Size(19, 13);
+            this.lblTest.TabIndex = 8;
+            this.lblTest.Text = "[0]";
+            // 
+            // lblTestLabel
+            // 
+            this.lblTestLabel.AutoSize = true;
+            this.lblTestLabel.Location = new System.Drawing.Point(372, 92);
+            this.lblTestLabel.Name = "lblTestLabel";
+            this.lblTestLabel.Size = new System.Drawing.Size(31, 13);
+            this.lblTestLabel.TabIndex = 7;
+            this.lblTestLabel.Tag = "Label_Test";
+            this.lblTestLabel.Text = "Test:";
+            // 
+            // tipTooltip
+            // 
+            this.tipTooltip.AutoPopDelay = 10000;
+            this.tipTooltip.InitialDelay = 250;
+            this.tipTooltip.IsBalloon = true;
+            this.tipTooltip.ReshowDelay = 100;
+            this.tipTooltip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
+            this.tipTooltip.ToolTipTitle = "Chummer Help";
+            // 
+            // nudRating
+            // 
+            this.nudRating.Enabled = false;
+            this.nudRating.Location = new System.Drawing.Point(441, 198);
+            this.nudRating.Name = "nudRating";
+            this.nudRating.Size = new System.Drawing.Size(37, 20);
+            this.nudRating.TabIndex = 14;
+            this.nudRating.ValueChanged += new System.EventHandler(this.nudRating_ValueChanged);
+            // 
+            // lblRatingLabel
+            // 
+            this.lblRatingLabel.AutoSize = true;
+            this.lblRatingLabel.Location = new System.Drawing.Point(381, 200);
+            this.lblRatingLabel.Name = "lblRatingLabel";
+            this.lblRatingLabel.Size = new System.Drawing.Size(41, 13);
+            this.lblRatingLabel.TabIndex = 13;
+            this.lblRatingLabel.Tag = "Label_Rating";
+            this.lblRatingLabel.Text = "Rating:";
+            // 
+            // cboMount
+            // 
+            this.cboMount.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboMount.FormattingEnabled = true;
+            this.cboMount.Location = new System.Drawing.Point(331, 32);
+            this.cboMount.Name = "cboMount";
+            this.cboMount.Size = new System.Drawing.Size(131, 21);
+            this.cboMount.TabIndex = 20;
+            this.cboMount.SelectedIndexChanged += new System.EventHandler(this.cboMount_SelectedIndexChanged);
+            // 
+            // chkBlackMarketDiscount
+            // 
+            this.chkBlackMarketDiscount.AutoSize = true;
+            this.chkBlackMarketDiscount.Location = new System.Drawing.Point(317, 141);
+            this.chkBlackMarketDiscount.Name = "chkBlackMarketDiscount";
+            this.chkBlackMarketDiscount.Size = new System.Drawing.Size(163, 17);
+            this.chkBlackMarketDiscount.TabIndex = 39;
+            this.chkBlackMarketDiscount.Tag = "Checkbox_BlackMarketDiscount";
+            this.chkBlackMarketDiscount.Text = "Black Market Discount (10%)";
+            this.chkBlackMarketDiscount.UseVisualStyleBackColor = true;
+            this.chkBlackMarketDiscount.Visible = false;
+            this.chkBlackMarketDiscount.CheckedChanged += new System.EventHandler(this.chkBlackMarketDiscount_CheckedChanged);
+            // 
+            // cboExtraMount
+            // 
+            this.cboExtraMount.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboExtraMount.FormattingEnabled = true;
+            this.cboExtraMount.Location = new System.Drawing.Point(331, 61);
+            this.cboExtraMount.Name = "cboExtraMount";
+            this.cboExtraMount.Size = new System.Drawing.Size(131, 21);
+            this.cboExtraMount.TabIndex = 41;
+            this.cboExtraMount.SelectedIndexChanged += new System.EventHandler(this.cboExtraMount_SelectedIndexChanged);
+            // 
+            // lblExtraMountLabel
+            // 
+            this.lblExtraMountLabel.AutoSize = true;
+            this.lblExtraMountLabel.Location = new System.Drawing.Point(258, 64);
+            this.lblExtraMountLabel.Name = "lblExtraMountLabel";
+            this.lblExtraMountLabel.Size = new System.Drawing.Size(67, 13);
+            this.lblExtraMountLabel.TabIndex = 40;
+            this.lblExtraMountLabel.Tag = "Label_ExtraMount";
+            this.lblExtraMountLabel.Text = "Extra Mount:";
+            // 
+            // frmSelectWeaponAccessory
+            // 
+            this.AcceptButton = this.cmdOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cmdCancel;
+            this.ClientSize = new System.Drawing.Size(507, 394);
+            this.Controls.Add(this.cboExtraMount);
+            this.Controls.Add(this.lblExtraMountLabel);
+            this.Controls.Add(this.chkBlackMarketDiscount);
+            this.Controls.Add(this.cboMount);
+            this.Controls.Add(this.lblTest);
+            this.Controls.Add(this.lblTestLabel);
+            this.Controls.Add(this.nudMarkup);
+            this.Controls.Add(this.lblMarkupLabel);
+            this.Controls.Add(this.lblMarkupPercentLabel);
+            this.Controls.Add(this.chkFreeItem);
+            this.Controls.Add(this.lblSource);
+            this.Controls.Add(this.lblSourceLabel);
+            this.Controls.Add(this.cmdOKAdd);
+            this.Controls.Add(this.lblMountLabel);
+            this.Controls.Add(this.lblCost);
+            this.Controls.Add(this.lblCostLabel);
+            this.Controls.Add(this.lblAvail);
+            this.Controls.Add(this.lblAvailLabel);
+            this.Controls.Add(this.lblRC);
+            this.Controls.Add(this.lblRCLabel);
+            this.Controls.Add(this.nudRating);
+            this.Controls.Add(this.lblRatingLabel);
+            this.Controls.Add(this.cmdCancel);
+            this.Controls.Add(this.cmdOK);
+            this.Controls.Add(this.lstAccessory);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "frmSelectWeaponAccessory";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            this.Tag = "Title_SelectWeaponAccessory";
+            this.Text = "Select an Accessory";
+            this.Load += new System.EventHandler(this.frmSelectWeaponAccessory_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudRating)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -379,5 +403,7 @@
 		private System.Windows.Forms.ToolTip tipTooltip;
 		private System.Windows.Forms.ComboBox cboMount;
 		private System.Windows.Forms.CheckBox chkBlackMarketDiscount;
-	}
+        private System.Windows.Forms.ComboBox cboExtraMount;
+        private System.Windows.Forms.Label lblExtraMountLabel;
+    }
 }

--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
@@ -68,7 +68,14 @@ namespace Chummer
 			// Populate the Accessory list.
 			string[] strAllowed = _strAllowedMounts.Split('/');
 			string strMount = "";
-			foreach (string strAllowedMount in strAllowed)
+            strMount += "(extramount = \"\"";
+            foreach (string strAllowedMount in strAllowed)
+            {
+                if (strAllowedMount != "")
+                    strMount += "or contains(extramount, \"" + strAllowedMount + "\") ";
+            }
+            strMount += ") and";
+            foreach (string strAllowedMount in strAllowed)
 			{
 				if (strAllowedMount != "")
 					strMount += "contains(mount, \"" + strAllowedMount + "\") or ";
@@ -173,9 +180,14 @@ namespace Chummer
 				lblRatingLabel.Visible = false;
 			}
 			List<string> strMounts = new List<string>();
+            string strExtraMount = "";
+            if (objXmlAccessory["extramount"].InnerText != "")
+            {
+                strExtraMount += "+ " + objXmlAccessory["extramount"].InnerText;
+            }
 			foreach (string strItem in (objXmlAccessory["mount"].InnerText.Split('/')))
 			{
-				strMounts.Add(strItem);
+				strMounts.Add(strItem + strExtraMount);
 			}
 			strMounts.Add("None");
 

--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.resx
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.resx
@@ -120,4 +120,7 @@
   <metadata name="tipTooltip.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>45</value>
+  </metadata>
 </root>

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -82,6 +82,7 @@ Data Changes:
 - Defiance EX-Shocker now gives a free "Defiance EX-Shocker Contacts" weapon entry for its melee contacts.
 - Ocular Drone cyberware now gives a free "Ocular Drone" vehicle entry in the vehicle tab.
 - Altered the Smartgun weapon accessories so that they now come pre-included with a Laser Range Finder and a Camera, Micro that takes vision enhancements, instead of the accessory allowing for the addition of vision enhancements.
+- Added a text field to Program Carrier so that its cyberprogram can be specified.
 
 Build 187
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -10,7 +10,14 @@ Application Changes:
 - Fixed an issue with the update mechanism that would prevent the Chummer executable from restarting properly until the application is closed. 
 - Fixed a crash caused by cancelling out of text selection bonus nodes such as when creating a Fake SIN. 
 - Fixed an issue that caused Essence loss in priority creation mode to revert MAG/RES metatype minimums to 1. 
-- Fixed a crash caused by adding a a new knowledge skill after adding the PUSHeD bioware. 
+- Fixed a crash caused by adding a a new knowledge skill after adding the PUSHeD bioware.
+- Added the ability for weapon accesories to occupy multiple slots simultaneously.
+- Fixed a crash when browsing Negative qualities for an Advanced Lifestyle caused by the way Thrifty quality was set up.
+- Recategorized SkillSoft Networks into a new Lifestyle quality category called "Contracts", which can now be taken by Basic Lifestyles too.
+- Renamed the "DocWagon Contracts" Gear category to "Contracts/Upkeep", which now houses every type of advance payment for contracts, 'ware upkeep, and the like.
+- Added the ability for cyberware to add vehicles the same way it can add weapons (e.g. for Ocular Drone).
+- Added the ability for vehicles, vehicle mods, and gear to be hidden from their browsing menus, just like cyberweapons are in the weapons menu.
+- Weapon accesories can now come with gear pre-included.
 
 Data Changes: 
 
@@ -23,6 +30,54 @@ Data Changes:
 - Fixed a missing weapon category for the Huge Weapon Mount. 
 - Fixed a missing damage reduction from the Sawed Off shotgun mod. 
 - Reduced the cost for YNT Softweave to the cost of the Armour rather than double.
+- Changed the Fichetti Security 600 to a Folding Stock.
+- Renamed the old Gecko Grip item to "Gecko Grip (for Weapon without Stock Slot)" and added a new Gecko Grip entry for weapons with a Stock slot that takes up the Stock slot.
+- Corrected the reference to the Vintage quality to GH3 page 3 instead of 53.
+- Corrected Ammo Skip weapon modification to require an Underbarrel slot.
+- Corrected Chameleon Coating weapon modification to require a Side slot.
+- Corrected Electronic Firing weapon modification to require a Barrel slot.
+- Corrected Mounted Crossbow and Underbarrel Laser weapon modifications to take up two weapon modification slots (Top & Underbarrel and Side & Underbarrel respectively).
+- Changed tasers have a concealability of -4. RAW justification includes indirect references to smaller size by Hidden Gun Arm Slide size restrictions, the Reach stat of Defiance EX-Shocker's contacts, and the essence/capacity cost of implanted cybertasers
+- Added a pair of drone arms and drone legs to the Ares Duelyst.
+- Added a pair of drone arms to the Transys Office Maid (fluff text makes reference to arms but not to legs).
+- Added a pair of drone arms and drone legs to the Modified Renraku Manservant-3 and recategorized it to Anthropomorphic, as per the original being a similar model to the Criado Juan.
+- Added a pair of drone arms, a pair of drone legs, and the Snake Fingers cyberware to the Caduceus CAD and recategorized it to Anthropomorphic.
+- Added a pair of synthetic drone arms and a pair of synthetic drone legs to the Mitsuhama Akiyama.
+- Added a pair of drone arms, a pair of drone legs, and all three R1 close combat tutorsofts to the Sparring Drone.
+- Added the following missing categories to the vehicle weapon mounts found in the core rulebook: Blades, Clubs, Exotic Melee Weapons, Crossbows, and Sporting Rifles to Standard Mounts, and Blades, Clubs, Exotic Melee Weapons, Crossbows, and Exotic Ranged Weapons for Heavy Mounts.
+- Removed the Sniper Rifle category from the Standard Weapon Mount found in the core rulebook (it is bigger than an Assault Rifle).
+- Gecko Tips vehicle modification will no longer show up for vehicles with a higher body than 6.
+- Removed the Melee, Machine Pistols, and Submachine Guns categories from the Rigger 5.0 Standard and Heavy Vehicle Weapon Mounts, but added a note to add them back once errata has been released.
+- Corrected Winch (Enhanced) to require 2 body slot mods instead of 1.
+- Added two new items for drone weapon mounts: blow-away panels and pop-out mods. Pop-out mod rating serves as the modified MP of the weapon mount in question.
+- Added entries for the Daihatsu-Caterpillar Horseman ModPods.
+- Added missing Holster to Sleeping Tiger.
+- Added entries to the Contracts lifestyle quality category for monthly payment of DocWagon contracts.
+- Added entries to the Contracts lifestyle quality category and the Contracts/Upkeep gear category for Datahost Subscription (e.g. Library of Alexandria), Shopsoft Network Subscription (e.g. Shoppazulu), and Mapping System Subscription (e.g. Ares' Getting Network) as found in Chrome Flesh.
+- Added entries to the Contracts/Upkeep gear category for pre-paid Skillsoft Network subscriptions.
+- Added the "Shadow Spirits" pre-written specialization to the Magical Threats knowledge skill
+- Added the "Mathematics" academic knowledge skill and populated it with a few specializations, as per Math SPU in Chrome Flesh.
+- Corrected Math SPU to properly give +4 dice pool to the Mathematics knowledge skill and +1 mental limit for scientific and technical knowledge skills.
+- Corrected Limbic Neural Amplifier nanoware to properly give +1 dice pool bonus to all Intuition-linked skills
+- Corrected Neocortical Neural Amplifier nanoware to properly give +1 dice pool bonus to all Logic-linked skills and to give +Rating bonus to mental limit when using those skills instead of +1.
+- Added the Immunization genemod from Chrome Flesh.
+- Added the Phenotypic Variations positive qualities as per the optional rule in Chrome Flesh (can be ignored just like Omegaware/Gammaware).
+- Added entries for commlink and cyberdeck form factor modifications from Data Trails.
+- Stun Dongle commlink accessory now gives a free "Stun Dongle" weapon entry in the weapons tab.
+- Added entries for commlink apps from Data Trails. Since their prices aren't specified, they have customizable pricing from 0 to 50, 50 being the cost of the most expensive entertainment software listed in Run Faster.
+- Corrected the bug where Camera, Micro could not be added to armor.
+- Added an entry for Microphone, Omni-Directional, Micro.
+- Added entries for 1-month Symbiotes Upkeep and 6-month Hard Nanohive Upkeep to the Contracts/Upkeep gear category.
+- Added an entry for the Shiawase Arms Simoom to Specialty Armor (it adds a corresponding entry in the weapons tab).
+- Corrected the bug where Riot Shield and Ballistic Shield would charge players twice (once for the armor, once for the weapon entry that was added with the armor). Riot Shield and Ballistic Shield can no longer be directly added from the weapons tab.
+- Hid all weapons entries for cyberweapons and gear items so that they cannot be mistakenly added for free (the player needs to buy the item through its main tab).
+- Added missing Stock and Side weapon accessory slots to all tasers, light pistols, and heavy pistols, as per HeroLab, as well as a few SMGs and a sniper rifle that was missing these slots.
+- Added missing Top and Underbarrel weapon accessory slots to the Ares Armatus.
+- Added built-in Vision Magnification and Camera, Micro to the Imaging Scope weapon accessory.
+- Feedback Clothing can now be added to armor as an armor mod with a capacity cost of 3, as per Herolab.
+- Defiance EX-Shocker now gives a free "Defiance EX-Shocker Contacts" weapon entry for its melee contacts.
+- Ocular Drone cyberware now gives a free "Ocular Drone" vehicle entry in the vehicle tab.
+- Altered the Smartgun weapon accessories so that they now come pre-included with a Laser Range Finder and a Camera, Micro that takes vision enhancements, instead of the accessory allowing for the addition of vision enhancements.
 
 Build 187
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -13,13 +13,13 @@ Application Changes:
 - Fixed a crash caused by adding a a new knowledge skill after adding the PUSHeD bioware.
 - Fixed a crash when loading the character roster caused by unreadable character files. 
 - Added the ability for qualities to qualify for discounts based on the presence of other qualities. 
-- Added the ability for weapon accesories to occupy multiple slots simultaneously.
+- Added the ability for weapon accessories to occupy multiple slots simultaneously.
 - Fixed a crash when browsing Negative qualities for an Advanced Lifestyle caused by the way Thrifty quality was set up.
 - Recategorized SkillSoft Networks into a new Lifestyle quality category called "Contracts", which can now be taken by Basic Lifestyles too.
 - Renamed the "DocWagon Contracts" Gear category to "Contracts/Upkeep", which now houses every type of advance payment for contracts, 'ware upkeep, and the like.
 - Added the ability for cyberware to add vehicles the same way it can add weapons (e.g. for Ocular Drone).
 - Added the ability for vehicles, vehicle mods, and gear to be hidden from their browsing menus, just like cyberweapons are in the weapons menu.
-- Weapon accesories can now come with gear pre-included.
+- Weapon accessories can now come with gear pre-included.
 
 Data Changes: 
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -41,7 +41,7 @@ Data Changes:
 - Corrected Chameleon Coating weapon modification to require a Side slot.
 - Corrected Electronic Firing weapon modification to require a Barrel slot.
 - Corrected Mounted Crossbow and Underbarrel Laser weapon modifications to take up two weapon modification slots (Top & Underbarrel and Side & Underbarrel respectively).
-- Changed tasers have a concealability of -4. RAW justification includes indirect references to smaller size by Hidden Gun Arm Slide size restrictions, the Reach stat of Defiance EX-Shocker's contacts, and the essence/capacity cost of implanted cybertasers
+- Changed tasers have a concealability of -4. RAW justification includes indirect references to smaller size by Hidden Gun Arm Slide size restrictions, the Reach stat of Defiance EX-Shocker's contacts, and the essence/capacity cost of implanted cybertasers.
 - Added a pair of drone arms and drone legs to the Ares Duelyst.
 - Added a pair of drone arms to the Transys Office Maid (fluff text makes reference to arms but not to legs).
 - Added a pair of drone arms and drone legs to the Modified Renraku Manservant-3 and recategorized it to Anthropomorphic, as per the original being a similar model to the Criado Juan.
@@ -59,10 +59,10 @@ Data Changes:
 - Added entries to the Contracts lifestyle quality category for monthly payment of DocWagon contracts.
 - Added entries to the Contracts lifestyle quality category and the Contracts/Upkeep gear category for Datahost Subscription (e.g. Library of Alexandria), Shopsoft Network Subscription (e.g. Shoppazulu), and Mapping System Subscription (e.g. Ares' Getting Network) as found in Chrome Flesh.
 - Added entries to the Contracts/Upkeep gear category for pre-paid Skillsoft Network subscriptions.
-- Added the "Shadow Spirits" pre-written specialization to the Magical Threats knowledge skill
+- Added the "Shadow Spirits" pre-written specialization to the Magical Threats knowledge skill.
 - Added the "Mathematics" academic knowledge skill and populated it with a few specializations, as per Math SPU in Chrome Flesh.
 - Corrected Math SPU to properly give +4 dice pool to the Mathematics knowledge skill and +1 mental limit for scientific and technical knowledge skills.
-- Corrected Limbic Neural Amplifier nanoware to properly give +1 dice pool bonus to all Intuition-linked skills
+- Corrected Limbic Neural Amplifier nanoware to properly give +1 dice pool bonus to all Intuition-linked skills.
 - Corrected Neocortical Neural Amplifier nanoware to properly give +1 dice pool bonus to all Logic-linked skills and to give +Rating bonus to mental limit when using those skills instead of +1.
 - Added the Immunization genemod from Chrome Flesh.
 - Added the Phenotypic Variations positive qualities as per the optional rule in Chrome Flesh (can be ignored just like Omegaware/Gammaware).

--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -634,6 +634,9 @@
 				<name>Newest Model</name>
 				<name rating="3">Ruthenium Polymer Coating</name>
 			</mods>
+			<gears>
+				<usegear>Holster</usegear>
+			</gears>
 			<source>RG</source>
 			<page>61</page>
 		</armor>

--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -1877,6 +1877,18 @@
 		<!-- End Region -->
 		<!-- Region Hard Targets -->
 		<armor>
+			<id>e3ab6aec-a4ef-4a04-92fe-ffca02ebd92a</id>
+			<name>Shiawase Arms Simoom</name>
+			<category>Specialty Armor</category>
+			<armor>+1</armor>
+			<armorcapacity>0</armorcapacity>
+			<addweapon>Shiawase Arms Simoom</addweapon>
+			<avail>14R</avail>
+			<cost>1500</cost>
+			<source>HT</source>
+			<page>184</page>
+		</armor>
+		<armor>
 			<id>6a50c63e-f6a9-4023-9ee9-d4b13ded6a9e</id>
 			<name>Cloak</name>
 			<category>Cloaks</category>

--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -2464,10 +2464,10 @@
 		<mod>
 			<id>3fdd4706-9052-4c6b-8c2c-61dbb5c1f16f</id>
 			<name>Feedback Clothing</name>
-			<category>Clothing</category>
+			<category>General</category>
 			<armor>0</armor>
 			<maxrating>1</maxrating>
-			<armorcapacity>[0]</armorcapacity>
+			<armorcapacity>[3]</armorcapacity>
 			<avail>8</avail>
 			<cost>500</cost>
 			<source>SR5</source>

--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -2139,6 +2139,20 @@
 			<source>CF</source>
 			<page>158</page>
 		</bioware>
+		<bioware>
+			<id>181f09c2-af17-4676-bb6a-62706c4fc521</id>
+			<name>Immunization</name>
+			<category>Genemods</category>
+			<ess>0.1</ess>
+			<capacity>0</capacity>
+			<avail>8</avail>
+			<cost>20000</cost>
+			<bonus>
+				<selecttext />
+			</bonus>
+			<source>CF</source>
+			<page>164</page>
+		</bioware>
 		<!-- End Region -->
 		<!-- Region Genetic Restoration -->
 		<bioware>

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -408,6 +408,7 @@
 			<ess>0</ess>
 			<capacity>[6]</capacity>
 			<avail>6</avail>
+			<addvehicle>Ocular Drone</addvehicle>
 			<cost>6000</cost>
 			<source>SR5</source>
 			<page>453</page>
@@ -1597,6 +1598,18 @@
 			<capacity>[1]</capacity>
 			<avail>8</avail>
 			<cost>2000</cost>
+			<bonus>
+				<specificskill>
+					<name>Mathematics</name>
+					<bonus>4</bonus>
+					<applytorating>no</applytorating>
+				</specificskill>
+				<limitmodifier>
+					<limit>Mental</limit>
+					<value>1</value>
+					<condition>Only for Scientific or Technical Knowledge Skills</condition>
+				</limitmodifier>
+			</bonus>
 			<source>CF</source>
 			<page>80</page>
 		</cyberware>
@@ -2032,7 +2045,7 @@
 				<limitmodifier>
 					<limit>Physical</limit>
 					<value>1</value>
-					<condition>Only wfor climbing</condition>
+					<condition>Only for climbing</condition>
 				</limitmodifier>
 			</bonus>
 			<source>CF</source>
@@ -3327,10 +3340,14 @@
 			<avail>16F</avail>
 			<cost>Rating * 7500</cost>
 			<bonus>
+				<skillattribute>
+					<name>INT</name>
+					<bonus>1</bonus>
+				</skillattribute>
 				<limitmodifier>
 					<limit>Mental</limit>
 					<value>Rating</value>
-					<condition>Only with Intuition-linked skills</condition>
+					<condition>Only with Intuition-based skills</condition>
 				</limitmodifier>
 			</bonus>
 			<forcegrade>Standard</forcegrade>
@@ -3347,9 +3364,13 @@
 			<avail>16F</avail>
 			<cost>Rating * 7500</cost>
 			<bonus>
+				<skillattribute>
+					<name>LOG</name>
+					<bonus>1</bonus>
+				</skillattribute>
 				<limitmodifier>
 					<limit>Mental</limit>
-					<value>1</value>
+					<value>Rating</value>
 					<condition>Only with Logic-based skills</condition>
 				</limitmodifier>
 			</bonus>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -33,12 +33,12 @@
 		<category>Commlink Accessories</category>
 		<category>Common Programs</category>
 		<category>Communications and Countermeasures</category>
+		<category>Contracts</category>
 		<category>Custom</category>
 		<category>Cyberdeck Modules</category>
 		<category>Cyberdecks</category>
 		<category>Cyberterminals</category>
 		<category>Disguises</category>
-		<category>DocWagon Contract</category>
 		<category>Drugs</category>
 		<category>Electronics Accessories</category>
 		<category>Electronic Modification</category>
@@ -5373,11 +5373,11 @@
 			<page>176</page>
 		</gear>
 		<!-- End Region -->
-		<!-- Region Docwagon Contracts -->
+		<!-- Region Contracts -->
 		<gear>
 			<id>6b28b36a-416a-4041-9561-558083158d7c</id>
-			<name>DocWagon Contract, Basic</name>
-			<category>DocWagon Contract</category>
+			<name>DocWagon Contract, Basic (1 Year Advance Payment)</name>
+			<category>Contracts</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>5000</cost>
@@ -5386,8 +5386,8 @@
 		</gear>
 		<gear>
 			<id>c985f952-df28-4b69-a7b7-b24a291cd651</id>
-			<name>DocWagon Contract, Gold</name>
-			<category>DocWagon Contract</category>
+			<name>DocWagon Contract, Gold (1 Year Advance Payment)</name>
+			<category>Contracts</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>25000</cost>
@@ -5396,8 +5396,8 @@
 		</gear>
 		<gear>
 			<id>aabed898-177f-413b-aeb6-5b862da67c6b</id>
-			<name>DocWagon Contract, Platinum</name>
-			<category>DocWagon Contract</category>
+			<name>DocWagon Contract, Platinum (1 Year Advance Payment)</name>
+			<category>Contracts</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>50000</cost>
@@ -5406,13 +5406,103 @@
 		</gear>
 		<gear>
 			<id>7c8251b6-b195-4c8f-90f0-c036f8a9146f</id>
-			<name>DocWagon Contract, Super-Platinum</name>
-			<category>DocWagon Contract</category>
+			<name>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</name>
+			<category>Contracts</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>100000</cost>
 			<source>SR5</source>
 			<page>450</page>
+		</gear>
+		<gear>
+			<id>c138c8f7-4561-476b-840f-f583afa38c7c</id>
+			<name>Skillsoft Network, Basic (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>2000</cost>
+			<source>CF</source>
+			<page>78</page>
+		</gear>
+		<gear>
+			<id>e94e5c36-57fe-4e59-bd91-fbc85b50d702</id>
+			<name>Skillsoft Network, Silver (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>10000</cost>
+			<source>CF</source>
+			<page>78</page>
+		</gear>
+		<gear>
+			<id>05d57fa9-3415-408a-8084-a40e33153fd0</id>
+			<name>Skillsoft Network, Gold (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>15000</cost>
+			<source>CF</source>
+			<page>78</page>
+		</gear>
+		<gear>
+			<id>13a79eae-ea01-451b-a59a-171a1be1937f</id>
+			<name>Skillsoft Network, Platinum (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>20000</cost>
+			<source>CF</source>
+			<page>78</page>
+		</gear>
+		<gear>
+			<id>02d9dd2f-4a10-4c30-b592-20052089e985</id>
+			<name>Datahost Subscription (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>250</cost>
+			<source>CF</source>
+			<page>80</page>
+		</gear>
+		<gear>
+			<id>a8eba631-78e9-4bd3-9420-5bf550212193</id>
+			<name>Shopsoft Network Subscription (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>250</cost>
+			<source>CF</source>
+			<page>80</page>
+		</gear>
+		<gear>
+			<id>e995f9ee-f3f9-4515-b86e-244e25c79521</id>
+			<name>Mapping System Subscription, Basic (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>50</cost>
+			<source>CF</source>
+			<page>81</page>
+		</gear>
+		<gear>
+			<id>8bb19ef9-9a8b-4d63-b86f-50b7c489ea4f</id>
+			<name>Mapping System Subscription, Silver (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>150</cost>
+			<source>CF</source>
+			<page>81</page>
+		</gear>
+		<gear>
+			<id>03a0f05e-7d07-44cb-b4e7-241e2b172d99</id>
+			<name>Mapping System Subscription, Gold (1 Month Advance Payment)</name>
+			<category>Contracts</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>500</cost>
+			<source>CF</source>
+			<page>81</page>
 		</gear>
 		<!-- End Region -->
 		<!-- Region Foci -->

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -34,7 +34,7 @@
 		<category>Commlink Apps</category>
 		<category>Common Programs</category>
 		<category>Communications and Countermeasures</category>
-		<category>Contracts</category>
+		<category>Contracts/Upkeep</category>
 		<category>Custom</category>
 		<category>Cyberdeck Modules</category>
 		<category>Cyberdecks</category>
@@ -3894,6 +3894,7 @@
 			<name>Camera, Micro</name>
 			<category>Vision Devices</category>
 			<rating>1</rating>
+			<armorcapacity>[1]</armorcapacity>
 			<capacity>1</capacity>
 			<avail>0</avail>
 			<cost>100</cost>
@@ -4132,6 +4133,18 @@
 			<cost>Rating * 50</cost>
 			<source>SR5</source>
 			<page>445</page>
+		</gear>
+		<gear>
+			<id>3ca6be75-6efb-4cf4-809f-da72eb83e909</id>
+			<name>Microphone, Omni-Directional, Micro</name>
+			<category>Audio Devices</category>
+			<armorcapacity>[2]</armorcapacity>
+			<rating>1</rating>
+			<capacity>1</capacity>
+			<avail>4</avail>
+			<cost>50</cost>
+			<source>SR5</source>
+			<page>443</page>
 		</gear>
 		<gear>
 			<id>bedcaf29-5b6e-4135-8589-d8b5a1291afb</id>
@@ -5432,11 +5445,31 @@
 			<page>176</page>
 		</gear>
 		<!-- End Region -->
-		<!-- Region Contracts -->
+		<!-- Region Contracts and Upkeep -->
+		<gear>
+			<id>2f40c4cd-7582-4358-8752-91c9f94f5b6e</id>
+			<name>Symbiotes Upkeep (1 Month Advance Payment)</name>
+			<category>Contracts/Upkeep</category>
+			<rating>4</rating>
+			<avail>0</avail>
+			<cost>Rating * 200</cost>
+			<source>SR5</source>
+			<page>459</page>
+		</gear>
+		<gear>
+			<id>bb20f803-0dc2-49ed-9460-248551cf1961</id>
+			<name>Hard Nanohive Upkeep (6 Months Advance Payment)</name>
+			<category>Contracts/Upkeep</category>
+			<rating>6</rating>
+			<avail>0</avail>
+			<cost>Rating * 500</cost>
+			<source>CF</source>
+			<page>151</page>
+		</gear>
 		<gear>
 			<id>6b28b36a-416a-4041-9561-558083158d7c</id>
 			<name>DocWagon Contract, Basic (1 Year Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>5000</cost>
@@ -5446,7 +5479,7 @@
 		<gear>
 			<id>c985f952-df28-4b69-a7b7-b24a291cd651</id>
 			<name>DocWagon Contract, Gold (1 Year Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>25000</cost>
@@ -5456,7 +5489,7 @@
 		<gear>
 			<id>aabed898-177f-413b-aeb6-5b862da67c6b</id>
 			<name>DocWagon Contract, Platinum (1 Year Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>50000</cost>
@@ -5466,7 +5499,7 @@
 		<gear>
 			<id>7c8251b6-b195-4c8f-90f0-c036f8a9146f</id>
 			<name>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>100000</cost>
@@ -5476,7 +5509,7 @@
 		<gear>
 			<id>c138c8f7-4561-476b-840f-f583afa38c7c</id>
 			<name>Skillsoft Network, Basic (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>2000</cost>
@@ -5486,7 +5519,7 @@
 		<gear>
 			<id>e94e5c36-57fe-4e59-bd91-fbc85b50d702</id>
 			<name>Skillsoft Network, Silver (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>10000</cost>
@@ -5496,7 +5529,7 @@
 		<gear>
 			<id>05d57fa9-3415-408a-8084-a40e33153fd0</id>
 			<name>Skillsoft Network, Gold (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>15000</cost>
@@ -5506,7 +5539,7 @@
 		<gear>
 			<id>13a79eae-ea01-451b-a59a-171a1be1937f</id>
 			<name>Skillsoft Network, Platinum (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>20000</cost>
@@ -5516,7 +5549,7 @@
 		<gear>
 			<id>02d9dd2f-4a10-4c30-b592-20052089e985</id>
 			<name>Datahost Subscription (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>250</cost>
@@ -5526,7 +5559,7 @@
 		<gear>
 			<id>a8eba631-78e9-4bd3-9420-5bf550212193</id>
 			<name>Shopsoft Network Subscription (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>250</cost>
@@ -5536,7 +5569,7 @@
 		<gear>
 			<id>e995f9ee-f3f9-4515-b86e-244e25c79521</id>
 			<name>Mapping System Subscription, Basic (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>50</cost>
@@ -5546,7 +5579,7 @@
 		<gear>
 			<id>8bb19ef9-9a8b-4d63-b86f-50b7c489ea4f</id>
 			<name>Mapping System Subscription, Silver (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>150</cost>
@@ -5556,7 +5589,7 @@
 		<gear>
 			<id>03a0f05e-7d07-44cb-b4e7-241e2b172d99</id>
 			<name>Mapping System Subscription, Gold (1 Month Advance Payment)</name>
-			<category>Contracts</category>
+			<category>Contracts/Upkeep</category>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>500</cost>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -30,6 +30,7 @@
 		<category>BTLs</category>
 		<category>Chemicals</category>
 		<category>Commlinks</category>
+		<category>Commlink/Cyberdeck Form Factors</category>
 		<category>Commlink Accessories</category>
 		<category>Commlink Apps</category>
 		<category>Common Programs</category>
@@ -7880,45 +7881,47 @@
 		<!-- Region Commlink and Cyberdeck Form Factors -->
 		<gear>
 			<id>f4ea77c8-e4d4-46a7-b43d-5193d4e0ea48</id>
-			<name>Form Factor: Non-Standard Commlink</name>
-			<category>Commlinks</category>
+			<name>Commlink Form Factor, Non-Standard</name>
+			<category>Commlink/Cyberdeck Form Factors</category>
 			<rating>0</rating>
-			<devicerating>0</devicerating>
+			<bonus>
+				<selecttext />
+			</bonus>
 			<avail>+2</avail>
-			<cost>Gear Cost * 1.2</cost>
+			<cost>Gear Cost * 0.2</cost>
 			<source>DT</source>
 			<page>61</page>
 		</gear>
 		<gear>
 			<id>d57e91ee-89b6-47ab-86fc-1977b92b79aa</id>
-			<name>Form Factor: Weapon Commlink</name>
-			<category>Commlinks</category>
+			<name>Commlink Form Factor, Weapon</name>
+			<category>Commlink/Cyberdeck Form Factors</category>
 			<rating>0</rating>
-			<devicerating>0</devicerating>
 			<avail>+4R</avail>
-			<cost>Gear Cost * 1.5</cost>
+			<cost>Gear Cost * 0.5</cost>
 			<source>DT</source>
 			<page>61</page>
 		</gear>
 		<gear>
 			<id>01c28047-0446-4f3d-817d-4805317167ce</id>
-			<name>Form Factor: Non-Standard Cyberdeck</name>
-			<category>Cyberdecks</category>
+			<name>Cyberdeck Form Factor, Non-Standard</name>
+			<category>Commlink/Cyberdeck Form Factors</category>
 			<rating>0</rating>
-			<devicerating>0</devicerating>
+			<bonus>
+				<selecttext />
+			</bonus>
 			<avail>+3</avail>
-			<cost>Gear Cost * 1.2</cost>
+			<cost>Gear Cost * 0.2</cost>
 			<source>DT</source>
 			<page>62</page>
 		</gear>
 		<gear>
 			<id>88c4b801-d7e1-4a20-9ddc-97644e15e85f</id>
-			<name>Form Factor: Weapon Cyberdeck</name>
-			<category>Cyberdecks</category>
+			<name>Cyberdeck Form Factor, Weapon</name>
+			<category>Commlink/Cyberdeck Form Factors</category>
 			<rating>0</rating>
-			<devicerating>0</devicerating>
 			<avail>+6R</avail>
-			<cost>Gear Cost * 1.5</cost>
+			<cost>Gear Cost * 0.5</cost>
 			<source>DT</source>
 			<page>62</page>
 		</gear>
@@ -7982,6 +7985,9 @@
 			<armorcapacity>[2]</armorcapacity>
 			<rating>0</rating>
 			<devicerating>0</devicerating>
+			<bonus>
+				<selecttext />
+			</bonus>
 			<avail>2</avail>
 			<cost>900</cost>
 			<source>DT</source>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -31,6 +31,7 @@
 		<category>Chemicals</category>
 		<category>Commlinks</category>
 		<category>Commlink Accessories</category>
+		<category>Commlink Apps</category>
 		<category>Common Programs</category>
 		<category>Communications and Countermeasures</category>
 		<category>Contracts</category>
@@ -2731,6 +2732,64 @@
 			<cost>140000</cost>
 			<source>SR5</source>
 			<page>266</page>
+		</gear>
+		<!-- End Region -->
+		<!-- Region Commlink Apps -->
+		<gear>
+			<id>6731a23a-25cc-4c86-be77-35e90693e837</id>
+			<name>AR Game</name>
+			<category>Commlink Apps</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>Variable(0-50)</cost>
+			<bonus>
+				<selecttext />
+			</bonus>
+			<source>DT</source>
+			<page>55</page>
+		</gear>
+		<gear>
+			<id>09e35306-4850-43f0-b952-188ee097b0d6</id>
+			<name>Diagnostics</name>
+			<category>Commlink Apps</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>Variable(0-50)</cost>
+			<source>DT</source>
+			<page>56</page>
+		</gear>
+		<gear>
+			<id>0f17d835-cb4a-4673-820e-3feab32f0866</id>
+			<name>P2.1</name>
+			<category>Commlink Apps</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>Variable(0-50)</cost>
+			<source>DT</source>
+			<page>56</page>
+		</gear>
+		<gear>
+			<id>f1d72c1e-32f6-48d1-88c9-f916119cbaf8</id>
+			<name>Theme Music</name>
+			<category>Commlink Apps</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>Variable(0-50)</cost>
+			<source>DT</source>
+			<page>56</page>
+		</gear>
+		<gear>
+			<id>e2af5e6b-3c6e-4b57-8093-d2e621a72a4c</id>
+			<name>Ticker</name>
+			<category>Commlink Apps</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>Variable(0-50)</cost>
+			<bonus>
+				<selecttext />
+			</bonus>
+			<source>DT</source>
+			<page>56</page>
 		</gear>
 		<!-- End Region -->
 		<!-- Region Programs -->
@@ -7766,6 +7825,7 @@
 			<armorcapacity>[2]</armorcapacity>
 			<rating>0</rating>
 			<devicerating>0</devicerating>
+			<addweapon>Stun Dongle</addweapon>
 			<avail>6R</avail>
 			<cost>600</cost>
 			<source>DT</source>
@@ -7780,6 +7840,52 @@
 			<devicerating>0</devicerating>
 			<avail>3</avail>
 			<cost>400</cost>
+			<source>DT</source>
+			<page>62</page>
+		</gear>
+		<!-- End Region -->
+		<!-- Region Commlink and Cyberdeck Form Factors -->
+		<gear>
+			<id>f4ea77c8-e4d4-46a7-b43d-5193d4e0ea48</id>
+			<name>Form Factor: Non-Standard Commlink</name>
+			<category>Commlinks</category>
+			<rating>0</rating>
+			<devicerating>0</devicerating>
+			<avail>+2</avail>
+			<cost>Gear Cost * 1.2</cost>
+			<source>DT</source>
+			<page>61</page>
+		</gear>
+		<gear>
+			<id>d57e91ee-89b6-47ab-86fc-1977b92b79aa</id>
+			<name>Form Factor: Weapon Commlink</name>
+			<category>Commlinks</category>
+			<rating>0</rating>
+			<devicerating>0</devicerating>
+			<avail>+4R</avail>
+			<cost>Gear Cost * 1.5</cost>
+			<source>DT</source>
+			<page>61</page>
+		</gear>
+		<gear>
+			<id>01c28047-0446-4f3d-817d-4805317167ce</id>
+			<name>Form Factor: Non-Standard Cyberdeck</name>
+			<category>Cyberdecks</category>
+			<rating>0</rating>
+			<devicerating>0</devicerating>
+			<avail>+3</avail>
+			<cost>Gear Cost * 1.2</cost>
+			<source>DT</source>
+			<page>62</page>
+		</gear>
+		<gear>
+			<id>88c4b801-d7e1-4a20-9ddc-97644e15e85f</id>
+			<name>Form Factor: Weapon Cyberdeck</name>
+			<category>Cyberdecks</category>
+			<rating>0</rating>
+			<devicerating>0</devicerating>
+			<avail>+6R</avail>
+			<cost>Gear Cost * 1.5</cost>
 			<source>DT</source>
 			<page>62</page>
 		</gear>

--- a/Chummer/data/lifestyles.xml
+++ b/Chummer/data/lifestyles.xml
@@ -25,6 +25,7 @@
 		<category>Entertainment - Outing</category>
 		<category>Positive</category>
 		<category>Negative</category>
+		<category>Contracts</category>
 	</categories>
 	<lifestyles>
 		<lifestyle>
@@ -964,6 +965,7 @@
 			<name>One Good Thing About This Place</name>
 			<category>Positive</category>
 			<lp>1</lp>
+			<allowed>Traveler</allowed>
 			<bonus>
 				<selecttext />
 			</bonus>
@@ -1016,13 +1018,9 @@
 			<id>61e7bb21-cb25-44ff-a332-639fe9dac893</id>
 			<name>Thrifty</name>
 			<category>Negative</category>
-      <required>
-        <oneof>
-          <lifestyle>Traveler</lifestyle>
-        </oneof>
-      </required>
+			<allowed>Traveler</allowed>
 			<lp>2</lp>
-      <cost>-1000</cost>
+			<cost>-1000</cost>
 			<source>RF</source>
 			<page>226</page>
 		</quality>
@@ -1038,8 +1036,8 @@
 		<!--Chrome Flesh -->
 		<quality>
 			<id>d4f23b83-d884-47e0-9bbf-7c04341e1894</id>
-			<name>Basic Skillsoft Network</name>
-			<category>Positive</category>
+			<name>Skillsoft Network, Basic</name>
+			<category>Contracts</category>
 			<lp>0</lp>
 			<cost>2000</cost>
 			<source>CF</source>
@@ -1047,8 +1045,8 @@
 		</quality>
 		<quality>
 			<id>5e090a22-119a-4922-ada5-c8d634399797</id>
-			<name>Silver Skillsoft Network</name>
-			<category>Positive</category>
+			<name>Skillsoft Network, Silver</name>
+			<category>Contracts</category>
 			<lp>0</lp>
 			<cost>10000</cost>
 			<source>CF</source>
@@ -1056,8 +1054,8 @@
 		</quality>
 		<quality>
 			<id>fbd64602-f7c5-410f-8ec8-5c5cd7fde945</id>
-			<name>Gold Skillsoft Network</name>
-			<category>Positive</category>
+			<name>Skillsoft Network, Gold</name>
+			<category>Contracts</category>
 			<lp>0</lp>
 			<cost>15000</cost>
 			<source>CF</source>
@@ -1065,13 +1063,96 @@
 		</quality>
 		<quality>
 			<id>1fc363ff-b577-4e5b-b3e7-ae87bbab0fe9</id>
-			<name>Platinum Skillsoft Network</name>
-			<category>Positive</category>
+			<name>Skillsoft Network, Platinum</name>
+			<category>Contracts</category>
 			<lp>0</lp>
 			<cost>20000</cost>
 			<source>CF</source>
 			<page>78</page>
 		</quality>
+		<quality>
+			<id>4d2bac20-5051-4035-8959-2286c0879686</id>
+			<name>Datahost Subscription</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CF</source>
+			<page>80</page>
+		</quality>
+		<quality>
+			<id>5d2d66a4-29b5-4055-859a-9471de62774b</id>
+			<name>Shopsoft Network Subscription</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CF</source>
+			<page>80</page>
+		</quality>
+		<quality>
+			<id>dea3d03c-9441-400c-a512-d8840f6f40d5</id>
+			<name>Mapping System Subscription, Basic</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>50</cost>
+			<source>CF</source>
+			<page>81</page>
+		</quality>
+		<quality>
+			<id>516c286b-b233-43f4-96d0-19e8295f9f88</id>
+			<name>Mapping System Subscription, Silver</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>150</cost>
+			<source>CF</source>
+			<page>81</page>
+		</quality>
+		<quality>
+			<id>53b8cea1-aa63-4e12-8a04-b7ba72aa1cbe</id>
+			<name>Mapping System Subscription, Gold</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>500</cost>
+			<source>CF</source>
+			<page>81</page>
+		</quality>
+		<!-- Region Docwagon Contracts -->
+		<quality>
+			<id>4f41448a-7d44-4a5f-a99a-e2cc1e2cc2b1</id>
+			<name>DocWagon Contract, Basic</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>417</cost>
+			<source>SR5</source>
+			<page>450</page>
+		</quality>
+		<quality>
+			<id>4f2d39cd-fbc7-4d02-a3eb-f8decdb9a415</id>
+			<name>DocWagon Contract, Gold</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>2084</cost>
+			<source>SR5</source>
+			<page>450</page>
+		</quality>
+		<quality>
+			<id>26476ddb-52f6-4c31-b1f0-949d0ef95495</id>
+			<name>DocWagon Contract, Platinum</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>4167</cost>
+			<source>SR5</source>
+			<page>450</page>
+		</quality>
+		<quality>
+			<id>0a58f493-a12e-4c08-b8b8-baac4c5e6591</id>
+			<name>DocWagon Contract, Super-Platinum</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>8334</cost>
+			<source>SR5</source>
+			<page>450</page>
+		</quality>
+		<!-- End Region -->
 		<!-- Hard Targets -->
 		<quality>
 			<name>Local Grid Subscription</name>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -11137,6 +11137,90 @@
 			<source>CF</source>
 			<page>56</page>
 		</quality>
+		<!-- End Region -->
+		<!--Region Chrome Flesh Phenotype Adjustments as Positive Qualities -->
+		<quality>
+			<id>0d5e6819-ac41-4700-ac7d-58fa957b328c</id>
+			<name>Phenotypic Variation - Genewipe</name>
+			<karma>32</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>157</page>
+		</quality>
+		<quality>
+			<id>13edde6a-f920-4665-9e65-53a20b30c2a3</id>
+			<name>Phenotypic Variation - Masque</name>
+			<karma>23</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>157</page>
+		</quality>
+		<quality>
+			<id>eac42e74-2f7b-418d-bd38-c1cdd56ceec4</id>
+			<name>Phenotypic Variation - Reprint</name>
+			<karma>18</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>157</page>
+		</quality>
+		<quality>
+			<id>f0bd7ebc-8b59-4586-b83a-d884540a7651</id>
+			<name>Phenotypic Variation - Shuffle</name>
+			<karma>13</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>157</page>
+		</quality>
+		<quality>
+			<id>9d4dd549-3bce-450d-be6e-8bfaf35d49b1</id>
+			<name>Phenotypic Variation - Genetic Optimization</name>
+			<karma>27</karma>
+			<category>Positive</category>
+			<bonus>
+				<selectattribute>
+					<excludeattribute>EDG</excludeattribute>
+					<excludeattribute>MAG</excludeattribute>
+					<excludeattribute>RES</excludeattribute>
+					<excludeattribute>DEP</excludeattribute>
+					<max>1</max>
+				</selectattribute>
+			</bonus>
+			<source>CF</source>
+			<page>157</page>
+		</quality>
+		<quality>
+			<id>e89ddeca-1de4-410e-916f-205aeaee6ea2</id>
+			<name>Phenotypic Variation - Cosmetic Alteration</name>
+			<karma>21</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>158</page>
+		</quality>
+		<quality>
+			<id>b17b895e-6819-4609-91e6-9ce42d0446a9</id>
+			<name>Phenotypic Variation - Print Removal</name>
+			<karma>12</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>158</page>
+		</quality>
+		<quality>
+			<id>89564979-72ca-4e73-9923-0ce088da0227</id>
+			<name>Phenotypic Variation - Metaposeur</name>
+			<karma>22</karma>
+			<category>Positive</category>
+			<bonus />
+			<source>CF</source>
+			<page>158</page>
+		</quality>
+		<!-- End Region -->
+		<!--Region Chrome Flesh Negative Qualities -->
 		<quality>
 			<id>b9afa9de-39c0-4e49-8271-f76910352ec2</id>
 			<name>Antipathy</name>
@@ -11146,8 +11230,6 @@
 			<source>CF</source>
 			<page>57</page>
 		</quality>
-		<!-- End Region -->
-		<!--Region Chrome Flesh Negative Qualities -->
 		<quality>
 			<id>b8f8799f-b89b-462e-9e8c-e47cdd965587</id>
 			<name>AIPS</name>

--- a/Chummer/data/skills.xml
+++ b/Chummer/data/skills.xml
@@ -2174,7 +2174,7 @@
         <spec>Adepts</spec>
         <spec>Shamans</spec>
         <spec>Mages</spec>
-        <spec>Magic Adepts</spec>
+        <spec>Mystic Adepts</spec>
       </specs>
     </skill>
     <skill>
@@ -2206,6 +2206,7 @@
         <spec>Blood Magic</spec>
         <spec>Toxic Magic</spec>
         <spec>Insect Spirits</spec>
+		<spec>Shadow Spirits</spec>
       </specs>
     </skill>
     <skill>
@@ -2220,6 +2221,26 @@
         <spec>Speak</spec>
         <spec>Dialect</spec>
         <spec>Lingo</spec>
+      </specs>
+    </skill>
+	<skill>
+      <id>9843709f-803a-4424-88a2-d972d3405955</id>
+      <name>Mathematics</name>
+      <attribute>LOG</attribute>
+      <category>Academic</category>
+      <default>No</default>
+      <skillgroup />
+      <specs>
+		<spec>Arithmetic</spec>
+		<spec>Calculus</spec>
+		<spec>Geometry</spec>
+		<spec>Algebra</spec>
+		<spec>Number Theory</spec>
+        <spec>Game Theory</spec>
+        <spec>Graph Theory</spec>
+        <spec>Group Theory</spec>
+		<spec>Combinatorics</spec>
+		<spec>Statistics</spec>
       </specs>
     </skill>
     <skill>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -5093,6 +5093,27 @@
 			<page>465</page>
 		</vehicle>
 		<vehicle>
+			<id>715a8171-8167-4391-8d33-f7d50217efec</id>
+			<name>Ocular Drone</name>
+			<category>Drones: Mini</category>
+			<hidden />
+			<handling>4</handling>
+			<accel>2</accel>
+			<speed>3</speed>
+			<pilot>3</pilot>
+			<body>1</body>
+			<armor>0</armor>
+			<seats>0</seats>
+			<sensor>3</sensor>
+			<gears>
+				<gear rating="3" maxrating="3">Sensor Array</gear>
+			</gears>
+			<avail>8</avail>
+			<cost>0</cost>
+			<source>SR5</source>
+			<page>453</page>
+		</vehicle>
+		<vehicle>
 			<id>d187e9f7-b308-426f-ac35-957ba601c70c</id>
 			<name>MCT Fly-Spy (Minidrone)</name>
 			<category>Drones: Mini</category>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -5195,6 +5195,10 @@
 				<gear rating="3" maxrating="6">Sensor Array</gear>
 			</gears>
 			<mods>
+				<name>Drone Arm</name>
+				<name>Drone Arm</name>
+				<name>Drone Leg</name>
+				<name>Drone Leg</name>
 				<name rating="1">Realistic Features</name>
 				<name>Weapon Mount</name>
 				<name>Weapon Mount</name>
@@ -5247,6 +5251,10 @@
 			<gears>
 				<gear rating="2" maxrating="4">Sensor Array</gear>
 			</gears>
+			<mods>
+				<name>Drone Arm</name>
+				<name>Drone Arm</name>
+			</mods>
 			<avail>4</avail>
 			<cost>8000</cost>
 			<source>SS</source>
@@ -5363,7 +5371,7 @@
 		<vehicle>
 			<id>0e8d9c3c-83c0-4c1d-96f0-1f2a2e0bf354</id>
 			<name>Modified Renraku Manservant-3 (Large)</name>
-			<category>Drones: Large</category>
+			<category>Drones: Anthro</category>
 			<handling>2</handling>
 			<accel>2</accel>
 			<speed>2</speed>
@@ -5375,6 +5383,12 @@
 			<gears>
 				<gear rating="2" maxrating="5">Sensor Array</gear>
 			</gears>
+			<mods>
+				<name>Drone Arm</name>
+				<name>Drone Arm</name>
+				<name>Drone Leg</name>
+				<name>Drone Leg</name>
+			</mods>
 			<avail>14F</avail>
 			<cost>9000</cost>
 			<source>SS</source>
@@ -5418,6 +5432,9 @@
 			<gears>
 				<gear rating="3" maxrating="5">Sensor Array</gear>
 			</gears>
+			<mods>
+				<name>Dustoff Armored Valkyrie Module</name>
+			</mods>
 			<avail>10R</avail>
 			<cost>12000</cost>
 			<source>BB</source>
@@ -5426,7 +5443,7 @@
 		<vehicle>
 			<id>d186dbc2-52e6-4804-94ca-7db96c2afdde</id>
 			<name>Shiawase Caduceus 'CAD' 7 (Medium)</name>
-			<category>Drones: Medium</category>
+			<category>Drones: Anthro</category>
 			<handling>4</handling>
 			<accel>1</accel>
 			<speed>2</speed>
@@ -5438,6 +5455,17 @@
 			<gears>
 				<gear rating="2" maxrating="4">Sensor Array</gear>
 			</gears>
+			<mods>
+				<name>Drone Arm</name>
+				<name>Drone Arm</name>
+				<name>Drone Leg</name>
+				<name>Drone Leg</name>
+			</mods>
+			<cyberwares>
+				<cyberware>
+					<name>Snake Fingers</name>
+				</cyberware>
+			</cyberwares>
 			<avail>12R</avail>
 			<cost>16500</cost>
 			<source>BB</source>
@@ -5527,6 +5555,12 @@
 			<gears>
 				<gear rating="3" maxrating="4">Sensor Array</gear>
 			</gears>
+			<mods>
+				<name>Synthetic Drone Arm</name>
+				<name>Synthetic Drone Arm</name>
+				<name>Synthetic Drone Leg</name>
+				<name>Synthetic Drone Leg</name>
+			</mods>
 			<avail>24F</avail>
 			<cost>200000</cost>
 			<source>HT</source>
@@ -5546,7 +5580,16 @@
 			<sensor>3</sensor>
 			<gears>
 				<gear rating="3" maxrating="4">Sensor Array</gear>
+				<gear rating="1" select="Blades">Tutorsoft</gear>
+				<gear rating="1" select="Clubs">Tutorsoft</gear>
+				<gear rating="1" select="Unarmed Combat">Tutorsoft</gear>
 			</gears>
+			<mods>
+				<name>Drone Arm</name>
+				<name>Drone Arm</name>
+				<name>Drone Leg</name>
+				<name>Drone Leg</name>
+			</mods>
 			<avail>6</avail>
 			<cost>5000</cost>
 			<source>HT</source>
@@ -5580,7 +5623,7 @@
 			<category>Vehicle Weapon Mount</category>
 			<rating>0</rating>
 			<slots>0</slots>
-			<weaponmountcategories>Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons</weaponmountcategories>
+			<weaponmountcategories>Blades,Clubs,Exotic Melee Weapons,Crossbows,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Sporting Rifles</weaponmountcategories>
 			<avail>8F</avail>
 			<cost>2500</cost>
 			<source>SR5</source>
@@ -5592,7 +5635,7 @@
 			<category>Vehicle Weapon Mount</category>
 			<rating>0</rating>
 			<slots>0</slots>
-			<weaponmountcategories>Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Shotguns,Machine Guns,Cannons,Grenade Launchers,Missile Launchers,Laser Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Flamethrowers,Sporting Rifles</weaponmountcategories>
+			<weaponmountcategories>Blades,Clubs,Exotic Melee Weapons,Crossbows,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Grenade Launchers,Missile Launchers,Laser Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Flamethrowers,Sporting Rifles,Exotic Ranged Weapons</weaponmountcategories>
 			<avail>14F</avail>
 			<cost>5000</cost>
 			<source>SR5</source>
@@ -5764,6 +5807,17 @@
 			<page>?</page>
 		</mod>
 		<mod>
+			<id>bdfd51e8-ac56-42b3-8b3e-a067608a21b3</id>
+			<name>Dustoff Armored Valkyrie Module</name>
+			<category>Body</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>0</cost>
+			<source>BB</source>
+			<page>23</page>
+		</mod>
+		<mod>
 			<id>6ac249ee-84c0-498f-9377-149ccbc2f959</id>
 			<name>Acceleration Enhancement</name>
 			<category>Powertrain</category>
@@ -5801,6 +5855,7 @@
 			<cost>5000</cost>
 			<required>
 				<bodymin>4</bodymin>
+				<bodymax>6</bodymax>
 			</required>
 			<source>R5</source>
 			<page>154</page>
@@ -6363,6 +6418,7 @@
 			<category>Weapons</category>
 			<rating>0</rating>
 			<slots>2</slots>
+			<!-- TODO: Add Melee, Machine Pistols, and Submachine Guns as soon as Errata comes out -->
 			<weaponmountcategories>Tasers,Holdouts,Light Pistols,Heavy Pistols,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons</weaponmountcategories>
 			<avail>8F</avail>
 			<cost>1500</cost>
@@ -6375,7 +6431,8 @@
 			<category>Weapons</category>
 			<rating>0</rating>
 			<slots>4</slots>
-			<weaponmountcategories>Melee,Machine Pistols,Submachine Guns,Tasers,Holdouts,Light Pistols,Heavy Pistols,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Missile Launchers,Lasers</weaponmountcategories>
+			<!-- TODO: Add Melee, Machine Pistols, and Submachine Guns as soon as Errata comes out -->
+			<weaponmountcategories>Tasers,Holdouts,Light Pistols,Heavy Pistols,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Missile Launchers,Lasers</weaponmountcategories>
 			<avail>10F</avail>
 			<cost>4000</cost>
 			<source>R5</source>
@@ -6529,6 +6586,9 @@
 			<name>Increased Seating</name>
 			<category>Body</category>
 			<rating>0</rating>
+			<bonus>
+				<seats>+Seats * 0.5</seats>
+			</bonus>
 			<slots>2</slots>
 			<avail>4</avail>
 			<cost>2000</cost>
@@ -6642,7 +6702,7 @@
 			<name>Winch (Enhanced)</name>
 			<category>Body</category>
 			<rating>0</rating>
-			<slots>1</slots>
+			<slots>2</slots>
 			<avail>8</avail>
 			<cost>4000</cost>
 			<source>R5</source>
@@ -7023,6 +7083,30 @@
 			<page>124</page>
 		</mod>
 		<mod>
+			<id>45d84d77-5461-4441-a529-527aba347334</id>
+			<name>Blow-Away Panel Weapon Mount Add-on (Drone)</name>
+			<category>All</category>
+			<optionaldrone/>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>25</cost>
+			<source>R5</source>
+			<page>124</page>
+		</mod>
+		<mod>
+			<id>dd03dc64-64e1-49a7-8836-d932cd4cb95b</id>
+			<name>Pop-Out Weapon Mount Add-on (Drone)</name>
+			<category>All</category>
+			<optionaldrone/>
+			<rating>7</rating>
+			<slots>1</slots>
+			<avail>0</avail>
+			<cost>Rating * 100</cost>
+			<source>R5</source>
+			<page>124</page>
+		</mod>
+		<mod>
 			<id>b5b9cd7e-dbb3-42e9-abcd-f805f6a4b10e</id>
 			<name>Realistic Features (Drone)</name>
 			<category>All</category>
@@ -7089,6 +7173,7 @@
 			<optionaldrone/>
 			<rating>0</rating>
 			<subsystems>
+				<subsystem>Bodyware</subsystem>
 				<subsystem>Cyberlimb Enhancement</subsystem>
 				<subsystem>Cyberlimb Accessory</subsystem>
 				<subsystem>Cyber Implant Weapon</subsystem>
@@ -7106,6 +7191,7 @@
 			<optionaldrone/>
 			<rating>0</rating>
 			<subsystems>
+				<subsystem>Bodyware</subsystem>
 				<subsystem>Cyberlimb Enhancement</subsystem>
 				<subsystem>Cyberlimb Accessory</subsystem>
 				<subsystem>Cyber Implant Weapon</subsystem>
@@ -7123,6 +7209,7 @@
 			<optionaldrone/>
 			<rating>0</rating>
 			<subsystems>
+				<subsystem>Bodyware</subsystem>
 				<subsystem>Cyberlimb Enhancement</subsystem>
 				<subsystem>Cyberlimb Accessory</subsystem>
 				<subsystem>Cyber Implant Weapon</subsystem>
@@ -7140,6 +7227,7 @@
 			<optionaldrone/>
 			<rating>0</rating>
 			<subsystems>
+				<subsystem>Bodyware</subsystem>
 				<subsystem>Cyberlimb Enhancement</subsystem>
 				<subsystem>Cyberlimb Accessory</subsystem>
 				<subsystem>Cyber Implant Weapon</subsystem>
@@ -7157,6 +7245,7 @@
 			<optionaldrone/>
 			<rating>0</rating>
 			<subsystems>
+				<subsystem>Bodyware</subsystem>
 				<subsystem>Cyberlimb Enhancement</subsystem>
 				<subsystem>Cyberlimb Accessory</subsystem>
 				<subsystem>Cyber Implant Weapon</subsystem>
@@ -7410,6 +7499,89 @@
 			<cost>Vehicle Cost * 0.05</cost>
 			<source>RF</source>
 			<page>157</page>
+		</mod>
+		<mod>
+			<id>9ab00bed-d955-4ade-b875-b6964517c137</id>
+			<name>Daihatsu-Caterpillar Horseman Passenger Pod</name>
+			<category>All</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>6000</cost>
+			<bonus>
+				<speed>-1</speed>
+				<accel>-1</accel>
+				<handling>-1</handling>
+				<seats>+1</seats>
+			</bonus>
+			<source>R5</source>
+			<page>42</page>
+		</mod>
+		<mod>
+			<id>5bb7fb2d-e657-4fb8-9f26-cf1f15854fbc</id>
+			<name>Daihatsu-Caterpillar Horseman Cargo Pod</name>
+			<category>All</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>6000</cost>
+			<bonus>
+				<speed>-1</speed>
+				<accel>-1</accel>
+				<handling>-1</handling>
+			</bonus>
+			<source>R5</source>
+			<page>42</page>
+		</mod>
+		<mod>
+			<id>e6e9ff78-b7f4-4fe4-969b-af1cb77c5c1b</id>
+			<name>Daihatsu-Caterpillar Horseman Advanced Cargo Pod</name>
+			<category>All</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>5000</cost>
+			<bonus>
+				<speed>-1</speed>
+				<accel>-1</accel>
+				<handling>-1</handling>
+			</bonus>
+			<source>R5</source>
+			<page>42</page>
+		</mod>
+		<mod>
+			<id>b7052288-0255-4f41-9827-8398c914542c</id>
+			<name>Daihatsu-Caterpillar Horseman Drone Pod</name>
+			<category>All</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>4000</cost>
+			<bonus>
+				<speed>-1</speed>
+				<accel>-1</accel>
+				<handling>-1</handling>
+			</bonus>
+			<source>R5</source>
+			<page>42</page>
+		</mod>
+		<mod>
+			<id>0be26038-6118-41d0-9f62-6fb831568e52</id>
+			<name>Daihatsu-Caterpillar Horseman Security Pod</name>
+			<category>All</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<!-- TODO: Add Melee, Machine Pistols, and Submachine Guns as soon as Errata comes out for weapon mount -->
+			<weaponmountcategories>Tasers,Holdouts,Light Pistols,Heavy Pistols,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons</weaponmountcategories>
+			<avail>0</avail>
+			<cost>5500</cost>
+			<bonus>
+				<speed>-1</speed>
+				<accel>-1</accel>
+				<handling>-1</handling>
+			</bonus>
+			<source>R5</source>
+			<page>42</page>
 		</mod>
 	</mods>
 </chummer>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -1612,6 +1612,27 @@
 			<page>422</page>
 		</weapon>
 		<weapon>
+			<id>b4b3a872-1532-4477-9bf3-76db34dc7bbf</id>
+			<name>Stun Dongle</name>
+			<category>Clubs</category>
+			<type>Melee</type>
+			<hide>yes</hide>
+			<conceal>-4</conceal>
+			<accuracy>4</accuracy>
+			<reach>0</reach>
+			<damage>8S(e)</damage>
+			<ap>-5</ap>
+			<mode>0</mode>
+			<rc>0</rc>
+			<ammo>3</ammo>
+			<requireammo>false</requireammo>
+			<avail>6R</avail>
+			<cost>0</cost>
+			<allowaccessory>true</allowaccessory>
+			<source>DT</source>
+			<page>62</page>
+		</weapon>
+		<weapon>
 			<id>a20f44a1-ced0-4018-9522-8a0e7234c29d</id>
 			<name>Aquadyne Shark-XS Harpoon Gun</name>
 			<category>Crossbows</category>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -1021,6 +1021,7 @@
 			<id>5ec246dc-c129-4e61-a27a-c4d82b223bea</id>
 			<name>Hand Blade</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>-2</conceal>
 			<spec>Cyber Implants</spec>
@@ -1043,6 +1044,7 @@
 			<id>16fe95d3-9c66-4ac6-b4e3-562de5e5619e</id>
 			<name>Hand Razors</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>-2</conceal>
 			<spec>Cyber Implants</spec>
@@ -1164,6 +1166,7 @@
 			<id>fe835c72-a973-4976-bf5f-751aff1371d4</id>
 			<name>Spurs</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<spec>Cyber Implants</spec>
@@ -1776,6 +1779,7 @@
 			<id>a47e8191-869a-456e-b376-ed04ba7a59f0</id>
 			<name>Ballistic Shield</name>
 			<category>Exotic Melee Weapons</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>8</conceal>
 			<spec>Shields</spec>
@@ -1787,7 +1791,7 @@
 			<rc>0</rc>
 			<ammo>0</ammo>
 			<avail>12R</avail>
-			<cost>1200</cost>
+			<cost>0</cost>
 			<allowaccessory>true</allowaccessory>
 			<source>SR5</source>
 			<page>438</page>
@@ -1916,6 +1920,7 @@
 			<id>e66ab7ea-3408-4a3b-9ab9-7bc26a8e8a6e</id>
 			<name>Riot Shield</name>
 			<category>Exotic Melee Weapons</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>8</conceal>
 			<spec>Shields</spec>
@@ -1927,7 +1932,7 @@
 			<rc>0</rc>
 			<ammo>0</ammo>
 			<avail>10R</avail>
-			<cost>1500</cost>
+			<cost>0</cost>
 			<allowaccessory>true</allowaccessory>
 			<source>SR5</source>
 			<page>438</page>
@@ -2050,6 +2055,7 @@
 			<id>9c267b03-103e-43f4-bfe8-986c69dc17d2</id>
 			<name>Grapple Gun</name>
 			<category>Exotic Ranged Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<spec>Grapple Gun</spec>
@@ -2071,6 +2077,7 @@
 			<id>87a94632-b229-44b7-a150-9808388cfa20</id>
 			<name>Hold-Fast Sprayer</name>
 			<category>Exotic Ranged Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<spec>Sprayer</spec>
@@ -2092,6 +2099,7 @@
 			<id>fac9d052-4f7d-43cd-a649-8703b4c0b9c2</id>
 			<name>Micro Flare Launcher</name>
 			<category>Exotic Ranged Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>-2</conceal>
 			<spec>Flare Launcher</spec>
@@ -2845,6 +2853,7 @@
 			<id>5fe3a884-8213-4fe3-a538-750eba3bda27</id>
 			<name>Cyber Microgrenade Launcher</name>
 			<category>Grenade Launchers</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>8</conceal>
 			<accuracy>4</accuracy>
@@ -2997,6 +3006,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -3026,6 +3037,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -3055,6 +3068,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -3084,6 +3099,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>RG</source>
 			<page>32</page>
@@ -3108,6 +3125,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>GH3</source>
 			<page>6</page>
@@ -3132,6 +3151,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>426</page>
@@ -3140,6 +3161,7 @@
 			<id>158224db-e409-407f-b2f0-4617886ad80f</id>
 			<name>Heavy Cyber Pistol</name>
 			<category>Heavy Pistols</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>0</conceal>
 			<spec>Semi-Automatics</spec>
@@ -3182,6 +3204,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -3217,6 +3241,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>RG</source>
 			<page>32</page>
@@ -3241,6 +3267,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>426</page>
@@ -3265,6 +3293,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>427</page>
@@ -3289,6 +3319,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -3302,6 +3334,7 @@
 			<id>c87b03f7-403d-4db9-987a-022ab525b4be</id>
 			<name>Cyber Hold-Out</name>
 			<category>Holdouts</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>-4</conceal>
 			<spec>Semi-Automatics</spec>
@@ -3872,6 +3905,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>425</page>
@@ -3896,6 +3931,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -3928,6 +3965,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Stock</name></accessory>
@@ -3956,6 +3995,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<range>Tasers</range>
 			<source>GH3</source>
@@ -3981,6 +4022,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>425</page>
@@ -4005,6 +4048,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>GH3</source>
 			<page>4</page>
@@ -4029,6 +4074,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>RG</source>
 			<page>30</page>
@@ -4053,6 +4100,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -4068,6 +4117,7 @@
 			<id>261165ce-6111-4a51-9519-46c41edac9b0</id>
 			<name>Light Cyber Pistol</name>
 			<category>Light Pistols</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>-2</conceal>
 			<spec>Semi-Automatics</spec>
@@ -4110,6 +4160,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -4140,6 +4192,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>RG</source>
 			<page>31</page>
@@ -4165,6 +4219,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -4275,6 +4331,7 @@
 			<id>496e4b81-8437-41fb-adf5-2e4709df656e</id>
 			<name>Cyber Machine Pistol</name>
 			<category>Machine Pistols</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>0</conceal>
 			<spec>Semi-Automatics</spec>
@@ -4756,6 +4813,7 @@
 			<id>97cab27f-620b-45d7-8da4-3136c1e69f2b</id>
 			<name>Cyber Shotgun</name>
 			<category>Shotguns</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<accuracy>4</accuracy>
@@ -5331,6 +5389,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Imaging Scope</name></accessory>
@@ -5462,6 +5522,8 @@
 			<accessorymounts>
 				<mount>Top</mount>
 				<mount>Under</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Light Pistols</range>
@@ -5487,6 +5549,8 @@
 			<accessorymounts>
 				<mount>Top</mount>
 				<mount>Under</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Shotguns</range>
@@ -5552,7 +5616,10 @@
 			<cost>2000</cost>
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
-				<mount>top</mount>
+				<mount>Top</mount>
+				<mount>Barrel</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Heavy Pistols</range>
@@ -5578,6 +5645,8 @@
 			<accessorymounts>
 				<mount>Top</mount>
 				<mount>Under</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Submachine Guns</range>
@@ -5665,6 +5734,8 @@
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Heavy Pistols</range>
@@ -5690,6 +5761,8 @@
 			<accessorymounts>
 				<mount>Top</mount>
 				<mount>Under</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Sniper Rifles</range>
@@ -6077,6 +6150,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Folding Stock</name></accessory>
@@ -6171,6 +6246,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Folding Stock</name></accessory>
@@ -6184,6 +6261,7 @@
 			<id>95295a59-46b3-4cc0-8a1d-ac869cf9912c</id>
 			<name>Cyber Submachine Gun</name>
 			<category>Submachine Guns</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>2</conceal>
 			<accuracy>4</accuracy>
@@ -6222,6 +6300,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Stock</name></accessory>
@@ -6249,6 +6329,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Folding Stock</name></accessory>
@@ -6277,6 +6359,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Smartgun System, Internal</name></accessory>
@@ -6304,6 +6388,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Smartgun System, Internal</name></accessory>
@@ -6359,6 +6445,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Folding Stock</name></accessory>
@@ -6386,6 +6474,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Folding Stock</name></accessory>
@@ -6412,6 +6502,8 @@
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Laser Sight</name></accessory>
@@ -6440,6 +6532,8 @@
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>424</page>
@@ -6480,6 +6574,8 @@
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory><name>Laser Sight</name></accessory>
@@ -6506,6 +6602,8 @@
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SR5</source>
 			<page>425</page>
@@ -6554,6 +6652,7 @@
 			<id>fec4a4f8-4432-4bdc-b3b9-83c032d71d63</id>
 			<name>Shock Hand</name>
 			<category>Unarmed</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<spec>Cyber Implants</spec>
@@ -6595,6 +6694,7 @@
 			<id>ae58f859-37ee-4fac-befa-365acd3c7da7</id>
 			<name>AK-98 Grenade Launcher</name>
 			<category>Underbarrel Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<accuracy>3</accuracy>
@@ -6625,6 +6725,7 @@
 			<id>e9bea546-f35d-4ecc-9d15-8b30df9bdb28</id>
 			<name>Ares Alpha Grenade Launcher</name>
 			<category>Underbarrel Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<accuracy>6</accuracy>
@@ -6657,6 +6758,7 @@
 			<id>74e0b1e5-2449-4075-9b0d-eb0d8383033b</id>
 			<name>HK XM30 Grenade Launcher</name>
 			<category>Underbarrel Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<spec>Grenade Launchers</spec>
@@ -6693,6 +6795,7 @@
 			<id>232dfc49-21ad-4b90-b05f-e5523b3ee142</id>
 			<name>Nissan Optiumum II Shotgun</name>
 			<category>Underbarrel Weapons</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>6</conceal>
 			<spec>Shotguns</spec>
@@ -6746,6 +6849,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>SASS</source>
 			<page>31</page>
@@ -7074,7 +7179,7 @@
 			<id>0b43e7a8-892d-403a-a0e2-0d015556b1af</id>
 			<name>Oral Slasher</name>
 			<category>Cyberweapon</category>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>-4</conceal>
 			<accuracy>Physical</accuracy>
@@ -7097,7 +7202,7 @@
 			<name>Flametosser</name>
 			<category>Flamethrowers</category>
 			<type>Ranged</type>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<conceal>2</conceal>
 			<accuracy>4</accuracy>
 			<reach>0</reach>
@@ -7120,7 +7225,7 @@
 			<name>Cyberfangs</name>
 			<category>Cyberweapon</category>
 			<type>Melee</type>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<conceal>-4</conceal>
 			<accuracy>Physical-2</accuracy>
 			<reach>0</reach>
@@ -7142,7 +7247,7 @@
 			<name>Extreme Cyberimplant</name>
 			<category>Cyberweapon</category>
 			<type>Melee</type>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
 			<reach>0</reach>
@@ -7164,7 +7269,7 @@
 			<name>Junkyard Jaw</name>
 			<category>Cyberweapon</category>
 			<type>Melee</type>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
 			<reach>0</reach>
@@ -7187,7 +7292,7 @@
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Claws (Bio-Weapon)</name>
 			<category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
@@ -7208,7 +7313,7 @@
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Retractable Claws (Bio-Weapon)</name>
 			<category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
@@ -7229,7 +7334,7 @@
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Electrical Discharge</name>
 			<category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
@@ -7249,8 +7354,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Fangs (Bio-Weapon)</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>3</accuracy>
@@ -7291,8 +7396,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Horns (Bio-Weapon)</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>4</accuracy>
@@ -7312,8 +7417,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Large Stinger</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
@@ -7333,8 +7438,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Medium Stinger</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical</accuracy>
@@ -7354,8 +7459,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Horns (Bio-Weapon)</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>4</accuracy>
@@ -7375,8 +7480,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Medium Tusk(s)</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>4</accuracy>
@@ -7396,8 +7501,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Large Tusk(s)</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>4</accuracy>
@@ -7417,8 +7522,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Raptor Foot</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<accuracy>Physical-1</accuracy>
@@ -7438,8 +7543,8 @@
 		<weapon>
 			<id>458A2ECB-725D-414B-B033-23C18C62E61B</id>
 			<name>Grapple Fist</name>
-      <category>Bio-Weapon</category>
-      <hide>yes</hide>
+			<category>Bio-Weapon</category>
+			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>0</conceal>
 			<spec>Grapple Gun</spec>
@@ -7531,6 +7636,7 @@
 			<id>d036885b-4238-4ed7-ae9d-5dba97071e19</id>
 			<name>Foot Blade</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<spec>Cyber Implants</spec>
@@ -7553,6 +7659,7 @@
 			<id>7b928bc3-c44e-4002-b8ac-17a2bdd01d5a</id>
 			<name>Bone Spike I</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<spec>Cyber Implants</spec>
@@ -7575,6 +7682,7 @@
 			<id>2ef46f42-8890-48fd-bb94-67c34c12f0fb</id>
 			<name>Bone Spike II</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<spec>Cyber Implants</spec>
@@ -7597,6 +7705,7 @@
 			<id>3babb9d3-a3bb-4c8f-96ce-73f27b6ec7a6</id>
 			<name>Bone Spike III</name>
 			<category>Blades</category>
+			<hide>yes</hide>
 			<type>Melee</type>
 			<conceal>0</conceal>
 			<spec>Cyber Implants</spec>
@@ -7716,6 +7825,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<source>HT</source>
 			<page>178</page>
@@ -7742,6 +7853,28 @@
 			<page>184</page>
 		</weapon>
 		<weapon>
+			<id>82aa8d25-179a-4c21-9a3c-61a171705f65</id>
+			<name>Shiawase Arms Simoom</name>
+			<category>Exotic Ranged Weapons</category>
+			<hide>yes</hide>
+			<type>Ranged</type>
+			<conceal>-4</conceal>
+			<accuracy>5</accuracy>
+			<reach>0</reach>
+			<damage>6P</damage>
+			<ap>0</ap>
+			<mode>SA/FA</mode>
+			<rc>0</rc>
+			<ammo>6(ml)</ammo>
+			<avail>14R</avail>
+			<cost>0</cost>
+			<allowaccessory>true</allowaccessory>
+			<useskill>Exotic Ranged Weapon</useskill>
+			<range>Light Pistols</range>
+			<source>HT</source>
+			<page>184</page>
+		</weapon>
+		<weapon>
 			<id>176ab92a-0c00-48fe-a994-668903407fbf</id>
 			<name>Ares Armatus</name>
 			<category>Exotic Ranged Weapons</category>
@@ -7757,6 +7890,10 @@
 			<avail>20F</avail>
 			<cost>19000</cost>
 			<allowaccessory>true</allowaccessory>
+			<accessorymounts>
+				<mount>Top</mount>
+				<mount>Under</mount>
+			</accessorymounts>
 			<useskill>Exotic Ranged Weapon</useskill>
 			<range>Shotgun</range>
 			<source>HT</source>
@@ -7802,6 +7939,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -7834,6 +7973,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -7956,6 +8097,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>
@@ -8173,6 +8316,8 @@
 			<accessorymounts>
 				<mount>Barrel</mount>
 				<mount>Top</mount>
+				<mount>Stock</mount>
+				<mount>Side</mount>
 			</accessorymounts>
 			<accessories>
 				<accessory>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -8545,7 +8545,7 @@
 			<avail>+2R</avail>
 			<cost>Weapon Cost</cost>
 			<gears>
-				<usegear rating="2">Laser Range Finder</usegear>
+				<usegear>Laser Range Finder</usegear>
 				<usegear>Camera, Micro</usegear>
 			</gears>
 			<source>SR5</source>
@@ -8560,7 +8560,7 @@
 			<avail>4R</avail>
 			<cost>200</cost>
 			<gears>
-				<usegear rating="2">Laser Range Finder</usegear>
+				<usegear>Laser Range Finder</usegear>
 				<usegear>Camera, Micro</usegear>
 			</gears>
 			<source>SR5</source>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -8452,6 +8452,10 @@
 			<rating>0</rating>
 			<avail>2</avail>
 			<cost>300</cost>
+			<gears>
+				<usegear>Camera, Micro</usegear>
+				<usegear>Vision Magnification</usegear>
+			</gears>
 			<allowgear>
 				<gearcategory>Vision Enhancements</gearcategory>
 			</allowgear>
@@ -8540,10 +8544,10 @@
 			<rating>0</rating>
 			<avail>+2R</avail>
 			<cost>Weapon Cost</cost>
-			<allowgear>
-				<gearcategory>Peripherals</gearcategory>
-				<gearcategory>Vision Enhancements</gearcategory>
-			</allowgear>
+			<gears>
+				<usegear rating="2">Laser Range Finder</usegear>
+				<usegear>Camera, Micro</usegear>
+			</gears>
 			<source>SR5</source>
 			<page>433</page>
 		</accessory>
@@ -8555,10 +8559,10 @@
 			<rating>0</rating>
 			<avail>4R</avail>
 			<cost>200</cost>
-			<allowgear>
-				<gearcategory>Peripherals</gearcategory>
-				<gearcategory>Vision Enhancements</gearcategory>
-			</allowgear>
+			<gears>
+				<usegear rating="2">Laser Range Finder</usegear>
+				<usegear>Camera, Micro</usegear>
+			</gears>
 			<source>SR5</source>
 			<page>433</page>
 		</accessory>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -4035,7 +4035,7 @@
 			</accessorymounts>
 			<accessories>
 				<accessory>
-					<name>Stock</name>
+					<name>Folding Stock</name>
 			</accessory>
 				<accessory>
 					<name>Laser Sight</name></accessory>
@@ -6378,7 +6378,7 @@
 			<name>Cavalier Safeguard</name>
 			<category>Tasers</category>
 			<type>Ranged</type>
-			<conceal>0</conceal>
+			<conceal>-2</conceal>
 			<accuracy>5</accuracy>
 			<reach>0</reach>
 			<damage>6S(e)</damage>
@@ -6403,7 +6403,7 @@
 			<name>Defiance EX Shocker</name>
 			<category>Tasers</category>
 			<type>Ranged</type>
-			<conceal>0</conceal>
+			<conceal>-2</conceal>
 			<accuracy>4</accuracy>
 			<reach>0</reach>
 			<damage>9S(e)</damage>
@@ -6413,6 +6413,9 @@
 			<ammo>4(m)</ammo>
 			<avail>0</avail>
 			<cost>250</cost>
+			<underbarrels>
+				<underbarrel>Defiance EX Shocker Contacts</underbarrel>
+			</underbarrels>
 			<allowaccessory>true</allowaccessory>
 			<accessorymounts>
 				<mount>Top</mount>
@@ -6421,11 +6424,29 @@
 			<page>424</page>
 		</weapon>
 		<weapon>
+			<id>3b12990b-afcb-4e0c-943d-ee215ffcfde1</id>
+			<name>Defiance EX Shocker (Melee Contacts)</name>
+			<category>Clubs</category>
+			<hide>yes</hide>
+			<type>Melee</type>
+			<conceal>-2</conceal>
+			<accuracy>3</accuracy>
+			<reach>0</reach>
+			<damage>8S(e)</damage>
+			<ap>-5</ap>
+			<mode>0</mode>
+			<rc>0</rc>
+			<ammo>10</ammo>
+			<requireammo>false</requireammo>
+			<source>SR5</source>
+			<page>424</page>
+		</weapon>
+		<weapon>
 			<id>3540d227-3288-410f-aa11-5048179ab322</id>
 			<name>Tiffani-Defiance Protector</name>
 			<category>Tasers</category>
 			<type>Ranged</type>
-			<conceal>0</conceal>
+			<conceal>-2</conceal>
 			<accuracy>5</accuracy>
 			<reach>0</reach>
 			<damage>7S(e)</damage>
@@ -6451,7 +6472,7 @@
 			<name>Yamaha Pulsar</name>
 			<category>Tasers</category>
 			<type>Ranged</type>
-			<conceal>0</conceal>
+			<conceal>-2</conceal>
 			<accuracy>5</accuracy>
 			<reach>0</reach>
 			<damage>7S(e)</damage>
@@ -8604,8 +8625,18 @@
 		</accessory>
 		<accessory>
 			<id>627f212a-ac15-4739-afbc-f44676dfe508</id>
-			<name>Gecko Grip</name>
+			<name>Gecko Grip (for Weapon with No Stock Slot)</name>
 			<mount/>
+			<rating>0</rating>
+			<avail>6</avail>
+			<cost>100</cost>
+			<source>RG</source>
+			<page>52</page>
+		</accessory>
+		<accessory>
+			<id>bf18c385-77bf-4f45-a51c-c17fd702526f</id>
+			<name>Gecko Grip (for Weapon with Stock Slot)</name>
+			<mount>Stock</mount>
 			<rating>0</rating>
 			<avail>6</avail>
 			<cost>100</cost>
@@ -8845,7 +8876,7 @@
 			<avail>0</avail>
 			<cost>0</cost>
 			<source>GH3</source>
-			<page>53</page>
+			<page>3</page>
 		</accessory>
 		<!-- End Region -->
 		<!-- Region Chrome Flesh -->
@@ -8864,7 +8895,7 @@
 		<accessory>
 			<id>0c315fd8-3a1a-4748-8359-cb6a04436fbd</id>
 			<name>Ammo Skip</name>
-			<mount />
+			<mount>Under</mount>
 			<rating>0</rating>
 			<avail>8R</avail>
 			<cost>250</cost>
@@ -8907,7 +8938,7 @@
 		<accessory>
 			<id>5cc39a55-3973-4368-81ee-c7a5c0432323</id>
 			<name>Chameleon Coating (Pistol)</name>
-			<mount />
+			<mount>Side</mount>
 			<rating>0</rating>
 			<conceal>-2</conceal>
 			<avail>10R</avail>
@@ -8918,7 +8949,7 @@
 		<accessory>
 			<id>98c9ed33-2636-40bb-a455-334e8fb8e65f</id>
 			<name>Chameleon Coating (Rifle)</name>
-			<mount />
+			<mount>Side</mount>
 			<rating>0</rating>
 			<conceal>-1</conceal>
 			<avail>10R</avail>
@@ -8982,7 +9013,7 @@
 		<accessory>
 			<id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id>
 			<name>Electronic Firing</name>
-			<mount />
+			<mount>Barrel</mount>
 			<rc>1</rc>
 			<rating>0</rating>
 			<avail>10R</avail>
@@ -8994,6 +9025,7 @@
 			<id>a2e4fcc6-cc21-4fc8-bbdf-efb489e9c377</id>
 			<name>Mounted Crossbow</name>
 			<mount>Under</mount>
+			<extramount>Barrel</extramount>
 			<rating>0</rating>
 			<avail>8R</avail>
 			<cost>1000</cost>
@@ -9004,6 +9036,7 @@
 			<id>b83d5f60-7be2-4991-a518-775f6ae49207</id>
 			<name>Underbarrel Laser</name>
 			<mount>Under</mount>
+			<extramount>Side</extramount>
 			<rating>0</rating>
 			<avail>16F</avail>
 			<cost>22000</cost>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -9024,8 +9024,8 @@
 		<accessory>
 			<id>a2e4fcc6-cc21-4fc8-bbdf-efb489e9c377</id>
 			<name>Mounted Crossbow</name>
-			<mount>Under</mount>
-			<extramount>Barrel</extramount>
+			<mount>Under/Barrel</mount>
+			<extramount>Under/Barrel</extramount>
 			<rating>0</rating>
 			<avail>8R</avail>
 			<cost>1000</cost>
@@ -9035,8 +9035,8 @@
 		<accessory>
 			<id>b83d5f60-7be2-4991-a518-775f6ae49207</id>
 			<name>Underbarrel Laser</name>
-			<mount>Under</mount>
-			<extramount>Side</extramount>
+			<mount>Under/Side</mount>
+			<extramount>Under/Side</extramount>
 			<rating>0</rating>
 			<avail>16F</avail>
 			<cost>22000</cost>

--- a/Chummer/data/weapons.xsd
+++ b/Chummer/data/weapons.xsd
@@ -109,6 +109,7 @@
 					<xs:element name="ammoslots" type="xs:string" minOccurs="0" maxOccurs="1" />
 					<xs:element name="ammoreplace" type="xs:string" minOccurs="0" maxOccurs="1" />
                     <xs:element name="mount" type="xs:string" minOccurs="1" maxOccurs="1" />
+					<xs:element name="extramount" type="xs:string" minOccurs="0" maxOccurs="1" />
 					<xs:element name="damage" type="xs:string" minOccurs="0" maxOccurs="1" />
 					<xs:element name="damagetype" type="xs:string" minOccurs="0" maxOccurs="1" />
 					<xs:element name="rcdeployable" type="xs:string" minOccurs="0" maxOccurs="1" />

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -5252,7 +5252,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			Weapon objWeapon = new Weapon(_objCharacter);
-			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory);
+			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear);
 			objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
 
 			int intCost = objWeapon.TotalCost;
@@ -5625,7 +5625,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			Vehicle objVehicle = new Vehicle(_objCharacter);
-			objVehicle.Create(objXmlVehicle, objNode, cmsVehicle, cmsVehicleGear, cmsVehicleWeapon, cmsVehicleWeaponAccessory);
+			objVehicle.Create(objXmlVehicle, objNode, cmsVehicle, cmsVehicleGear, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear);
 			// Update the Used Vehicle information if applicable.
 			if (frmPickVehicle.UsedVehicle)
 			{
@@ -8876,7 +8876,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			WeaponAccessory objAccessory = new WeaponAccessory(_objCharacter);
-			objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount, Convert.ToInt32(frmPickWeaponAccessory.SelectedRating));
+			objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount, Convert.ToInt32(frmPickWeaponAccessory.SelectedRating), cmsWeaponAccessoryGear);
 			objAccessory.Parent = objWeapon;
 
             if (objAccessory.Cost.StartsWith("Variable"))
@@ -9320,7 +9320,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			Weapon objWeapon = new Weapon(_objCharacter);
-			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory);
+			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsVehicleWeapon, cmsVehicleWeaponAccessory, cmsVehicleWeaponAccessoryGear);
 			objWeapon.VehicleMounted = true;
 
 			int intCost = objWeapon.TotalCost;
@@ -9446,7 +9446,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			WeaponAccessory objAccessory = new WeaponAccessory(_objCharacter);
-			objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount, Convert.ToInt32(frmPickWeaponAccessory.SelectedRating));
+			objAccessory.Create(objXmlWeapon, objNode, frmPickWeaponAccessory.SelectedMount, Convert.ToInt32(frmPickWeaponAccessory.SelectedRating), cmsWeaponAccessoryGear);
 			objAccessory.Parent = objWeapon;
 
 			// Check the item's Cost and make sure the character can afford it.
@@ -9535,7 +9535,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			Weapon objWeapon = new Weapon(_objCharacter);
-			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory);
+			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear);
 			objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
 			objWeapon.VehicleMounted = true;
 			objWeapon.IsUnderbarrelWeapon = true;
@@ -11807,7 +11807,7 @@ namespace Chummer
 
 			TreeNode objNode = new TreeNode();
 			Weapon objWeapon = new Weapon(_objCharacter);
-			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory);
+			objWeapon.Create(objXmlWeapon, _objCharacter, objNode, cmsWeapon, cmsWeaponAccessory, cmsWeaponAccessoryGear);
 			objWeapon.DiscountCost = frmPickWeapon.BlackMarketDiscount;
 			objWeapon.IsUnderbarrelWeapon = true;
 

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -8818,11 +8818,12 @@ namespace Chummer
 					bool blnFound = false;
 					foreach (WeaponAccessory objMod in objWeapon.WeaponAccessories)
 					{
-						if (objMod.Mount == objXmlMount.InnerText)
-						{
-							blnFound = true;
+                        if ((objMod.Mount == objXmlMount.InnerText) || (objMod.ExtraMount == objXmlMount.InnerText))
+                        {
+                            blnFound = true;
+                            break;
                         }
-					}
+                    }
 					if (!blnFound)
 					{
 						strMounts += objXmlMount.InnerText + "/";
@@ -9394,9 +9395,12 @@ namespace Chummer
 					bool blnFound = false;
 					foreach (WeaponAccessory objCurrentAccessory in objWeapon.WeaponAccessories)
 					{
-						if (objCurrentAccessory.Mount == objXmlMount.InnerText)
-							blnFound = true;
-					}
+                        if ((objCurrentAccessory.Mount == objXmlMount.InnerText) || (objCurrentAccessory.ExtraMount == objXmlMount.InnerText))
+                        {
+                            blnFound = true;
+                            break;
+                        }
+                    }
 					if (!blnFound)
 						strMounts += objXmlMount.InnerText + "/";
 				}
@@ -22036,8 +22040,28 @@ namespace Chummer
 						// Remove the trailing /
 						if (strMount != "" && strMount.Contains('/'))
 							strMount = strMount.Substring(0, strMount.Length - 1);
+                        if ((objSelectedAccessory.ExtraMount != "") && (objSelectedAccessory.ExtraMount != "None"))
+                        {
+                            bool boolHaveAddedItem = false;
+                            string[] strExtraMounts = objSelectedAccessory.ExtraMount.Split('/');
+                            foreach (string strCurrentExtraMount in strExtraMounts)
+                            {
+                                if (strCurrentExtraMount != "")
+                                {
+                                    if (!boolHaveAddedItem)
+                                    {
+                                        strMount += " + ";
+                                        boolHaveAddedItem = true;
+                                    }
+                                    strMount += LanguageManager.Instance.GetString("String_Mount" + strCurrentExtraMount) + "/";
+                                }
+                            }
+                            // Remove the trailing /
+                            if (boolHaveAddedItem)
+                                strMount = strMount.Substring(0, strMount.Length - 1);
+                        }
 
-						lblWeaponSlots.Text = strMount;
+                        lblWeaponSlots.Text = strMount;
 						string strBook = _objOptions.LanguageBookShort(objSelectedAccessory.Source);
 						string strPage = objSelectedAccessory.Page;
 						lblWeaponSource.Text = strBook + " " + strPage;
@@ -24577,8 +24601,28 @@ namespace Chummer
 						// Remove the trailing /
 						if (strMount != "" && strMount.Contains('/'))
 							strMount = strMount.Substring(0, strMount.Length - 1);
+                        if ((objAccessory.ExtraMount != "") && (objAccessory.ExtraMount != "None"))
+                        {
+                            bool boolHaveAddedItem = false;
+                            string[] strExtraMounts = objAccessory.ExtraMount.Split('/');
+                            foreach (string strCurrentExtraMount in strExtraMounts)
+                            {
+                                if (strCurrentExtraMount != "")
+                                {
+                                    if (!boolHaveAddedItem)
+                                    {
+                                        strMount += " + ";
+                                        boolHaveAddedItem = true;
+                                    }
+                                    strMount += LanguageManager.Instance.GetString("String_Mount" + strCurrentExtraMount) + "/";
+                                }
+                            }
+                            // Remove the trailing /
+                            if (boolHaveAddedItem)
+                                strMount = strMount.Substring(0, strMount.Length - 1);
+                        }
 
-						lblVehicleSlots.Text = strMount;
+                        lblVehicleSlots.Text = strMount;
 						string strBook = _objOptions.LanguageBookShort(objAccessory.Source);
 						string strPage = objAccessory.Page;
 						lblVehicleSource.Text = strBook + " " + strPage;
@@ -24770,8 +24814,28 @@ namespace Chummer
 					// Remove the trailing /
 					if (strMount != "" && strMount.Contains('/'))
 						strMount = strMount.Substring(0, strMount.Length - 1);
+                    if ((objAccessory.ExtraMount != "") && (objAccessory.ExtraMount != "None"))
+                    {
+                        bool boolHaveAddedItem = false;
+                        string[] strExtraMounts = objAccessory.ExtraMount.Split('/');
+                        foreach (string strCurrentExtraMount in strExtraMounts)
+                        {
+                            if (strCurrentExtraMount != "")
+                            {
+                                if (!boolHaveAddedItem)
+                                {
+                                    strMount += " + ";
+                                    boolHaveAddedItem = true;
+                                }
+                                strMount += LanguageManager.Instance.GetString("String_Mount" + strCurrentExtraMount) + "/";
+                            }
+                        }
+                        // Remove the trailing /
+                        if (boolHaveAddedItem)
+                            strMount = strMount.Substring(0, strMount.Length - 1);
+                    }
 
-					lblVehicleSlots.Text = strMount;
+                    lblVehicleSlots.Text = strMount;
 					string strBook = _objOptions.LanguageBookShort(objAccessory.Source);
 					string strPage = objAccessory.Page;
 					lblVehicleSource.Text = strBook + " " + strPage;

--- a/Chummer/frmCreatePACKSKit.cs
+++ b/Chummer/frmCreatePACKSKit.cs
@@ -536,8 +536,9 @@ namespace Chummer
 									objWriter.WriteStartElement("accessory");
 									objWriter.WriteElementString("name", objAccessory.Name);
 									objWriter.WriteElementString("mount", objAccessory.Mount);
+                                    objWriter.WriteElementString("extramount", objAccessory.ExtraMount);
 
-									if (objAccessory.Gear.Count > 0)
+                                    if (objAccessory.Gear.Count > 0)
 										WriteGear(objWriter, objAccessory.Gear);
 
 									// </accessory>
@@ -642,8 +643,9 @@ namespace Chummer
 											objWriter.WriteStartElement("accessory");
 											objWriter.WriteElementString("name", objAccessory.Name);
 											objWriter.WriteElementString("mount", objAccessory.Mount);
-											// </accessory>
-											objWriter.WriteEndElement();
+                                            objWriter.WriteElementString("extramount", objAccessory.ExtraMount);
+                                            // </accessory>
+                                            objWriter.WriteEndElement();
 										}
 									}
 									// </accessories>

--- a/Chummer/frmTest.cs
+++ b/Chummer/frmTest.cs
@@ -296,7 +296,7 @@ namespace Chummer
 				{
 					TreeNode objTempNode = new TreeNode();
 					WeaponAccessory objTemp = new WeaponAccessory(objCharacter);
-					objTemp.Create(objXmlGear, objTempNode, "", 0);
+					objTemp.Create(objXmlGear, objTempNode, new string[] { "" , "" }, 0);
 					try
 					{
 						int objValue = objTemp.TotalCost;

--- a/Chummer/frmTest.cs
+++ b/Chummer/frmTest.cs
@@ -518,7 +518,9 @@ namespace Chummer
 					Cyberware objTemp = new Cyberware(objCharacter);
 					List<Weapon> lstWeapons = new List<Weapon>();
 					List<TreeNode> lstNodes = new List<TreeNode>();
-					objTemp.Create(objXmlGear, objCharacter, GlobalOptions.CyberwareGrades.GetGrade("Standard"), objSource, 1, objTempNode, lstWeapons, lstNodes);
+                    List<Vehicle> objVehicles = new List<Vehicle>();
+                    List<TreeNode> objVehicleNodes = new List<TreeNode>();
+                    objTemp.Create(objXmlGear, objCharacter, GlobalOptions.CyberwareGrades.GetGrade("Standard"), objSource, 1, objTempNode, lstWeapons, lstNodes, objVehicles, objVehicleNodes);
 					try
 					{
 						int objValue = objTemp.TotalCost;

--- a/Chummer/frmTest.cs
+++ b/Chummer/frmTest.cs
@@ -296,7 +296,7 @@ namespace Chummer
 				{
 					TreeNode objTempNode = new TreeNode();
 					WeaponAccessory objTemp = new WeaponAccessory(objCharacter);
-					objTemp.Create(objXmlGear, objTempNode, new string[] { "" , "" }, 0);
+					objTemp.Create(objXmlGear, objTempNode, new string[] { "" , "" }, 0, null);
 					try
 					{
 						int objValue = objTemp.TotalCost;

--- a/Chummer/lang/de.xml
+++ b/Chummer/lang/de.xml
@@ -237,6 +237,10 @@
       <key>Label_Mount</key>
       <text>Halterung:</text>
     </string>
+	<string>
+      <key>Label_ExtraMount</key>
+      <text>Extra Halterung:</text>
+    </string>
     <string>
       <key>Label_DataFile</key>
       <text>Datei:</text>

--- a/Chummer/lang/de_data.xml
+++ b/Chummer/lang/de_data.xml
@@ -6443,7 +6443,7 @@
 			<category translate="Audioverstärkung">Audio Enhancements</category>
 			<category translate="Biotech" translated="True">Biotech</category>
 			<category translate="Kommlink-Zubehör">Commlink Accessories</category>
-			<category translate="Verträge">Contracts</category>
+			<category translate="Verträge/Unterhalt">Contracts/Upkeep</category>
 			<category translate="Drogen">Drugs</category>
 			<category translate="Sprengstoffe">Explosives</category>
 			<category translate="Foki">Foci</category>

--- a/Chummer/lang/de_data.xml
+++ b/Chummer/lang/de_data.xml
@@ -6443,7 +6443,7 @@
 			<category translate="Audioverstärkung">Audio Enhancements</category>
 			<category translate="Biotech" translated="True">Biotech</category>
 			<category translate="Kommlink-Zubehör">Commlink Accessories</category>
-			<category translate="DocWagon-Vertrag">DocWagon Contract</category>
+			<category translate="Verträge">Contracts</category>
 			<category translate="Drogen">Drugs</category>
 			<category translate="Sprengstoffe">Explosives</category>
 			<category translate="Foki">Foci</category>
@@ -8706,26 +8706,26 @@
 			</gear>
 			<gear translated="True">
 				<id>6b28b36a-416a-4041-9561-558083158d7c</id>
-				<name>DocWagon Contract, Basic</name>
-				<translate>DocWagon-Vertrag, Standard</translate>
+				<name>DocWagon Contract, Basic (1 Year Advance Payment)</name>
+				<translate>DocWagon-Vertrag, Standard (Einjährige Vorleistung)</translate>
 				<page>454</page>
 			</gear>
 			<gear translated="True">
 				<id>c985f952-df28-4b69-a7b7-b24a291cd651</id>
-				<name>DocWagon Contract, Gold</name>
-				<translate>DocWagon-Vertrag, Gold</translate>
+				<name>DocWagon Contract, Gold (1 Year Advance Payment)</name>
+				<translate>DocWagon-Vertrag, Gold (Einjährige Vorleistung)</translate>
 				<page>454</page>
 			</gear>
 			<gear translated="True">
 				<id>aabed898-177f-413b-aeb6-5b862da67c6b</id>
-				<name>DocWagon Contract, Platinum</name>
-				<translate>DocWagon-Vertrag, Platin</translate>
+				<name>DocWagon Contract, Platinum (1 Year Advance Payment)</name>
+				<translate>DocWagon-Vertrag, Platin (Einjährige Vorleistung)</translate>
 				<page>454</page>
 			</gear>
 			<gear translated="True">
 				<id>7c8251b6-b195-4c8f-90f0-c036f8a9146f</id>
-				<name>DocWagon Contract, Super-Platinum</name>
-				<translate>DocWagon-Vertrag, Superplatin</translate>
+				<name>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</name>
+				<translate>DocWagon-Vertrag, Superplatin (Einjährige Vorleistung)</translate>
 				<page>454</page>
 			</gear>
 			<gear translated="True">
@@ -9573,6 +9573,30 @@
 				<name>Dangerous Area</name>
 				<translate>gefährliche Gegend</translate>
 				<page>374</page>
+			</quality>
+			<quality translated="True">
+				<id>6b28b36a-416a-4041-9561-558083158d7c</id>
+				<name>DocWagon Contract, Basic</name>
+				<translate>DocWagon-Vertrag, Standard</translate>
+				<page>454</page>
+			</quality>
+			<quality translated="True">
+				<id>c985f952-df28-4b69-a7b7-b24a291cd651</id>
+				<name>DocWagon Contract, Gold</name>
+				<translate>DocWagon-Vertrag, Gold</translate>
+				<page>454</page>
+			</quality>
+			<quality translated="True">
+				<id>aabed898-177f-413b-aeb6-5b862da67c6b</id>
+				<name>DocWagon Contract, Platinum</name>
+				<translate>DocWagon-Vertrag, Platin</translate>
+				<page>454</page>
+			</quality>
+			<quality translated="True">
+				<id>7c8251b6-b195-4c8f-90f0-c036f8a9146f</id>
+				<name>DocWagon Contract, Super-Platinum</name>
+				<translate>DocWagon-Vertrag, Superplatin</translate>
+				<page>454</page>
 			</quality>
 		</qualities>
 	</chummer>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -583,6 +583,10 @@
 			<text>Mount:</text>
 		</string>
 		<string>
+			<key>Label_ExtraMount</key>
+			<text>Extra Mount:</text>
+		</string>
+		<string>
 			<key>Label_DataFile</key>
 			<text>Data File:</text>
 		</string>

--- a/Chummer/lang/en-us2.xml
+++ b/Chummer/lang/en-us2.xml
@@ -359,6 +359,10 @@
 			<text>Mount:</text>
 		</string>
 		<string>
+			<key>Label_ExtraMount</key>
+			<text>Extra Mount:</text>
+		</string>
+		<string>
 			<key>Label_DataFile</key>
 			<text>Data File:</text>
 		</string>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -250,6 +250,10 @@
       <key>Label_Mount</key>
       <text>Monture :</text>
     </string>
+	<string>
+      <key>Label_Mount</key>
+      <text>Monture Extra :</text>
+    </string>
     <string>
       <key>Label_DataFile</key>
       <text>Fichiers :</text>

--- a/Chummer/lang/fr_data.xml
+++ b/Chummer/lang/fr_data.xml
@@ -6243,7 +6243,7 @@
       <category translate="Appareils auditifs">Audio Enhancements</category>
       <category translate="Biotech">Biotech</category>
       <category translate="Accessoires pour commlinks">Commlink Accessories</category>
-      <category translate="Contrats DocWagon">DocWagon Contract</category>
+      <category translate="Contrats">Contracts</category>
       <category translate="Drogues">Drugs</category>
       <category translate="Explosifs">Explosives</category>
       <category translate="Foci">Foci</category>
@@ -8271,26 +8271,26 @@
       </gear>
       <gear>
         <id>6b28b36a-416a-4041-9561-558083158d7c</id>
-        <name>DocWagon Contract, Basic</name>
-        <translate>DocWagon Contract, Basic</translate>
+        <name>DocWagon Contract, Basic (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Basic (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>
         <id>c985f952-df28-4b69-a7b7-b24a291cd651</id>
-        <name>DocWagon Contract, Gold</name>
-        <translate>DocWagon Contract, Gold</translate>
+        <name>DocWagon Contract, Gold (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Gold (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>
         <id>aabed898-177f-413b-aeb6-5b862da67c6b</id>
-        <name>DocWagon Contract, Platinum</name>
-        <translate>DocWagon Contract, Platinum</translate>
+        <name>DocWagon Contract, Platinum (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Platinum (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>
         <id>7c8251b6-b195-4c8f-90f0-c036f8a9146f</id>
-        <name>DocWagon Contract, Super-Platinum</name>
-        <translate>DocWagon Contract, Super-Platinum</translate>
+        <name>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>

--- a/Chummer/lang/fr_data.xml
+++ b/Chummer/lang/fr_data.xml
@@ -6243,7 +6243,7 @@
       <category translate="Appareils auditifs">Audio Enhancements</category>
       <category translate="Biotech">Biotech</category>
       <category translate="Accessoires pour commlinks">Commlink Accessories</category>
-      <category translate="Contrats">Contracts</category>
+      <category translate="Contrats/Entretien">Contracts/Upkeep</category>
       <category translate="Drogues">Drugs</category>
       <category translate="Explosifs">Explosives</category>
       <category translate="Foci">Foci</category>

--- a/Chummer/lang/jp.xml
+++ b/Chummer/lang/jp.xml
@@ -256,6 +256,10 @@
       <key>Label_Mount</key>
       <text>Mount:</text>
     </string>
+	<string>
+		<key>Label_ExtraMount</key>
+		<text>Extra Mount:</text>
+	</string>
     <string>
       <key>Label_DataFile</key>
       <text>データファイル:</text>

--- a/Chummer/lang/jp_data.xml
+++ b/Chummer/lang/jp_data.xml
@@ -6252,7 +6252,7 @@
       <category translate="聴覚強化機能">Audio Enhancements</category>
       <category translate="医療機器">Biotech</category>
       <category translate="コムリンク・アクセサリー">Commlink Accessories</category>
-      <category translate="契約">Contracts</category>
+      <category translate="契約/営繕">Contracts/Upkeep</category>
       <category translate="ドラッグ">Drugs</category>
       <category translate="爆薬">Explosives</category>
       <category translate="収束具">Foci</category>

--- a/Chummer/lang/jp_data.xml
+++ b/Chummer/lang/jp_data.xml
@@ -6252,7 +6252,7 @@
       <category translate="聴覚強化機能">Audio Enhancements</category>
       <category translate="医療機器">Biotech</category>
       <category translate="コムリンク・アクセサリー">Commlink Accessories</category>
-      <category translate="ドクワゴン契約">DocWagon Contract</category>
+      <category translate="契約">Contracts</category>
       <category translate="ドラッグ">Drugs</category>
       <category translate="爆薬">Explosives</category>
       <category translate="収束具">Foci</category>
@@ -8280,26 +8280,26 @@
       </gear>
       <gear>
         <id>6b28b36a-416a-4041-9561-558083158d7c</id>
-        <name>DocWagon Contract, Basic</name>
-        <translate>DocWagon Contract, Basic</translate>
+        <name>DocWagon Contract, Basic (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Basic (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>
         <id>c985f952-df28-4b69-a7b7-b24a291cd651</id>
-        <name>DocWagon Contract, Gold</name>
-        <translate>DocWagon Contract, Gold</translate>
+        <name>DocWagon Contract, Gold (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Gold (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>
         <id>aabed898-177f-413b-aeb6-5b862da67c6b</id>
-        <name>DocWagon Contract, Platinum</name>
-        <translate>DocWagon Contract, Platinum</translate>
+        <name>DocWagon Contract, Platinum (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Platinum (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>
         <id>7c8251b6-b195-4c8f-90f0-c036f8a9146f</id>
-        <name>DocWagon Contract, Super-Platinum</name>
-        <translate>DocWagon Contract, Super-Platinum</translate>
+        <name>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</name>
+        <translate>DocWagon Contract, Super-Platinum (1 Year Advance Payment)</translate>
         <page>450</page>
       </gear>
       <gear>


### PR DESCRIPTION
Application Changes:

- Added the ability for weapon accessories to occupy multiple slots simultaneously.
- Fixed a crash when browsing Negative qualities for an Advanced Lifestyle caused by the way Thrifty quality was set up.
- Recategorized SkillSoft Networks into a new Lifestyle quality category called "Contracts", which can now be taken by Basic Lifestyles too.
- Renamed the "DocWagon Contracts" Gear category to "Contracts/Upkeep", which now houses every type of advance payment for contracts, 'ware upkeep, and the like.
- Added the ability for cyberware to add vehicles the same way it can add weapons (e.g. for Ocular Drone).
- Added the ability for vehicles, vehicle mods, and gear to be hidden from their browsing menus, just like cyberweapons are in the weapons menu.
- Weapon accessories can now come with gear pre-included.

Data Changes:

- Corrected the Fichetti Security 600 to a Folding Stock.
- Renamed the old Gecko Grip item to "Gecko Grip (for Weapon without Stock Slot)" and added a new Gecko Grip entry for weapons with a Stock slot that takes up the Stock slot.
- Corrected the reference to the Vintage quality to GH3 page 3 instead of 53.
- Corrected Ammo Skip weapon modification to require an Underbarrel slot.
- Corrected Chameleon Coating weapon modification to require a Side slot.
- Corrected Electronic Firing weapon modification to require a Barrel slot.
- Corrected Mounted Crossbow and Underbarrel Laser weapon modifications to take up two weapon modification slots (Top & Underbarrel and Side & Underbarrel respectively).
- Changed tasers have a concealability of -4. RAW justification includes indirect references to smaller size by Hidden Gun Arm Slide size restrictions, the Reach stat of Defiance EX-Shocker's contacts, and the essence/capacity cost of implanted cybertasers.
- Added a pair of drone arms and drone legs to the Ares Duelyst.
- Added a pair of drone arms to the Transys Office Maid (fluff text makes reference to arms but not to legs).
- Added a pair of drone arms and drone legs to the Modified Renraku Manservant-3 and recategorized it to Anthropomorphic, as per the original being a similar model to the Criado Juan.
- Added a pair of drone arms, a pair of drone legs, and the Snake Fingers cyberware to the Caduceus CAD and recategorized it to Anthropomorphic.
- Added a pair of synthetic drone arms and a pair of synthetic drone legs to the Mitsuhama Akiyama.
- Added a pair of drone arms, a pair of drone legs, and all three R1 close combat tutorsofts to the Sparring Drone.
- Added the following missing categories to the vehicle weapon mounts found in the core rulebook: Blades, Clubs, Exotic Melee Weapons, Crossbows, and Sporting Rifles to Standard Mounts, and Blades, Clubs, Exotic Melee Weapons, Crossbows, and Exotic Ranged Weapons for Heavy Mounts.
- Removed the Sniper Rifle category from the Standard Weapon Mount found in the core rulebook (it is bigger than an Assault Rifle).
- Gecko Tips vehicle modification will no longer show up for vehicles with a higher body than 6.
- Removed the Melee, Machine Pistols, and Submachine Guns categories from the Rigger 5.0 Standard and Heavy Vehicle Weapon Mounts, but added a note to add them back once errata has been released.
- Corrected Winch (Enhanced) to require 2 body slot mods instead of 1.
- Added two new items for drone weapon mounts: blow-away panels and pop-out mods. Pop-out mod rating serves as the modified MP of the weapon mount in question.
- Added entries for the Daihatsu-Caterpillar Horseman ModPods.
- Added missing Holster to Sleeping Tiger.
- Added entries to the Contracts lifestyle quality category for monthly payment of DocWagon contracts.
- Added entries to the Contracts lifestyle quality category and the Contracts/Upkeep gear category for Datahost Subscription (e.g. Library of Alexandria), Shopsoft Network Subscription (e.g. Shoppazulu), and Mapping System Subscription (e.g. Ares' Getting Network) as found in Chrome Flesh.
- Added entries to the Contracts/Upkeep gear category for pre-paid Skillsoft Network subscriptions.
- Added the "Shadow Spirits" pre-written specialization to the Magical Threats knowledge skill.
- Added the "Mathematics" academic knowledge skill and populated it with a few specializations, as per Math SPU in Chrome Flesh.
- Corrected Math SPU to properly give +4 dice pool to the Mathematics knowledge skill and +1 mental limit for scientific and technical knowledge skills.
- Corrected Limbic Neural Amplifier nanoware to properly give +1 dice pool bonus to all Intuition-linked skills.
- Corrected Neocortical Neural Amplifier nanoware to properly give +1 dice pool bonus to all Logic-linked skills and to give +Rating bonus to mental limit when using those skills instead of +1.
- Added the Immunization genemod from Chrome Flesh.
- Added the Phenotypic Variations positive qualities as per the optional rule in Chrome Flesh (can be ignored just like Omegaware/Gammaware).
- Added entries for commlink and cyberdeck form factor modifications from Data Trails.
- Stun Dongle commlink accessory now gives a free "Stun Dongle" weapon entry in the weapons tab.
- Added entries for commlink apps from Data Trails. Since their prices aren't specified, they have customizable pricing from 0 to 50, 50 being the cost of the most expensive entertainment software listed in Run Faster.
- Corrected the bug where Camera, Micro could not be added to armor.
- Added an entry for Microphone, Omni-Directional, Micro.
- Added entries for 1-month Symbiotes Upkeep and 6-month Hard Nanohive Upkeep to the Contracts/Upkeep gear category.
- Added an entry for the Shiawase Arms Simoom to Specialty Armor (it adds a corresponding entry in the weapons tab).
- Corrected the bug where Riot Shield and Ballistic Shield would charge players twice (once for the armor, once for the weapon entry that was added with the armor). Riot Shield and Ballistic Shield can no longer be directly added from the weapons tab.
- Hid all weapons entries for cyberweapons and gear items so that they cannot be mistakenly added for free (the player needs to buy the item through its main tab).
- Added missing Stock and Side weapon accessory slots to all tasers, light pistols, and heavy pistols, as per HeroLab, as well as a few SMGs and a sniper rifle that was missing these slots.
- Added missing Top and Underbarrel weapon accessory slots to the Ares Armatus.
- Added built-in Vision Magnification and Camera, Micro to the Imaging Scope weapon accessory.
- Feedback Clothing can now be added to armor as an armor mod with a capacity cost of 3, as per Herolab.
- Defiance EX-Shocker now gives a free "Defiance EX-Shocker Contacts" weapon entry for its melee contacts.
- Ocular Drone cyberware now gives a free "Ocular Drone" vehicle entry in the vehicle tab.
- Altered the Smartgun weapon accessories so that they now come pre-included with a Laser Range Finder and a Camera, Micro that takes vision enhancements, instead of the accessory allowing for the addition of vision enhancements.
- Added a text field to Program Carrier so that its cyberprogram can be specified.