### PR TITLE
Delnar's Bunch 'o' Changes #2

### DIFF
--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -235,6 +235,38 @@ namespace Chummer.Backend.Equipment
 					{
 						objAccessory.Create(objXmlAccessory, objAccessoryNode, new string[] { "Internal" , "None" }, intAccessoryRating, cmsWeaponAccessoryGear, false, blnCreateChildren);
 					}
+                    // Add any extra Gear that comes with the Weapon Accessory.
+                    if (objXmlWeaponAccessory["gears"] != null && blnCreateChildren)
+                    {
+                        XmlDocument objXmlGearDocument = XmlManager.Instance.Load("gear.xml");
+                        foreach (XmlNode objXmlAccessoryGear in objXmlWeaponAccessory.SelectNodes("gears/usegear"))
+                        {
+                            int intGearRating = 0;
+                            string strForceValue = "";
+                            if (objXmlAccessoryGear.Attributes["rating"] != null)
+                                intGearRating = Convert.ToInt32(objXmlAccessoryGear.Attributes["rating"].InnerText);
+                            if (objXmlAccessoryGear.Attributes["select"] != null)
+                                strForceValue = objXmlAccessoryGear.Attributes["select"].InnerText;
+
+                            XmlNode objXmlGear = objXmlGearDocument.SelectSingleNode("/chummer/gears/gear[name = \"" + objXmlAccessoryGear.InnerText + "\"]");
+                            Gear objGear = new Gear(_objCharacter);
+
+                            TreeNode objGearNode = new TreeNode();
+                            List<Weapon> lstWeapons = new List<Weapon>();
+                            List<TreeNode> lstWeaponNodes = new List<TreeNode>();
+
+                            objGear.Create(objXmlGear, _objCharacter, objGearNode, intGearRating, lstWeapons, lstWeaponNodes, strForceValue, false, false, true);
+                            objGear.Cost = "0";
+                            objGear.MaxRating = objGear.Rating;
+                            objGear.MinRating = objGear.Rating;
+                            objGear.IncludedInParent = true;
+                            objAccessory.Gear.Add(objGear);
+
+                            objGearNode.ContextMenuStrip = cmsWeaponAccessoryGear;
+                            objAccessoryNode.Nodes.Add(objGearNode);
+                            objAccessoryNode.Expand();
+                        }
+                    }
 
                     objAccessory.IncludedInWeapon = true;
 					objAccessory.Parent = this;
@@ -1178,6 +1210,7 @@ namespace Chummer.Backend.Equipment
 					intReturn += objAccessory.Concealability;
 			}
 
+            /* Commented out because there's no reference to this in RAW
 			// Add +4 for each Underbarrel Weapon installed.
 			if (_lstUnderbarrel.Count > 0)
 			{
@@ -1187,6 +1220,7 @@ namespace Chummer.Backend.Equipment
 						intReturn += 4;
 				}
 			}
+            */
 
 			// Factor in the character's Concealability modifiers.
 			ImprovementManager objImprovementManager = new ImprovementManager(_objCharacter);

--- a/Chummer/Backend/Equipment/WeaponAccessory.cs
+++ b/Chummer/Backend/Equipment/WeaponAccessory.cs
@@ -101,7 +101,7 @@ namespace Chummer.Backend.Equipment
 			objXmlAccessory.TryGetField("ammobonus", out _intAmmoBonus);
 			objXmlAccessory.TryGetField("accessorycostmultiplier", out _intAccessoryCostMultiplier);
 
-            // Add any Gear that comes with the Armor.
+            // Add any Gear that comes with the Weapon Accessory.
             if (objXmlAccessory["gears"] != null && blnCreateChildren)
             {
                 XmlDocument objXmlGearDocument = XmlManager.Instance.Load("gear.xml");

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -15811,7 +15811,7 @@ namespace Chummer
 
                     lblWeaponAvail.Text = objWeapon.TotalAvail;
                     lblWeaponCost.Text = String.Format("{0:###,###,##0¥}", objWeapon.TotalCost);
-                    lblWeaponConceal.Text = "+4";
+                    lblWeaponConceal.Text = objWeapon.CalculatedConcealability();
                     lblWeaponDamage.Text = objWeapon.CalculatedDamage();
                     lblWeaponAccuracy.Text = objWeapon.TotalAccuracy.ToString();
                     lblWeaponRC.Text = objWeapon.TotalRC;

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -1375,8 +1375,8 @@ namespace Chummer
                 if (!_objOptions.ESSLossReducesMaximumOnly)
                     intEssenceLoss = _objCharacter.EssencePenalty;
                 nudMAG.Minimum = _objCharacter.MAG.MetatypeMinimum;
-                nudMAG.Maximum = _objCharacter.MAG.MetatypeMaximum;
-                nudKMAG.Maximum = _objCharacter.MAG.MetatypeMaximum;
+                nudMAG.Maximum = _objCharacter.MAG.MetatypeMaximum + intEssenceLoss;
+                nudKMAG.Maximum = _objCharacter.MAG.MetatypeMaximum + intEssenceLoss;
 
                 // If the character options permit initiation in create mode, show the Initiation page.
                 if (_objOptions.AllowInitiationInCreateMode)
@@ -1424,6 +1424,7 @@ namespace Chummer
                     intEssenceLoss = _objCharacter.EssencePenalty;
                 nudRES.Minimum = _objCharacter.RES.MetatypeMinimum;
                 nudRES.Maximum = _objCharacter.RES.MetatypeMaximum + intEssenceLoss;
+                nudKRES.Maximum = _objCharacter.RES.MetatypeMaximum + intEssenceLoss;
                 // If the character options permit submersion in create mode, show the Initiation page.
                 if (_objOptions.AllowInitiationInCreateMode)
                 {
@@ -21119,11 +21120,11 @@ namespace Chummer
             nudEDG.Maximum = _objCharacter.EDG.TotalMaximum;
             if (_objCharacter.BuildMethod == CharacterBuildMethod.Karma)
             {
-                nudKMAG.Maximum = _objCharacter.MAG.TotalMaximum;
-                nudKRES.Maximum = _objCharacter.RES.TotalMaximum;
+                nudKMAG.Maximum = _objCharacter.MAG.TotalMaximum + intEssenceLoss;
+                nudKRES.Maximum = _objCharacter.RES.TotalMaximum + intEssenceLoss;
             }
-            nudMAG.Maximum = _objCharacter.MAG.TotalMaximum;
-            nudRES.Maximum = _objCharacter.RES.TotalMaximum;
+            nudMAG.Maximum = _objCharacter.MAG.TotalMaximum + intEssenceLoss;
+            nudRES.Maximum = _objCharacter.RES.TotalMaximum + intEssenceLoss;
 
             nudBOD.Minimum = _objCharacter.BOD.MetatypeMinimum;
             nudAGI.Minimum = _objCharacter.AGI.MetatypeMinimum;

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -21043,17 +21043,17 @@ namespace Chummer
                 intEssenceLoss = _objCharacter.EssencePenalty;
 
             // Determine the number of points that have been put into Attributes.
-            int intBOD = _objCharacter.BOD.Value - _objCharacter.BOD.MetatypeMinimum;
-            int intAGI = _objCharacter.AGI.Value - _objCharacter.AGI.MetatypeMinimum;
-            int intREA = _objCharacter.REA.Value - _objCharacter.REA.MetatypeMinimum;
-            int intSTR = _objCharacter.STR.Value - _objCharacter.STR.MetatypeMinimum;
-            int intCHA = _objCharacter.CHA.Value - _objCharacter.CHA.MetatypeMinimum;
-            int intINT = _objCharacter.INT.Value - _objCharacter.INT.MetatypeMinimum;
-            int intLOG = _objCharacter.LOG.Value - _objCharacter.LOG.MetatypeMinimum;
-            int intWIL = _objCharacter.WIL.Value - _objCharacter.WIL.MetatypeMinimum;
-            int intEDG = _objCharacter.EDG.Value - _objCharacter.EDG.MetatypeMinimum;
-	        int intMAG = Math.Max(_objCharacter.MAG.Value - _objCharacter.MAG.MetatypeMinimum, 0);
-	        int intRES = Math.Max(_objCharacter.RES.Value - _objCharacter.RES.MetatypeMinimum, 0);
+            int intBOD = _objCharacter.BOD.Base - _objCharacter.BOD.MetatypeMinimum;
+            int intAGI = _objCharacter.AGI.Base - _objCharacter.AGI.MetatypeMinimum;
+            int intREA = _objCharacter.REA.Base - _objCharacter.REA.MetatypeMinimum;
+            int intSTR = _objCharacter.STR.Base - _objCharacter.STR.MetatypeMinimum;
+            int intCHA = _objCharacter.CHA.Base - _objCharacter.CHA.MetatypeMinimum;
+            int intINT = _objCharacter.INT.Base - _objCharacter.INT.MetatypeMinimum;
+            int intLOG = _objCharacter.LOG.Base - _objCharacter.LOG.MetatypeMinimum;
+            int intWIL = _objCharacter.WIL.Base - _objCharacter.WIL.MetatypeMinimum;
+            int intEDG = _objCharacter.EDG.Base - _objCharacter.EDG.MetatypeMinimum;
+	        int intMAG = Math.Max(_objCharacter.MAG.Base - _objCharacter.MAG.MetatypeMinimum, 0);
+	        int intRES = Math.Max(_objCharacter.RES.Base - _objCharacter.RES.MetatypeMinimum, 0);
 
             // Build a list of the current Metatype's Improvements to remove if the Metatype changes.
             List<Improvement> lstImprovement = _objCharacter.Improvements.Where(objImprovement => objImprovement.ImproveSource == Improvement.ImprovementSource.Metatype || objImprovement.ImproveSource == Improvement.ImprovementSource.Metavariant || objImprovement.ImproveSource == Improvement.ImprovementSource.Heritage).ToList();

--- a/Chummer/Character Creation/frmKarmaMetatype.cs
+++ b/Chummer/Character Creation/frmKarmaMetatype.cs
@@ -836,7 +836,8 @@ namespace Chummer
 					_objCharacter.INT.Value = _objCharacter.INT.TotalMinimum;
 					_objCharacter.LOG.Value = _objCharacter.LOG.TotalMinimum;
 					_objCharacter.WIL.Value = _objCharacter.WIL.TotalMinimum;
-					_objCharacter.MAG.Value = _objCharacter.MAG.TotalMinimum;
+                    _objCharacter.EDG.Value = _objCharacter.EDG.TotalMinimum;
+                    _objCharacter.MAG.Value = _objCharacter.MAG.TotalMinimum;
 					_objCharacter.RES.Value = _objCharacter.RES.TotalMinimum;
 					_objCharacter.DEP.Value = _objCharacter.DEP.TotalMinimum;
 
@@ -847,7 +848,8 @@ namespace Chummer
 					_objCharacter.CHA.Base = _objCharacter.CHA.TotalMinimum;
 					_objCharacter.INT.Base = _objCharacter.INT.TotalMinimum;
 					_objCharacter.LOG.Base = _objCharacter.LOG.TotalMinimum;
-					_objCharacter.WIL.Base = _objCharacter.WIL.TotalMinimum;
+                    _objCharacter.EDG.Base = _objCharacter.EDG.TotalMinimum;
+                    _objCharacter.WIL.Base = _objCharacter.WIL.TotalMinimum;
 					_objCharacter.MAG.Base = _objCharacter.MAG.TotalMinimum;
 					_objCharacter.RES.Base = _objCharacter.RES.TotalMinimum;
 					_objCharacter.DEP.Base = _objCharacter.DEP.TotalMinimum;

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -364,8 +364,18 @@ namespace Chummer
 				SumtoTen();
 			}
 
-			// Add Possession and Inhabitation to the list of Critter Tradition variations.
-			tipTooltip.SetToolTip(chkPossessionBased, LanguageManager.Instance.GetString("Tip_Metatype_PossessionTradition"));
+            // Make sure lists are properly populated so that you can't e.g. select Magician if you're reprioritizing a Mundane
+            string strMetatype = "";
+            if (lstMetatypes.SelectedIndex >= 0)
+            {
+                strMetatype = lstMetatypes.SelectedValue.ToString();
+            }
+            LoadMetatypes();
+            lstMetatypes.SelectedValue = strMetatype;
+            PopulateTalents();
+
+            // Add Possession and Inhabitation to the list of Critter Tradition variations.
+            tipTooltip.SetToolTip(chkPossessionBased, LanguageManager.Instance.GetString("Tip_Metatype_PossessionTradition"));
 			tipTooltip.SetToolTip(chkBloodSpirit, LanguageManager.Instance.GetString("Tip_Metatype_BloodSpirit"));
 
             XmlDocument objXmlDocument = XmlManager.Instance.Load("critterpowers.xml");
@@ -609,6 +619,7 @@ namespace Chummer
 							cboSkill2.DisplayMember = "Name";
 							cboSkill2.DataSource = lstSkills;
 							cboSkill2.Visible = true;
+                            cboSkill2.SelectedIndex = cboSkill1.SelectedIndex + 1;
 						}
 						lblMetatypeSkillSelection.Visible = true;
 					}
@@ -633,7 +644,7 @@ namespace Chummer
 			}
 		}
 
-	    private void cboMetavariant_SelectedIndexChanged(object sender, EventArgs e)
+        private void cboMetavariant_SelectedIndexChanged(object sender, EventArgs e)
 		{
 			XmlDocument objXmlDocument = XmlManager.Instance.Load(_strXmlFile);
 			XmlDocument objXmlQualityDocument = XmlManager.Instance.Load("qualities.xml");
@@ -1175,7 +1186,8 @@ namespace Chummer
 					_objCharacter.INT.Value = _objCharacter.INT.TotalMinimum;
 					_objCharacter.LOG.Value = _objCharacter.LOG.TotalMinimum;
 					_objCharacter.WIL.Value = _objCharacter.WIL.TotalMinimum;
-					_objCharacter.MAG.Value = _objCharacter.MAG.TotalMinimum;
+                    _objCharacter.EDG.Value = _objCharacter.EDG.TotalMinimum;
+                    _objCharacter.MAG.Value = _objCharacter.MAG.TotalMinimum;
 					_objCharacter.RES.Value = _objCharacter.RES.TotalMinimum;
 					_objCharacter.DEP.Value = _objCharacter.DEP.TotalMinimum;
 
@@ -1187,7 +1199,8 @@ namespace Chummer
                     _objCharacter.INT.Base = _objCharacter.INT.TotalMinimum;
                     _objCharacter.LOG.Base = _objCharacter.LOG.TotalMinimum;
                     _objCharacter.WIL.Base = _objCharacter.WIL.TotalMinimum;
-					_objCharacter.MAG.Base = _objCharacter.MAG.TotalMinimum;
+                    _objCharacter.EDG.Base = _objCharacter.EDG.TotalMinimum;
+                    _objCharacter.MAG.Base = _objCharacter.MAG.TotalMinimum;
 					_objCharacter.RES.Base = _objCharacter.RES.TotalMinimum;
 					_objCharacter.DEP.Base = _objCharacter.DEP.TotalMinimum;
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -27,6 +27,11 @@ Application Changes:
 - Fixed the implementation of the Stock Remova/Shortbarrel mods. Current technical limitations prevent the penalty to accuracy if both mods are installed from working, so another modification that rolls both mods in together has been added. 
 - Added the ability to forbid/require weapon accessories based on the presence of other accessories. 
 - Altered the behaviour of the Weapon Focus to avoid some silly behaviour like letting your fists be a weapon focus. 
+- Added the ability for weapons with built-in accessories to attach extra gear to said built-in accessories.
+- Corrected the issue where weapons would receive +4 concealability for each underbarrel weapon.
+- Fixed the issue where changing metatypes under priority or sum-to-ten generation would save the incorrect amount of points spent on an attribute if it also had karma spent on it.
+- Fixed the issue where the magic dropdown menu and the metatype selection list would not update properly when the priority selection screen was initialised.
+- Fixed the issue where Edge was not properly re-adjusted when changing metatypes during character creation.
 
 Data Changes: 
 
@@ -95,6 +100,8 @@ Data Changes:
 - Added missing Carrier qualities from Run Faster. 
 - Reorganised the critters.xml file to support creating Spirits in Chummer.
 - Fixed an issue with the Defiance EX-Shocker that caused a crash. 
+- Added commlink gear to the built-in weapon commlinks of the Ogre Hammer SWS Assault Cannon and the Terracotta Arms AM-47
+- Added missing Imaging Scope addons for the Imaging Scopes that are built into the Ogre Hammer SWS Assault Cannon, the Krupp Arms Kriegfaust, the Ultimax Rain Forest Carbine, the Terracotta Arms AM-47, the Marlin X71, and the Springfield M1A. 
 
 Build 187
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -32,6 +32,7 @@ Application Changes:
 - Fixed the issue where changing metatypes under priority or sum-to-ten generation would save the incorrect amount of points spent on an attribute if it also had karma spent on it.
 - Fixed the issue where the magic dropdown menu and the metatype selection list would not update properly when the priority selection screen was initialised.
 - Fixed the issue where Edge was not properly re-adjusted when changing metatypes during character creation.
+- Fixed a crash issue where changing metatypes or the magic priority mid-creation would not take essence loss into account when setting new values for magic or resonance. Fixes #1229.
 
 Data Changes: 
 

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -2589,6 +2589,40 @@
 			<source>HKS</source>
 			<page>77</page>
 		</gear>
+		<gear>
+			<id>adea2313-b20b-4ad1-bf7a-f101f67de800</id>
+			<name>Ogre Hammer SWS Assault Cannon (Commlink)</name>
+			<category>Commlinks</category>
+			<hidden />
+			<capacity>0</capacity>
+			<rating>0</rating>
+			<devicerating>4</devicerating>
+			<attack>0</attack>
+			<sleaze>0</sleaze>
+			<dataprocessing>4</dataprocessing>
+			<firewall>4</firewall>
+			<avail>0</avail>
+			<cost>0</cost>
+			<source>RG</source>
+			<page>46</page>
+		</gear>
+		<gear>
+			<id>e794709c-059f-4eda-9bbd-ae0aa7aead2a</id>
+			<name>Terracotta Arms AM-47 (Commlink)</name>
+			<category>Commlinks</category>
+			<hidden />
+			<capacity>0</capacity>
+			<rating>0</rating>
+			<devicerating>5</devicerating>
+			<attack>0</attack>
+			<sleaze>0</sleaze>
+			<dataprocessing>5</dataprocessing>
+			<firewall>5</firewall>
+			<avail>0</avail>
+			<cost>0</cost>
+			<source>RG</source>
+			<page>38</page>
+		</gear>
 		<!-- End Region -->
 		<!-- Region RCCs -->
 		<gear>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -206,9 +206,17 @@
 				</accessory>
 				<accessory>
 					<name>Weapon Commlink</name>
+					<gears>
+						<usegear rating="4">Ogre Hammer SWS Assault Cannon (Commlink)</usegear>
+					</gears>
 				</accessory>
 				<accessory>
 					<name>Imaging Scope</name>
+					<gears>
+						<usegear>Image Link</usegear>
+						<usegear>Flare Compensation</usegear>
+						<usegear>Low Light</usegear>
+					</gears>
 				</accessory>
 			</accessories>
 			<source>RG</source>
@@ -715,6 +723,9 @@
 			<accessories>
 				<accessory>
 					<name>Imaging Scope</name>
+					<gears>
+						<usegear rating="1">Vision Enhancement</usegear>
+					</gears>
 				</accessory>
 			</accessories>
 			<source>GH3</source>
@@ -852,10 +863,15 @@
 			<accessories>
 				<accessory>
 					<name>Imaging Scope</name>
-			</accessory>
+					<gears>
+						<usegear>Image Link</usegear>
+						<usegear>Flare Compensation</usegear>
+						<usegear>Low Light</usegear>
+					</gears>
+				</accessory>
 				<accessory>
 					<name>Folding Stock</name>
-			</accessory>
+				</accessory>
 			</accessories>
 			<source>GH3</source>
 			<page>32</page>
@@ -5486,12 +5502,19 @@
 				</accessory>
 				<accessory>
 					<name>Weapon Commlink</name>
+					<gears>
+						<usegear rating="5">Terracotta Arms AM-47 (Commlink)</usegear>
+					</gears>
 				</accessory>
 				<accessory>
 					<name>Smartgun System, Internal</name>
 				</accessory>
 				<accessory>
 					<name>Imaging Scope</name>
+					<gears>
+						<usegear>Image Link</usegear>
+						<usegear>Low Light</usegear>
+					</gears>
 				</accessory>
 				<accessory>
 					<name>Underbarrel Weight</name>
@@ -5971,7 +5994,13 @@
 				<mount>Under</mount>
 			</accessorymounts>
 			<accessories>
-				<accessory><name>Imaging Scope</name></accessory>
+				<accessory>
+					<name>Imaging Scope</name>
+					<gears>
+						<usegear>Low Light</usegear>
+						<usegear rating="2">Vision Enhancement</usegear>
+					</gears>
+				</accessory>
 				<accessory>
 					<name>Extreme Environment Modification</name>
 					<rating>1</rating>
@@ -6035,7 +6064,13 @@
 				<mount>Under</mount>
 			</accessorymounts>
 			<accessories>
-				<accessory><name>Imaging Scope</name></accessory>
+				<accessory>
+					<name>Imaging Scope</name>
+					<gears>
+						<usegear>Image Link</usegear>
+						<usegear rating="1">Vision Enhancement</usegear>
+					</gears>
+				</accessory>
 			</accessories>
 			<source>GH3</source>
 			<page>26</page>


### PR DESCRIPTION
Application Changes:

- Added the ability for weapons with built-in accessories to attach extra gear to said built-in accessories.
- Corrected the issue where weapons would receive +4 concealability for each underbarrel weapon.
- Fixed the issue where changing metatypes under priority or sum-to-ten generation would save the incorrect amount of points spent on an attribute if it also had karma spent on it.
- Fixed the issue where the magic dropdown menu and the metatype selection list would not update properly when the priority selection screen was initialised.
- Fixed the issue where Edge was not properly re-adjusted when changing metatypes during character creation.
- Fixed a crash issue where changing metatypes or the magic priority mid-creation would not take essence loss into account when setting new values for magic or resonance. Fixes #1229.

Data Changes:

- Added commlink gear to the built-in weapon commlinks of the Ogre Hammer SWS Assault Cannon and the Terracotta Arms AM-47
- Added missing Imaging Scope addons for the Imaging Scopes that are built into the Ogre Hammer SWS Assault Cannon, the Krupp Arms Kriegfaust, the Ultimax Rain Forest Carbine, the Terracotta Arms AM-47, the Marlin X71, and the Springfield M1A.