### PR TITLE
Coriolis, Vehicle, and Vehicle Mod Changes

### DIFF
--- a/Chummer/Backend/Equipment/Vehicle.cs
+++ b/Chummer/Backend/Equipment/Vehicle.cs
@@ -1593,7 +1593,7 @@ namespace Chummer.Backend.Equipment
                                 XmlDocument objXmlDocument = new XmlDocument();
                                 XPathNavigator nav = objXmlDocument.CreateNavigator();
                                 XPathExpression xprSeats = nav.Compile(objMod.Bonus["seats"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Seats", intTotalSeats.ToString()));
-                                intTotalBonusSeats += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                                intTotalBonusSeats += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
                     }
@@ -1664,7 +1664,7 @@ namespace Chummer.Backend.Equipment
                                 XmlDocument objXmlDocument = new XmlDocument();
                                 XPathNavigator nav = objXmlDocument.CreateNavigator();
                                 XPathExpression xprSeats = nav.Compile(objMod.Bonus["speed"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Speed", intTotalSpeed.ToString()));
-                                intTotalBonusSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                                intTotalBonusSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
                         if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
@@ -1676,7 +1676,7 @@ namespace Chummer.Backend.Equipment
                                 XmlDocument objXmlDocument = new XmlDocument();
                                 XPathNavigator nav = objXmlDocument.CreateNavigator();
                                 XPathExpression xprSeats = nav.Compile(objMod.Bonus["offroadspeed"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("OffroadSpeed", intBaseOffroadSpeed.ToString()));
-                                intTotalBonusOffroadSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                                intTotalBonusOffroadSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
                     }
@@ -1762,7 +1762,7 @@ namespace Chummer.Backend.Equipment
                                 XmlDocument objXmlDocument = new XmlDocument();
                                 XPathNavigator nav = objXmlDocument.CreateNavigator();
                                 XPathExpression xprSeats = nav.Compile(objMod.Bonus["accel"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Accel", intTotalAccel.ToString()));
-                                intTotalBonusAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                                intTotalBonusAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
                         if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
@@ -1774,7 +1774,7 @@ namespace Chummer.Backend.Equipment
                                 XmlDocument objXmlDocument = new XmlDocument();
                                 XPathNavigator nav = objXmlDocument.CreateNavigator();
                                 XPathExpression xprSeats = nav.Compile(objMod.Bonus["offroadspeed"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("OffroadAccel", intBaseOffroadAccel.ToString()));
-                                intTotalBonusOffroadAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                                intTotalBonusOffroadAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
                     }
@@ -1892,7 +1892,7 @@ namespace Chummer.Backend.Equipment
                                 XmlDocument objXmlDocument = new XmlDocument();
                                 XPathNavigator nav = objXmlDocument.CreateNavigator();
                                 XPathExpression xprSeats = nav.Compile(objMod.Bonus["handling"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Handling", intBaseHandling.ToString()));
-                                intTotalBonusHandling += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                                intTotalBonusHandling += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
                         if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadhandling>"))

--- a/Chummer/Backend/Equipment/Vehicle.cs
+++ b/Chummer/Backend/Equipment/Vehicle.cs
@@ -1615,7 +1615,6 @@ namespace Chummer.Backend.Equipment
                 int intBaseOffroadSpeed = OffroadSpeed;
                 int intTotalArmor = 0;
 				int intPenalty = 0;
-                bool boolCheckOffroad = OffroadSpeed > 0;
 
                 // First check for mods that overwrite the speed value or add to armor
                 foreach (VehicleMod objMod in _lstVehicleMods)
@@ -1630,7 +1629,7 @@ namespace Chummer.Backend.Equipment
 								intTotalSpeed = Math.Max(intTotalSpeed, Convert.ToInt32(objMod.Bonus["speed"].InnerText.Replace("Rating", objMod.Rating.ToString())));
 							}
 						}
-                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
+                        if (objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
                         {
                             chrFirstCharacter = objMod.Bonus["offroadspeed"].InnerText[0];
                             if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
@@ -1667,7 +1666,7 @@ namespace Chummer.Backend.Equipment
                                 intTotalBonusSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
-                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
+                        if (objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
                         {
                             chrFirstCharacter = objMod.Bonus["offroadspeed"].InnerText[0];
                             if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
@@ -1690,7 +1689,7 @@ namespace Chummer.Backend.Equipment
 					intPenalty = (int) Math.Floor(dblResult);
 				}
 
-                if (boolCheckOffroad)
+                if (Speed != OffroadSpeed || intTotalSpeed + intTotalBonusSpeed != intBaseOffroadSpeed + intTotalBonusOffroadSpeed)
                 {
                     return ((intTotalSpeed + intTotalBonusSpeed - intPenalty).ToString() + '/' + (intBaseOffroadSpeed + intTotalBonusOffroadSpeed - intPenalty).ToString());
                 }
@@ -1713,7 +1712,6 @@ namespace Chummer.Backend.Equipment
                 int intBaseOffroadAccel = OffroadAccel;
                 int intTotalArmor = 0;
                 int intPenalty = 0;
-                bool boolCheckOffroad = OffroadAccel > 0;
 
                 // First check for mods that overwrite the accel value or add to armor
                 foreach (VehicleMod objMod in _lstVehicleMods)
@@ -1728,7 +1726,7 @@ namespace Chummer.Backend.Equipment
                                 intTotalAccel = Math.Max(intTotalAccel, Convert.ToInt32(objMod.Bonus["accel"].InnerText.Replace("Rating", objMod.Rating.ToString())));
                             }
                         }
-                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
+                        if (objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
                         {
                             chrFirstCharacter = objMod.Bonus["offroadaccel"].InnerText[0];
                             if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
@@ -1765,7 +1763,7 @@ namespace Chummer.Backend.Equipment
                                 intTotalBonusAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
-                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
+                        if (objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
                         {
                             chrFirstCharacter = objMod.Bonus["offroadspeed"].InnerText[0];
                             if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
@@ -1788,7 +1786,7 @@ namespace Chummer.Backend.Equipment
 					intPenalty = (int)Math.Floor(dblResult);
 				}
 
-                if (boolCheckOffroad)
+                if (Accel != OffroadAccel || intTotalAccel + intTotalBonusAccel != intBaseOffroadAccel + intTotalBonusOffroadAccel)
                 {
                     return ((intTotalAccel + intTotalBonusAccel - intPenalty).ToString() + '/' + (intBaseOffroadAccel + intTotalBonusOffroadAccel - intPenalty).ToString());
                 }
@@ -1843,7 +1841,6 @@ namespace Chummer.Backend.Equipment
                 int intBaseOffroadHandling = OffroadHandling;
                 int intPenalty = 0;
                 int intTotalArmor = 0;
-                bool boolCheckOffroad = OffroadHandling > 0;
 
                 // First check for mods that overwrite the handling value or add to armor
                 foreach (VehicleMod objMod in _lstVehicleMods)
@@ -1858,7 +1855,7 @@ namespace Chummer.Backend.Equipment
                                 intBaseHandling = Math.Max(intBaseHandling, Convert.ToInt32(objMod.Bonus["handling"].InnerText.Replace("Rating", objMod.Rating.ToString())));
                             }
                         }
-                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
+                        if (objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
                         {
                             chrFirstCharacter = objMod.Bonus["offroadhandling"].InnerText[0];
                             if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
@@ -1895,7 +1892,7 @@ namespace Chummer.Backend.Equipment
                                 intTotalBonusHandling += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo);
                             }
                         }
-                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
+                        if (objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
                         {
                             chrFirstCharacter = objMod.Bonus["offroadhandling"].InnerText[0];
                             if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
@@ -1918,7 +1915,7 @@ namespace Chummer.Backend.Equipment
                     intPenalty = (int)Math.Floor(dblResult);
                 }
 
-                if (boolCheckOffroad)
+                if (Handling != OffroadHandling || intBaseHandling + intTotalBonusHandling != intBaseOffroadHandling + intTotalBonusOffroadHandling)
                 {
                     return ((intBaseHandling + intTotalBonusHandling - intPenalty).ToString() + '/' + (intBaseOffroadHandling + intTotalBonusOffroadHandling - intPenalty).ToString());
                 }

--- a/Chummer/Backend/Equipment/Vehicle.cs
+++ b/Chummer/Backend/Equipment/Vehicle.cs
@@ -19,8 +19,10 @@ namespace Chummer.Backend.Equipment
 		private int _intHandling = 0;
 		private int _intOffroadHandling = 0;
 		private int _intAccel = 0;
-		private int _intSpeed = 0;
-		private int _intPilot = 0;
+        private int _intOffroadAccel = 0;
+        private int _intSpeed = 0;
+        private int _intOffroadSpeed = 0;
+        private int _intPilot = 0;
 		private int _intBody = 0;
 		private int _intArmor = 0;
 		private int _intSensor = 0;
@@ -86,9 +88,28 @@ namespace Chummer.Backend.Equipment
 			else
 			{
 				_intHandling = Convert.ToInt32(objXmlVehicle["handling"].InnerText);
-			}
-			_intAccel = Convert.ToInt32(objXmlVehicle["accel"].InnerText);
-			_intSpeed = Convert.ToInt32(objXmlVehicle["speed"].InnerText);
+                _intOffroadHandling = _intHandling;
+            }
+            if (objXmlVehicle["accel"].InnerText.Contains('/'))
+            {
+                _intAccel = Convert.ToInt32(objXmlVehicle["accel"].InnerText.Split('/')[0]);
+                _intOffroadAccel = Convert.ToInt32(objXmlVehicle["accel"].InnerText.Split('/')[1]);
+            }
+            else
+            {
+                _intAccel = Convert.ToInt32(objXmlVehicle["accel"].InnerText);
+                _intOffroadAccel = _intAccel;
+            }
+            if (objXmlVehicle["speed"].InnerText.Contains('/'))
+            {
+                _intSpeed = Convert.ToInt32(objXmlVehicle["speed"].InnerText.Split('/')[0]);
+                _intOffroadSpeed = Convert.ToInt32(objXmlVehicle["speed"].InnerText.Split('/')[1]);
+            }
+            else
+            {
+                _intSpeed = Convert.ToInt32(objXmlVehicle["speed"].InnerText);
+                _intOffroadSpeed = _intSpeed;
+            }
 			_intPilot = Convert.ToInt32(objXmlVehicle["pilot"].InnerText);
 			_intBody = Convert.ToInt32(objXmlVehicle["body"].InnerText);
 			_intArmor = Convert.ToInt32(objXmlVehicle["armor"].InnerText);
@@ -352,8 +373,10 @@ namespace Chummer.Backend.Equipment
 			objWriter.WriteElementString("handling", _intHandling.ToString());
 			objWriter.WriteElementString("offroadhandling", _intOffroadHandling.ToString());
 			objWriter.WriteElementString("accel", _intAccel.ToString());
-			objWriter.WriteElementString("speed", _intSpeed.ToString());
-			objWriter.WriteElementString("pilot", _intPilot.ToString());
+            objWriter.WriteElementString("offroadaccel", _intOffroadAccel.ToString());
+            objWriter.WriteElementString("speed", _intSpeed.ToString());
+            objWriter.WriteElementString("offroadspeed", _intOffroadSpeed.ToString());
+            objWriter.WriteElementString("pilot", _intPilot.ToString());
 			objWriter.WriteElementString("body", _intBody.ToString());
 			objWriter.WriteElementString("seats", _intSeats.ToString());
 			objWriter.WriteElementString("armor", _intArmor.ToString());
@@ -439,9 +462,33 @@ namespace Chummer.Backend.Equipment
 					_intOffroadHandling = Convert.ToInt32(objNode["offroadhandling"].InnerText);
 				}
 			}
-			_intAccel = Convert.ToInt32(objNode["accel"].InnerText);
+            if (objNode["accel"].InnerText.Contains('/'))
+            {
+                _intAccel = Convert.ToInt32(objNode["accel"].InnerText.Split('/')[0]);
+                _intOffroadAccel = Convert.ToInt32(objNode["accel"].InnerText.Split('/')[1]);
+            }
+            else
+            {
+                _intAccel = Convert.ToInt32(objNode["accel"].InnerText);
+                if (objNode.InnerXml.Contains("offroadaccel"))
+                {
+                    _intOffroadAccel = Convert.ToInt32(objNode["offroadaccel"].InnerText);
+                }
+            }
+            if (objNode["speed"].InnerText.Contains('/'))
+            {
+                _intSpeed = Convert.ToInt32(objNode["speed"].InnerText.Split('/')[0]);
+                _intOffroadSpeed = Convert.ToInt32(objNode["speed"].InnerText.Split('/')[1]);
+            }
+            else
+            {
+                _intSpeed = Convert.ToInt32(objNode["speed"].InnerText);
+                if (objNode.InnerXml.Contains("offroadspeed"))
+                {
+                    _intOffroadSpeed = Convert.ToInt32(objNode["offroadspeed"].InnerText);
+                }
+            }
 			objNode.TryGetField("seats", out _intSeats);
-			_intSpeed = Convert.ToInt32(objNode["speed"].InnerText);
 			_intPilot = Convert.ToInt32(objNode["pilot"].InnerText);
 			_intBody = Convert.ToInt32(objNode["body"].InnerText);
 			_intArmor = Convert.ToInt32(objNode["armor"].InnerText);
@@ -757,10 +804,25 @@ namespace Chummer.Backend.Equipment
 			}
 		}
 
-		/// <summary>
-		/// Speed.
+        /// <summary>
+		/// Offroad Acceleration.
 		/// </summary>
-		public int Speed
+		public int OffroadAccel
+        {
+            get
+            {
+                return _intOffroadAccel;
+            }
+            set
+            {
+                _intOffroadAccel = value;
+            }
+        }
+
+        /// <summary>
+        /// Speed.
+        /// </summary>
+        public int Speed
 		{
 			get
 			{
@@ -772,10 +834,25 @@ namespace Chummer.Backend.Equipment
 			}
 		}
 
-		/// <summary>
-		/// Pilot.
-		/// </summary>
-		public int Pilot
+        /// <summary>
+        /// Speed.
+        /// </summary>
+        public int OffroadSpeed
+        {
+            get
+            {
+                return _intOffroadSpeed;
+            }
+            set
+            {
+                _intOffroadSpeed = value;
+            }
+        }
+
+        /// <summary>
+        /// Pilot.
+        /// </summary>
+        public int Pilot
 		{
 			get
 			{
@@ -1476,35 +1553,92 @@ namespace Chummer.Backend.Equipment
 			}
 		}
 
-		/// <summary>
-		/// Total Speed of the Vehicle including Modifications.
+        /// <summary>
+		/// Total Seats of the Vehicle including Modifications.
 		/// </summary>
-		public int TotalSpeed
+		public int TotalSeats
+        {
+            get
+            {
+                char chrFirstCharacter = (char)0;
+                // First check for mods that overwrite the seat value
+                int intTotalSeats = Seats;
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<seats>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["seats"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
+                            {
+                                intTotalSeats = Math.Max(Convert.ToInt32(objMod.Bonus["seats"].InnerText.Replace("Rating", objMod.Rating.ToString())), intTotalSeats);
+                            }
+                        }
+                    }
+                }
+
+                // Then check for mods that modify the seat value (needs separate loop in case of % modifiers on top of stat-overriding mods)
+                int intTotalBonusSeats = 0;
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<seats>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["seats"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing seat number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["seats"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Seats", intTotalSeats.ToString()));
+                                intTotalBonusSeats += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                    }
+                }
+
+                return intTotalSeats + intTotalBonusSeats;
+            }
+        }
+
+        /// <summary>
+        /// Total Speed of the Vehicle including Modifications.
+        /// </summary>
+        public string TotalSpeed
 		{
 			get
 			{
-				int intTotalSpeed = _intSpeed;
-				int intTotalArmor = 0;
+                char chrFirstCharacter = (char)0;
+                int intTotalSpeed = Speed;
+                int intBaseOffroadSpeed = OffroadSpeed;
+                int intTotalArmor = 0;
 				int intPenalty = 0;
+                bool boolCheckOffroad = OffroadSpeed > 0;
 
-				foreach (VehicleMod objMod in _lstVehicleMods)
+                // First check for mods that overwrite the speed value or add to armor
+                foreach (VehicleMod objMod in _lstVehicleMods)
 				{
 					if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
 					{
 						if (objMod.Bonus.InnerXml.Contains("<speed>"))
 						{
-							//Increase the vehicles base Speed by the Modification's value.
-							if (objMod.Bonus["speed"].InnerText.Contains("+"))
+                            chrFirstCharacter = objMod.Bonus["speed"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
 							{
-								intTotalSpeed += Convert.ToInt32(objMod.Bonus["speed"].InnerText.Replace("Rating", objMod.Rating.ToString()).Replace("+", string.Empty));
-							}
-							// Add the Vehicle's base Speed to the Modification's Speed adjustment.
-							else
-							{
-								intTotalSpeed = Convert.ToInt32(objMod.Bonus["speed"].InnerText.Replace("Rating", objMod.Rating.ToString()));
+								intTotalSpeed = Math.Max(intTotalSpeed, Convert.ToInt32(objMod.Bonus["speed"].InnerText.Replace("Rating", objMod.Rating.ToString())));
 							}
 						}
-						if (objMod.Bonus.InnerXml.Contains("<armor>"))
+                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["offroadspeed"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
+                            {
+                                intBaseOffroadSpeed = Math.Max(intBaseOffroadSpeed, Convert.ToInt32(objMod.Bonus["offroadspeed"].InnerText.Replace("Rating", objMod.Rating.ToString())));
+                            }
+                        }
+                        if (objMod.Bonus.InnerXml.Contains("<armor>"))
 						{
 							if (IsDrone && GlobalOptions.Instance.Dronemods)
 							{
@@ -1514,7 +1648,41 @@ namespace Chummer.Backend.Equipment
 					}
 				}
 
-				if (intTotalArmor > _intBody * 3)
+                // Then check for mods that modify the speed value (needs separate loop in case of % modifiers on top of stat-overriding mods)
+                int intTotalBonusSpeed = 0;
+                int intTotalBonusOffroadSpeed = 0;
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<speed>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["speed"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing speed number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["speed"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Speed", intTotalSpeed.ToString()));
+                                intTotalBonusSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadspeed>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["offroadspeed"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing speed number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["offroadspeed"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("OffroadSpeed", intBaseOffroadSpeed.ToString()));
+                                intTotalBonusOffroadSpeed += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                    }
+                }
+
+                if (intTotalArmor > _intBody * 3)
 				{
 					// Reduce speed of the drone if there is too much armor
 					int intExcess = intTotalArmor - (_intBody * 3);
@@ -1522,49 +1690,95 @@ namespace Chummer.Backend.Equipment
 					intPenalty = (int) Math.Floor(dblResult);
 				}
 
-				return intTotalSpeed - intPenalty;
-			}
+                if (boolCheckOffroad)
+                {
+                    return ((intTotalSpeed + intTotalBonusSpeed - intPenalty).ToString() + '/' + (intBaseOffroadSpeed + intTotalBonusOffroadSpeed - intPenalty).ToString());
+                }
+                else
+                {
+                    return ((intTotalSpeed + intTotalBonusSpeed - intPenalty).ToString());
+                }
+            }
 		}
 
 		/// <summary>
 		/// Total Accel of the Vehicle including Modifications.
 		/// </summary>
-		public int TotalAccel
+		public string TotalAccel
 		{
 			get
 			{
-				int intTotalAccel = _intAccel;
-				int intTotalArmor = 0;
-				int intPenalty = 0;
+                char chrFirstCharacter = (char)0;
+                int intTotalAccel = Accel;
+                int intBaseOffroadAccel = OffroadAccel;
+                int intTotalArmor = 0;
+                int intPenalty = 0;
+                bool boolCheckOffroad = OffroadAccel > 0;
 
+                // First check for mods that overwrite the accel value or add to armor
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<accel>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["accel"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
+                            {
+                                intTotalAccel = Math.Max(intTotalAccel, Convert.ToInt32(objMod.Bonus["accel"].InnerText.Replace("Rating", objMod.Rating.ToString())));
+                            }
+                        }
+                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["offroadaccel"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
+                            {
+                                intBaseOffroadAccel = Math.Max(intBaseOffroadAccel, Convert.ToInt32(objMod.Bonus["offroadaccel"].InnerText.Replace("Rating", objMod.Rating.ToString())));
+                            }
+                        }
+                        if (objMod.Bonus.InnerXml.Contains("<armor>"))
+                        {
+                            if (IsDrone && GlobalOptions.Instance.Dronemods)
+                            {
+                                intTotalArmor = Convert.ToInt32(objMod.Bonus["armor"].InnerText.Replace("Rating", objMod.Rating.ToString()));
+                            }
+                        }
+                    }
+                }
 
-				foreach (VehicleMod objMod in _lstVehicleMods)
-				{
-					if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
-					{
-						// Multiply the Vehicle's base Accel by the Modification's Accel multiplier.
-						if (objMod.Bonus.InnerXml.Contains("<accel>"))
-						{
-							if (objMod.Bonus["accel"].InnerText.Contains("+"))
-							{
-								string strAccel = objMod.Bonus["accel"].InnerText.Replace("Rating", objMod.Rating.ToString()).Replace("+", string.Empty);
-								intTotalAccel += Convert.ToInt32(strAccel, GlobalOptions.Instance.CultureInfo);
-							}
-							else
-							{
-								string strAccel = objMod.Bonus["accel"].InnerText.Replace("Rating", objMod.Rating.ToString()).Replace("+", string.Empty);
-								intTotalAccel = Convert.ToInt32(strAccel, GlobalOptions.Instance.CultureInfo);
-							}
-						}
-						if (objMod.Bonus.InnerXml.Contains("<armor>"))
-						{
-							if (IsDrone && GlobalOptions.Instance.Dronemods)
-							{
-								intTotalArmor = Convert.ToInt32(objMod.Bonus["armor"].InnerText.Replace("Rating", objMod.Rating.ToString()));
-							}
-						}
-					}
-				}
+                // Then check for mods that modify the accel value (needs separate loop in case of % modifiers on top of stat-overriding mods)
+                int intTotalBonusAccel = 0;
+                int intTotalBonusOffroadAccel = 0;
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<accel>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["accel"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing speed number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["accel"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Accel", intTotalAccel.ToString()));
+                                intTotalBonusAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadaccel>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["offroadspeed"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing speed number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["offroadspeed"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("OffroadAccel", intBaseOffroadAccel.ToString()));
+                                intTotalBonusOffroadAccel += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                    }
+                }
 
 				if (intTotalArmor > _intBody * 3)
 				{
@@ -1574,7 +1788,14 @@ namespace Chummer.Backend.Equipment
 					intPenalty = (int)Math.Floor(dblResult);
 				}
 
-				return intTotalAccel - intPenalty;
+                if (boolCheckOffroad)
+                {
+                    return ((intTotalAccel + intTotalBonusAccel - intPenalty).ToString() + '/' + (intBaseOffroadAccel + intTotalBonusOffroadAccel - intPenalty).ToString());
+                }
+                else
+                {
+                    return ((intTotalAccel + intTotalBonusAccel - intPenalty).ToString());
+                }
 			}
 		}
 
@@ -1617,63 +1838,94 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				string strHandling = "";
-				int intBaseHandling = _intHandling;
-				int intBaseOffroadHandling = _intOffroadHandling;
-				int intPenalty = 0;
-				int intTotalArmor = 0;
+                char chrFirstCharacter = (char)0;
+                int intBaseHandling = Handling;
+                int intBaseOffroadHandling = OffroadHandling;
+                int intPenalty = 0;
+                int intTotalArmor = 0;
+                bool boolCheckOffroad = OffroadHandling > 0;
 
-				foreach (VehicleMod objMod in _lstVehicleMods)
-				{
-					if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
-					{
-						// Add the Modification's Handling to the Vehicle's base Handling.
-						if (objMod.Bonus.InnerXml.Contains("<handling>"))
-						{
-							if (objMod.Bonus["handling"].InnerText.Contains("+"))
-							{
-								string strHandle = objMod.Bonus["handling"].InnerText.Replace("Rating", objMod.Rating.ToString()).Replace("+", string.Empty);
-								intBaseHandling += Convert.ToInt32(strHandle, GlobalOptions.Instance.CultureInfo);
-							}
-							else intBaseHandling = Convert.ToInt32(objMod.Bonus["handling"].InnerText.Replace("Rating", objMod.Rating.ToString()));
-						}
-						if (objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
-						{
-							if (objMod.Bonus["offroadhandling"].InnerText.Contains("+"))
-							{
-								string strHandle = objMod.Bonus["offroadhandling"].InnerText.Replace("Rating", objMod.Rating.ToString()).Replace("+", string.Empty);
-								intBaseOffroadHandling += Convert.ToInt32(strHandle, GlobalOptions.Instance.CultureInfo);
-							}
-							else intBaseOffroadHandling = Convert.ToInt32(objMod.Bonus["offroadhandling"].InnerText.Replace("Rating", objMod.Rating.ToString()));
-						}
-						if (objMod.Bonus.InnerXml.Contains("<armor>"))
-						{
-							if (IsDrone && GlobalOptions.Instance.Dronemods)
-							{
-								intTotalArmor = Convert.ToInt32(objMod.Bonus["armor"].InnerText.Replace("Rating", objMod.Rating.ToString()));
-							}
-						}
-					}
-				}
+                // First check for mods that overwrite the handling value or add to armor
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<handling>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["handling"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
+                            {
+                                intBaseHandling = Math.Max(intBaseHandling, Convert.ToInt32(objMod.Bonus["handling"].InnerText.Replace("Rating", objMod.Rating.ToString())));
+                            }
+                        }
+                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["offroadhandling"].InnerText[0];
+                            if (chrFirstCharacter != '+' && chrFirstCharacter != '-')
+                            {
+                                intBaseOffroadHandling = Math.Max(intBaseOffroadHandling, Convert.ToInt32(objMod.Bonus["offroadhandling"].InnerText.Replace("Rating", objMod.Rating.ToString())));
+                            }
+                        }
+                        if (objMod.Bonus.InnerXml.Contains("<armor>"))
+                        {
+                            if (IsDrone && GlobalOptions.Instance.Dronemods)
+                            {
+                                intTotalArmor = Convert.ToInt32(objMod.Bonus["armor"].InnerText.Replace("Rating", objMod.Rating.ToString()));
+                            }
+                        }
+                    }
+                }
 
-				if (intTotalArmor > _intBody * 3)
-				{
-					// Reduce speed of the drone if there is too much armor
-					int intExcess = intTotalArmor - (_intBody * 3);
-					double dblResult = intExcess / 3;
-					intPenalty = (int)Math.Floor(dblResult);
-				}
+                // Then check for mods that modify the handling value (needs separate loop in case of % modifiers on top of stat-overriding mods)
+                int intTotalBonusHandling = 0;
+                int intTotalBonusOffroadHandling = 0;
+                foreach (VehicleMod objMod in _lstVehicleMods)
+                {
+                    if (!objMod.IncludedInVehicle && objMod.Installed && objMod.Bonus != null)
+                    {
+                        if (objMod.Bonus.InnerXml.Contains("<handling>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["handling"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing speed number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["handling"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("Handling", intBaseHandling.ToString()));
+                                intTotalBonusHandling += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                        if (boolCheckOffroad && objMod.Bonus.InnerXml.Contains("<offroadhandling>"))
+                        {
+                            chrFirstCharacter = objMod.Bonus["offroadhandling"].InnerText[0];
+                            if (chrFirstCharacter == '+' || chrFirstCharacter == '-')
+                            {
+                                // If the bonus is determined by the existing speed number, evaluate the expression.
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                XPathNavigator nav = objXmlDocument.CreateNavigator();
+                                XPathExpression xprSeats = nav.Compile(objMod.Bonus["offroadhandling"].InnerText.TrimStart('+').Replace("Rating", objMod.Rating.ToString()).Replace("OffroadHandling", intBaseOffroadHandling.ToString()));
+                                intTotalBonusOffroadHandling += Convert.ToInt32(nav.Evaluate(xprSeats), GlobalOptions.Instance.CultureInfo) * (chrFirstCharacter == '-' ? -1 : 1);
+                            }
+                        }
+                    }
+                }
 
-				if (_intOffroadHandling > 0)
-				{
-					strHandling = ((intBaseHandling - intPenalty).ToString() + '/' + (intBaseOffroadHandling - intPenalty).ToString());
-				}
-				else
-				{
-					strHandling = ((intBaseHandling - intPenalty).ToString());
-				}
+                if (intTotalArmor > _intBody * 3)
+                {
+                    // Reduce speed of the drone if there is too much armor
+                    int intExcess = intTotalArmor - (_intBody * 3);
+                    double dblResult = intExcess / 6;
+                    intPenalty = (int)Math.Floor(dblResult);
+                }
 
-				return strHandling;
+                if (boolCheckOffroad)
+                {
+                    return ((intBaseHandling + intTotalBonusHandling - intPenalty).ToString() + '/' + (intBaseOffroadHandling + intTotalBonusOffroadHandling - intPenalty).ToString());
+                }
+                else
+                {
+                    return ((intBaseHandling + intTotalBonusHandling - intPenalty).ToString());
+                }
 			}
 		}
 

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -7957,8 +7957,9 @@ namespace Chummer
             frmSelectVehicleMod frmPickVehicleMod = new frmSelectVehicleMod(_objCharacter);
 			// Set the Vehicle properties for the window.
 			frmPickVehicleMod.SelectedVehicle = objSelectedVehicle;
+            frmPickVehicleMod.InstalledMods = objSelectedVehicle.Mods;
 
-			frmPickVehicleMod.ShowDialog(this);
+            frmPickVehicleMod.ShowDialog(this);
 
             // Make sure the dialogue window was not canceled.
             if (frmPickVehicleMod.DialogResult == DialogResult.Cancel)

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -17692,7 +17692,7 @@ namespace Chummer
                 lblVehiclePilot.Text = objVehicle.Pilot.ToString();
                 lblVehicleBody.Text = objVehicle.TotalBody.ToString();
                 lblVehicleArmor.Text = objVehicle.TotalArmor.ToString();
-	            lblVehicleSeats.Text = objVehicle.Seats.ToString();
+	            lblVehicleSeats.Text = objVehicle.TotalSeats.ToString();
 
 				// Update the vehicle mod slots
 				if (objVehicle.IsDrone && GlobalOptions.Instance.Dronemods)

--- a/Chummer/Selection Forms/frmSelectVehicle.Designer.cs
+++ b/Chummer/Selection Forms/frmSelectVehicle.Designer.cs
@@ -28,534 +28,556 @@
 		/// </summary>
 		private void InitializeComponent()
 		{
-			this.components = new System.ComponentModel.Container();
-			this.txtSearch = new System.Windows.Forms.TextBox();
-			this.lblSearchLabel = new System.Windows.Forms.Label();
-			this.lblVehiclePilot = new System.Windows.Forms.Label();
-			this.lblVehiclePilotLabel = new System.Windows.Forms.Label();
-			this.lblVehicleArmor = new System.Windows.Forms.Label();
-			this.lblVehicleArmorLabel = new System.Windows.Forms.Label();
-			this.lblVehicleBody = new System.Windows.Forms.Label();
-			this.lblVehicleBodyLabel = new System.Windows.Forms.Label();
-			this.lblVehicleSpeed = new System.Windows.Forms.Label();
-			this.lblVehicleSpeedLabel = new System.Windows.Forms.Label();
-			this.lblVehicleCost = new System.Windows.Forms.Label();
-			this.lblVehicleCostLabel = new System.Windows.Forms.Label();
-			this.lblVehicleAvail = new System.Windows.Forms.Label();
-			this.lblVehicleAvailLabel = new System.Windows.Forms.Label();
-			this.lblVehicleAccel = new System.Windows.Forms.Label();
-			this.lblVehicleAccelLabel = new System.Windows.Forms.Label();
-			this.lblVehicleHandling = new System.Windows.Forms.Label();
-			this.lblVehicleHandlingLabel = new System.Windows.Forms.Label();
-			this.cmdCancel = new System.Windows.Forms.Button();
-			this.cmdOK = new System.Windows.Forms.Button();
-			this.lstVehicle = new System.Windows.Forms.ListBox();
-			this.lblCategory = new System.Windows.Forms.Label();
-			this.cboCategory = new System.Windows.Forms.ComboBox();
-			this.lblVehicleSensor = new System.Windows.Forms.Label();
-			this.lblVehicleSensorLabel = new System.Windows.Forms.Label();
-			this.cmdOKAdd = new System.Windows.Forms.Button();
-			this.lblSource = new System.Windows.Forms.Label();
-			this.lblSourceLabel = new System.Windows.Forms.Label();
-			this.chkFreeItem = new System.Windows.Forms.CheckBox();
-			this.chkUsedVehicle = new System.Windows.Forms.CheckBox();
-			this.lblUsedVehicleDiscountLabel = new System.Windows.Forms.Label();
-			this.nudUsedVehicleDiscount = new System.Windows.Forms.NumericUpDown();
-			this.lblUsedVehicleDiscountPercentLabel = new System.Windows.Forms.Label();
-			this.nudMarkup = new System.Windows.Forms.NumericUpDown();
-			this.lblMarkupLabel = new System.Windows.Forms.Label();
-			this.lblMarkupPercentLabel = new System.Windows.Forms.Label();
-			this.lblTest = new System.Windows.Forms.Label();
-			this.lblTestLabel = new System.Windows.Forms.Label();
-			this.tipTooltip = new System.Windows.Forms.ToolTip(this.components);
-			this.chkBlackMarketDiscount = new System.Windows.Forms.CheckBox();
-			((System.ComponentModel.ISupportInitialize)(this.nudUsedVehicleDiscount)).BeginInit();
-			((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).BeginInit();
-			this.SuspendLayout();
-			// 
-			// txtSearch
-			// 
-			this.txtSearch.Location = new System.Drawing.Point(553, 6);
-			this.txtSearch.Name = "txtSearch";
-			this.txtSearch.Size = new System.Drawing.Size(174, 20);
-			this.txtSearch.TabIndex = 1;
-			this.txtSearch.TextChanged += new System.EventHandler(this.txtSearch_TextChanged);
-			this.txtSearch.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtSearch_KeyDown);
-			this.txtSearch.KeyUp += new System.Windows.Forms.KeyEventHandler(this.txtSearch_KeyUp);
-			// 
-			// lblSearchLabel
-			// 
-			this.lblSearchLabel.AutoSize = true;
-			this.lblSearchLabel.Location = new System.Drawing.Point(503, 9);
-			this.lblSearchLabel.Name = "lblSearchLabel";
-			this.lblSearchLabel.Size = new System.Drawing.Size(44, 13);
-			this.lblSearchLabel.TabIndex = 0;
-			this.lblSearchLabel.Tag = "Label_Search";
-			this.lblSearchLabel.Text = "&Search:";
-			// 
-			// lblVehiclePilot
-			// 
-			this.lblVehiclePilot.AutoSize = true;
-			this.lblVehiclePilot.Location = new System.Drawing.Point(629, 68);
-			this.lblVehiclePilot.Name = "lblVehiclePilot";
-			this.lblVehiclePilot.Size = new System.Drawing.Size(33, 13);
-			this.lblVehiclePilot.TabIndex = 9;
-			this.lblVehiclePilot.Text = "[Pilot]";
-			// 
-			// lblVehiclePilotLabel
-			// 
-			this.lblVehiclePilotLabel.AutoSize = true;
-			this.lblVehiclePilotLabel.Location = new System.Drawing.Point(572, 68);
-			this.lblVehiclePilotLabel.Name = "lblVehiclePilotLabel";
-			this.lblVehiclePilotLabel.Size = new System.Drawing.Size(30, 13);
-			this.lblVehiclePilotLabel.TabIndex = 8;
-			this.lblVehiclePilotLabel.Tag = "Label_Pilot";
-			this.lblVehiclePilotLabel.Text = "Pilot:";
-			// 
-			// lblVehicleArmor
-			// 
-			this.lblVehicleArmor.AutoSize = true;
-			this.lblVehicleArmor.Location = new System.Drawing.Point(628, 91);
-			this.lblVehicleArmor.Name = "lblVehicleArmor";
-			this.lblVehicleArmor.Size = new System.Drawing.Size(40, 13);
-			this.lblVehicleArmor.TabIndex = 13;
-			this.lblVehicleArmor.Text = "[Armor]";
-			// 
-			// lblVehicleArmorLabel
-			// 
-			this.lblVehicleArmorLabel.AutoSize = true;
-			this.lblVehicleArmorLabel.Location = new System.Drawing.Point(572, 91);
-			this.lblVehicleArmorLabel.Name = "lblVehicleArmorLabel";
-			this.lblVehicleArmorLabel.Size = new System.Drawing.Size(37, 13);
-			this.lblVehicleArmorLabel.TabIndex = 12;
-			this.lblVehicleArmorLabel.Tag = "Label_Armor";
-			this.lblVehicleArmorLabel.Text = "Armor:";
-			// 
-			// lblVehicleBody
-			// 
-			this.lblVehicleBody.AutoSize = true;
-			this.lblVehicleBody.Location = new System.Drawing.Point(478, 91);
-			this.lblVehicleBody.Name = "lblVehicleBody";
-			this.lblVehicleBody.Size = new System.Drawing.Size(37, 13);
-			this.lblVehicleBody.TabIndex = 11;
-			this.lblVehicleBody.Text = "[Body]";
-			// 
-			// lblVehicleBodyLabel
-			// 
-			this.lblVehicleBodyLabel.AutoSize = true;
-			this.lblVehicleBodyLabel.Location = new System.Drawing.Point(421, 91);
-			this.lblVehicleBodyLabel.Name = "lblVehicleBodyLabel";
-			this.lblVehicleBodyLabel.Size = new System.Drawing.Size(34, 13);
-			this.lblVehicleBodyLabel.TabIndex = 10;
-			this.lblVehicleBodyLabel.Tag = "Label_Body";
-			this.lblVehicleBodyLabel.Text = "Body:";
-			// 
-			// lblVehicleSpeed
-			// 
-			this.lblVehicleSpeed.AutoSize = true;
-			this.lblVehicleSpeed.Location = new System.Drawing.Point(478, 68);
-			this.lblVehicleSpeed.Name = "lblVehicleSpeed";
-			this.lblVehicleSpeed.Size = new System.Drawing.Size(44, 13);
-			this.lblVehicleSpeed.TabIndex = 7;
-			this.lblVehicleSpeed.Text = "[Speed]";
-			// 
-			// lblVehicleSpeedLabel
-			// 
-			this.lblVehicleSpeedLabel.AutoSize = true;
-			this.lblVehicleSpeedLabel.Location = new System.Drawing.Point(421, 68);
-			this.lblVehicleSpeedLabel.Name = "lblVehicleSpeedLabel";
-			this.lblVehicleSpeedLabel.Size = new System.Drawing.Size(41, 13);
-			this.lblVehicleSpeedLabel.TabIndex = 6;
-			this.lblVehicleSpeedLabel.Tag = "Label_Speed";
-			this.lblVehicleSpeedLabel.Text = "Speed:";
-			// 
-			// lblVehicleCost
-			// 
-			this.lblVehicleCost.AutoSize = true;
-			this.lblVehicleCost.Location = new System.Drawing.Point(478, 162);
-			this.lblVehicleCost.Name = "lblVehicleCost";
-			this.lblVehicleCost.Size = new System.Drawing.Size(34, 13);
-			this.lblVehicleCost.TabIndex = 21;
-			this.lblVehicleCost.Text = "[Cost]";
-			// 
-			// lblVehicleCostLabel
-			// 
-			this.lblVehicleCostLabel.AutoSize = true;
-			this.lblVehicleCostLabel.Location = new System.Drawing.Point(421, 162);
-			this.lblVehicleCostLabel.Name = "lblVehicleCostLabel";
-			this.lblVehicleCostLabel.Size = new System.Drawing.Size(31, 13);
-			this.lblVehicleCostLabel.TabIndex = 20;
-			this.lblVehicleCostLabel.Tag = "Label_Cost";
-			this.lblVehicleCostLabel.Text = "Cost:";
-			// 
-			// lblVehicleAvail
-			// 
-			this.lblVehicleAvail.AutoSize = true;
-			this.lblVehicleAvail.Location = new System.Drawing.Point(478, 139);
-			this.lblVehicleAvail.Name = "lblVehicleAvail";
-			this.lblVehicleAvail.Size = new System.Drawing.Size(36, 13);
-			this.lblVehicleAvail.TabIndex = 17;
-			this.lblVehicleAvail.Text = "[Avail]";
-			// 
-			// lblVehicleAvailLabel
-			// 
-			this.lblVehicleAvailLabel.AutoSize = true;
-			this.lblVehicleAvailLabel.Location = new System.Drawing.Point(421, 139);
-			this.lblVehicleAvailLabel.Name = "lblVehicleAvailLabel";
-			this.lblVehicleAvailLabel.Size = new System.Drawing.Size(33, 13);
-			this.lblVehicleAvailLabel.TabIndex = 16;
-			this.lblVehicleAvailLabel.Tag = "Label_Avail";
-			this.lblVehicleAvailLabel.Text = "Avail:";
-			// 
-			// lblVehicleAccel
-			// 
-			this.lblVehicleAccel.AutoSize = true;
-			this.lblVehicleAccel.Location = new System.Drawing.Point(629, 45);
-			this.lblVehicleAccel.Name = "lblVehicleAccel";
-			this.lblVehicleAccel.Size = new System.Drawing.Size(40, 13);
-			this.lblVehicleAccel.TabIndex = 5;
-			this.lblVehicleAccel.Text = "[Accel]";
-			// 
-			// lblVehicleAccelLabel
-			// 
-			this.lblVehicleAccelLabel.AutoSize = true;
-			this.lblVehicleAccelLabel.Location = new System.Drawing.Point(572, 45);
-			this.lblVehicleAccelLabel.Name = "lblVehicleAccelLabel";
-			this.lblVehicleAccelLabel.Size = new System.Drawing.Size(37, 13);
-			this.lblVehicleAccelLabel.TabIndex = 4;
-			this.lblVehicleAccelLabel.Tag = "Label_Accel";
-			this.lblVehicleAccelLabel.Text = "Accel:";
-			// 
-			// lblVehicleHandling
-			// 
-			this.lblVehicleHandling.AutoSize = true;
-			this.lblVehicleHandling.Location = new System.Drawing.Point(478, 45);
-			this.lblVehicleHandling.Name = "lblVehicleHandling";
-			this.lblVehicleHandling.Size = new System.Drawing.Size(55, 13);
-			this.lblVehicleHandling.TabIndex = 3;
-			this.lblVehicleHandling.Text = "[Handling]";
-			// 
-			// lblVehicleHandlingLabel
-			// 
-			this.lblVehicleHandlingLabel.AutoSize = true;
-			this.lblVehicleHandlingLabel.Location = new System.Drawing.Point(421, 45);
-			this.lblVehicleHandlingLabel.Name = "lblVehicleHandlingLabel";
-			this.lblVehicleHandlingLabel.Size = new System.Drawing.Size(52, 13);
-			this.lblVehicleHandlingLabel.TabIndex = 2;
-			this.lblVehicleHandlingLabel.Tag = "Label_Handling";
-			this.lblVehicleHandlingLabel.Text = "Handling:";
-			// 
-			// cmdCancel
-			// 
-			this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cmdCancel.Location = new System.Drawing.Point(567, 378);
-			this.cmdCancel.Name = "cmdCancel";
-			this.cmdCancel.Size = new System.Drawing.Size(75, 23);
-			this.cmdCancel.TabIndex = 37;
-			this.cmdCancel.Tag = "String_Cancel";
-			this.cmdCancel.Text = "Cancel";
-			this.cmdCancel.UseVisualStyleBackColor = true;
-			this.cmdCancel.Click += new System.EventHandler(this.cmdCancel_Click);
-			// 
-			// cmdOK
-			// 
-			this.cmdOK.Location = new System.Drawing.Point(648, 378);
-			this.cmdOK.Name = "cmdOK";
-			this.cmdOK.Size = new System.Drawing.Size(75, 23);
-			this.cmdOK.TabIndex = 35;
-			this.cmdOK.Tag = "String_OK";
-			this.cmdOK.Text = "OK";
-			this.cmdOK.UseVisualStyleBackColor = true;
-			this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
-			// 
-			// lstVehicle
-			// 
-			this.lstVehicle.FormattingEnabled = true;
-			this.lstVehicle.Location = new System.Drawing.Point(12, 33);
-			this.lstVehicle.Name = "lstVehicle";
-			this.lstVehicle.Size = new System.Drawing.Size(403, 368);
-			this.lstVehicle.TabIndex = 32;
-			this.lstVehicle.SelectedIndexChanged += new System.EventHandler(this.lstVehicle_SelectedIndexChanged);
-			this.lstVehicle.DoubleClick += new System.EventHandler(this.lstVehicle_DoubleClick);
-			// 
-			// lblCategory
-			// 
-			this.lblCategory.AutoSize = true;
-			this.lblCategory.Location = new System.Drawing.Point(12, 9);
-			this.lblCategory.Name = "lblCategory";
-			this.lblCategory.Size = new System.Drawing.Size(52, 13);
-			this.lblCategory.TabIndex = 33;
-			this.lblCategory.Tag = "Label_Category";
-			this.lblCategory.Text = "Category:";
-			// 
-			// cboCategory
-			// 
-			this.cboCategory.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
-			this.cboCategory.FormattingEnabled = true;
-			this.cboCategory.Location = new System.Drawing.Point(70, 6);
-			this.cboCategory.Name = "cboCategory";
-			this.cboCategory.Size = new System.Drawing.Size(235, 21);
-			this.cboCategory.TabIndex = 34;
-			this.cboCategory.SelectedIndexChanged += new System.EventHandler(this.cboCategory_SelectedIndexChanged);
-			// 
-			// lblVehicleSensor
-			// 
-			this.lblVehicleSensor.AutoSize = true;
-			this.lblVehicleSensor.Location = new System.Drawing.Point(478, 114);
-			this.lblVehicleSensor.Name = "lblVehicleSensor";
-			this.lblVehicleSensor.Size = new System.Drawing.Size(46, 13);
-			this.lblVehicleSensor.TabIndex = 15;
-			this.lblVehicleSensor.Text = "[Sensor]";
-			// 
-			// lblVehicleSensorLabel
-			// 
-			this.lblVehicleSensorLabel.AutoSize = true;
-			this.lblVehicleSensorLabel.Location = new System.Drawing.Point(421, 114);
-			this.lblVehicleSensorLabel.Name = "lblVehicleSensorLabel";
-			this.lblVehicleSensorLabel.Size = new System.Drawing.Size(43, 13);
-			this.lblVehicleSensorLabel.TabIndex = 14;
-			this.lblVehicleSensorLabel.Tag = "Label_Sensor";
-			this.lblVehicleSensorLabel.Text = "Sensor:";
-			// 
-			// cmdOKAdd
-			// 
-			this.cmdOKAdd.Location = new System.Drawing.Point(648, 349);
-			this.cmdOKAdd.Name = "cmdOKAdd";
-			this.cmdOKAdd.Size = new System.Drawing.Size(75, 23);
-			this.cmdOKAdd.TabIndex = 36;
-			this.cmdOKAdd.Tag = "String_AddMore";
-			this.cmdOKAdd.Text = "&Add && More";
-			this.cmdOKAdd.UseVisualStyleBackColor = true;
-			this.cmdOKAdd.Click += new System.EventHandler(this.cmdOKAdd_Click);
-			// 
-			// lblSource
-			// 
-			this.lblSource.AutoSize = true;
-			this.lblSource.Location = new System.Drawing.Point(472, 297);
-			this.lblSource.Name = "lblSource";
-			this.lblSource.Size = new System.Drawing.Size(47, 13);
-			this.lblSource.TabIndex = 31;
-			this.lblSource.Text = "[Source]";
-			this.lblSource.Click += new System.EventHandler(this.lblSource_Click);
-			// 
-			// lblSourceLabel
-			// 
-			this.lblSourceLabel.AutoSize = true;
-			this.lblSourceLabel.Location = new System.Drawing.Point(421, 297);
-			this.lblSourceLabel.Name = "lblSourceLabel";
-			this.lblSourceLabel.Size = new System.Drawing.Size(44, 13);
-			this.lblSourceLabel.TabIndex = 30;
-			this.lblSourceLabel.Tag = "Label_Source";
-			this.lblSourceLabel.Text = "Source:";
-			// 
-			// chkFreeItem
-			// 
-			this.chkFreeItem.AutoSize = true;
-			this.chkFreeItem.Location = new System.Drawing.Point(421, 234);
-			this.chkFreeItem.Name = "chkFreeItem";
-			this.chkFreeItem.Size = new System.Drawing.Size(50, 17);
-			this.chkFreeItem.TabIndex = 26;
-			this.chkFreeItem.Tag = "Checkbox_Free";
-			this.chkFreeItem.Text = "Free!";
-			this.chkFreeItem.UseVisualStyleBackColor = true;
-			this.chkFreeItem.Visible = true;
-			this.chkFreeItem.CheckedChanged += new System.EventHandler(this.chkFreeItem_CheckedChanged);
-			// 
-			// chkUsedVehicle
-			// 
-			this.chkUsedVehicle.AutoSize = true;
-			this.chkUsedVehicle.Location = new System.Drawing.Point(421, 207);
-			this.chkUsedVehicle.Name = "chkUsedVehicle";
-			this.chkUsedVehicle.Size = new System.Drawing.Size(89, 17);
-			this.chkUsedVehicle.TabIndex = 22;
-			this.chkUsedVehicle.Tag = "Checkbox_SelectVehicle_UsedVehicle";
-			this.chkUsedVehicle.Text = "Used Vehicle";
-			this.chkUsedVehicle.UseVisualStyleBackColor = true;
-			this.chkUsedVehicle.Visible = false;
-			this.chkUsedVehicle.CheckedChanged += new System.EventHandler(this.chkUsedVehicle_CheckedChanged);
-			// 
-			// lblUsedVehicleDiscountLabel
-			// 
-			this.lblUsedVehicleDiscountLabel.AutoSize = true;
-			this.lblUsedVehicleDiscountLabel.Location = new System.Drawing.Point(519, 208);
-			this.lblUsedVehicleDiscountLabel.Name = "lblUsedVehicleDiscountLabel";
-			this.lblUsedVehicleDiscountLabel.Size = new System.Drawing.Size(52, 13);
-			this.lblUsedVehicleDiscountLabel.TabIndex = 23;
-			this.lblUsedVehicleDiscountLabel.Tag = "Label_SelectVehicle_Discount";
-			this.lblUsedVehicleDiscountLabel.Text = "Discount:";
-			this.lblUsedVehicleDiscountLabel.Visible = false;
-			// 
-			// nudUsedVehicleDiscount
-			// 
-			this.nudUsedVehicleDiscount.Location = new System.Drawing.Point(577, 206);
-			this.nudUsedVehicleDiscount.Maximum = new decimal(new int[] {
+            this.components = new System.ComponentModel.Container();
+            this.txtSearch = new System.Windows.Forms.TextBox();
+            this.lblSearchLabel = new System.Windows.Forms.Label();
+            this.lblVehiclePilot = new System.Windows.Forms.Label();
+            this.lblVehiclePilotLabel = new System.Windows.Forms.Label();
+            this.lblVehicleArmor = new System.Windows.Forms.Label();
+            this.lblVehicleArmorLabel = new System.Windows.Forms.Label();
+            this.lblVehicleBody = new System.Windows.Forms.Label();
+            this.lblVehicleBodyLabel = new System.Windows.Forms.Label();
+            this.lblVehicleSpeed = new System.Windows.Forms.Label();
+            this.lblVehicleSpeedLabel = new System.Windows.Forms.Label();
+            this.lblVehicleCost = new System.Windows.Forms.Label();
+            this.lblVehicleCostLabel = new System.Windows.Forms.Label();
+            this.lblVehicleAvail = new System.Windows.Forms.Label();
+            this.lblVehicleAvailLabel = new System.Windows.Forms.Label();
+            this.lblVehicleAccel = new System.Windows.Forms.Label();
+            this.lblVehicleAccelLabel = new System.Windows.Forms.Label();
+            this.lblVehicleHandling = new System.Windows.Forms.Label();
+            this.lblVehicleHandlingLabel = new System.Windows.Forms.Label();
+            this.cmdCancel = new System.Windows.Forms.Button();
+            this.cmdOK = new System.Windows.Forms.Button();
+            this.lstVehicle = new System.Windows.Forms.ListBox();
+            this.lblCategory = new System.Windows.Forms.Label();
+            this.cboCategory = new System.Windows.Forms.ComboBox();
+            this.lblVehicleSensor = new System.Windows.Forms.Label();
+            this.lblVehicleSensorLabel = new System.Windows.Forms.Label();
+            this.cmdOKAdd = new System.Windows.Forms.Button();
+            this.lblSource = new System.Windows.Forms.Label();
+            this.lblSourceLabel = new System.Windows.Forms.Label();
+            this.chkFreeItem = new System.Windows.Forms.CheckBox();
+            this.chkUsedVehicle = new System.Windows.Forms.CheckBox();
+            this.lblUsedVehicleDiscountLabel = new System.Windows.Forms.Label();
+            this.nudUsedVehicleDiscount = new System.Windows.Forms.NumericUpDown();
+            this.lblUsedVehicleDiscountPercentLabel = new System.Windows.Forms.Label();
+            this.nudMarkup = new System.Windows.Forms.NumericUpDown();
+            this.lblMarkupLabel = new System.Windows.Forms.Label();
+            this.lblMarkupPercentLabel = new System.Windows.Forms.Label();
+            this.lblTest = new System.Windows.Forms.Label();
+            this.lblTestLabel = new System.Windows.Forms.Label();
+            this.tipTooltip = new System.Windows.Forms.ToolTip(this.components);
+            this.chkBlackMarketDiscount = new System.Windows.Forms.CheckBox();
+            this.lblVehicleSeatsLabel = new System.Windows.Forms.Label();
+            this.lblVehicleSeats = new System.Windows.Forms.Label();
+            ((System.ComponentModel.ISupportInitialize)(this.nudUsedVehicleDiscount)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).BeginInit();
+            this.SuspendLayout();
+            // 
+            // txtSearch
+            // 
+            this.txtSearch.Location = new System.Drawing.Point(553, 6);
+            this.txtSearch.Name = "txtSearch";
+            this.txtSearch.Size = new System.Drawing.Size(174, 20);
+            this.txtSearch.TabIndex = 1;
+            this.txtSearch.TextChanged += new System.EventHandler(this.txtSearch_TextChanged);
+            this.txtSearch.KeyDown += new System.Windows.Forms.KeyEventHandler(this.txtSearch_KeyDown);
+            this.txtSearch.KeyUp += new System.Windows.Forms.KeyEventHandler(this.txtSearch_KeyUp);
+            // 
+            // lblSearchLabel
+            // 
+            this.lblSearchLabel.AutoSize = true;
+            this.lblSearchLabel.Location = new System.Drawing.Point(503, 9);
+            this.lblSearchLabel.Name = "lblSearchLabel";
+            this.lblSearchLabel.Size = new System.Drawing.Size(44, 13);
+            this.lblSearchLabel.TabIndex = 0;
+            this.lblSearchLabel.Tag = "Label_Search";
+            this.lblSearchLabel.Text = "&Search:";
+            // 
+            // lblVehiclePilot
+            // 
+            this.lblVehiclePilot.AutoSize = true;
+            this.lblVehiclePilot.Location = new System.Drawing.Point(629, 68);
+            this.lblVehiclePilot.Name = "lblVehiclePilot";
+            this.lblVehiclePilot.Size = new System.Drawing.Size(33, 13);
+            this.lblVehiclePilot.TabIndex = 9;
+            this.lblVehiclePilot.Text = "[Pilot]";
+            // 
+            // lblVehiclePilotLabel
+            // 
+            this.lblVehiclePilotLabel.AutoSize = true;
+            this.lblVehiclePilotLabel.Location = new System.Drawing.Point(572, 68);
+            this.lblVehiclePilotLabel.Name = "lblVehiclePilotLabel";
+            this.lblVehiclePilotLabel.Size = new System.Drawing.Size(30, 13);
+            this.lblVehiclePilotLabel.TabIndex = 8;
+            this.lblVehiclePilotLabel.Tag = "Label_Pilot";
+            this.lblVehiclePilotLabel.Text = "Pilot:";
+            // 
+            // lblVehicleArmor
+            // 
+            this.lblVehicleArmor.AutoSize = true;
+            this.lblVehicleArmor.Location = new System.Drawing.Point(628, 91);
+            this.lblVehicleArmor.Name = "lblVehicleArmor";
+            this.lblVehicleArmor.Size = new System.Drawing.Size(40, 13);
+            this.lblVehicleArmor.TabIndex = 13;
+            this.lblVehicleArmor.Text = "[Armor]";
+            // 
+            // lblVehicleArmorLabel
+            // 
+            this.lblVehicleArmorLabel.AutoSize = true;
+            this.lblVehicleArmorLabel.Location = new System.Drawing.Point(572, 91);
+            this.lblVehicleArmorLabel.Name = "lblVehicleArmorLabel";
+            this.lblVehicleArmorLabel.Size = new System.Drawing.Size(37, 13);
+            this.lblVehicleArmorLabel.TabIndex = 12;
+            this.lblVehicleArmorLabel.Tag = "Label_Armor";
+            this.lblVehicleArmorLabel.Text = "Armor:";
+            // 
+            // lblVehicleBody
+            // 
+            this.lblVehicleBody.AutoSize = true;
+            this.lblVehicleBody.Location = new System.Drawing.Point(478, 91);
+            this.lblVehicleBody.Name = "lblVehicleBody";
+            this.lblVehicleBody.Size = new System.Drawing.Size(37, 13);
+            this.lblVehicleBody.TabIndex = 11;
+            this.lblVehicleBody.Text = "[Body]";
+            // 
+            // lblVehicleBodyLabel
+            // 
+            this.lblVehicleBodyLabel.AutoSize = true;
+            this.lblVehicleBodyLabel.Location = new System.Drawing.Point(421, 91);
+            this.lblVehicleBodyLabel.Name = "lblVehicleBodyLabel";
+            this.lblVehicleBodyLabel.Size = new System.Drawing.Size(34, 13);
+            this.lblVehicleBodyLabel.TabIndex = 10;
+            this.lblVehicleBodyLabel.Tag = "Label_Body";
+            this.lblVehicleBodyLabel.Text = "Body:";
+            // 
+            // lblVehicleSpeed
+            // 
+            this.lblVehicleSpeed.AutoSize = true;
+            this.lblVehicleSpeed.Location = new System.Drawing.Point(478, 68);
+            this.lblVehicleSpeed.Name = "lblVehicleSpeed";
+            this.lblVehicleSpeed.Size = new System.Drawing.Size(44, 13);
+            this.lblVehicleSpeed.TabIndex = 7;
+            this.lblVehicleSpeed.Text = "[Speed]";
+            // 
+            // lblVehicleSpeedLabel
+            // 
+            this.lblVehicleSpeedLabel.AutoSize = true;
+            this.lblVehicleSpeedLabel.Location = new System.Drawing.Point(421, 68);
+            this.lblVehicleSpeedLabel.Name = "lblVehicleSpeedLabel";
+            this.lblVehicleSpeedLabel.Size = new System.Drawing.Size(41, 13);
+            this.lblVehicleSpeedLabel.TabIndex = 6;
+            this.lblVehicleSpeedLabel.Tag = "Label_Speed";
+            this.lblVehicleSpeedLabel.Text = "Speed:";
+            // 
+            // lblVehicleCost
+            // 
+            this.lblVehicleCost.AutoSize = true;
+            this.lblVehicleCost.Location = new System.Drawing.Point(478, 162);
+            this.lblVehicleCost.Name = "lblVehicleCost";
+            this.lblVehicleCost.Size = new System.Drawing.Size(34, 13);
+            this.lblVehicleCost.TabIndex = 21;
+            this.lblVehicleCost.Text = "[Cost]";
+            // 
+            // lblVehicleCostLabel
+            // 
+            this.lblVehicleCostLabel.AutoSize = true;
+            this.lblVehicleCostLabel.Location = new System.Drawing.Point(421, 162);
+            this.lblVehicleCostLabel.Name = "lblVehicleCostLabel";
+            this.lblVehicleCostLabel.Size = new System.Drawing.Size(31, 13);
+            this.lblVehicleCostLabel.TabIndex = 20;
+            this.lblVehicleCostLabel.Tag = "Label_Cost";
+            this.lblVehicleCostLabel.Text = "Cost:";
+            // 
+            // lblVehicleAvail
+            // 
+            this.lblVehicleAvail.AutoSize = true;
+            this.lblVehicleAvail.Location = new System.Drawing.Point(478, 139);
+            this.lblVehicleAvail.Name = "lblVehicleAvail";
+            this.lblVehicleAvail.Size = new System.Drawing.Size(36, 13);
+            this.lblVehicleAvail.TabIndex = 17;
+            this.lblVehicleAvail.Text = "[Avail]";
+            // 
+            // lblVehicleAvailLabel
+            // 
+            this.lblVehicleAvailLabel.AutoSize = true;
+            this.lblVehicleAvailLabel.Location = new System.Drawing.Point(421, 139);
+            this.lblVehicleAvailLabel.Name = "lblVehicleAvailLabel";
+            this.lblVehicleAvailLabel.Size = new System.Drawing.Size(33, 13);
+            this.lblVehicleAvailLabel.TabIndex = 16;
+            this.lblVehicleAvailLabel.Tag = "Label_Avail";
+            this.lblVehicleAvailLabel.Text = "Avail:";
+            // 
+            // lblVehicleAccel
+            // 
+            this.lblVehicleAccel.AutoSize = true;
+            this.lblVehicleAccel.Location = new System.Drawing.Point(629, 45);
+            this.lblVehicleAccel.Name = "lblVehicleAccel";
+            this.lblVehicleAccel.Size = new System.Drawing.Size(40, 13);
+            this.lblVehicleAccel.TabIndex = 5;
+            this.lblVehicleAccel.Text = "[Accel]";
+            // 
+            // lblVehicleAccelLabel
+            // 
+            this.lblVehicleAccelLabel.AutoSize = true;
+            this.lblVehicleAccelLabel.Location = new System.Drawing.Point(572, 45);
+            this.lblVehicleAccelLabel.Name = "lblVehicleAccelLabel";
+            this.lblVehicleAccelLabel.Size = new System.Drawing.Size(37, 13);
+            this.lblVehicleAccelLabel.TabIndex = 4;
+            this.lblVehicleAccelLabel.Tag = "Label_Accel";
+            this.lblVehicleAccelLabel.Text = "Accel:";
+            // 
+            // lblVehicleHandling
+            // 
+            this.lblVehicleHandling.AutoSize = true;
+            this.lblVehicleHandling.Location = new System.Drawing.Point(478, 45);
+            this.lblVehicleHandling.Name = "lblVehicleHandling";
+            this.lblVehicleHandling.Size = new System.Drawing.Size(55, 13);
+            this.lblVehicleHandling.TabIndex = 3;
+            this.lblVehicleHandling.Text = "[Handling]";
+            // 
+            // lblVehicleHandlingLabel
+            // 
+            this.lblVehicleHandlingLabel.AutoSize = true;
+            this.lblVehicleHandlingLabel.Location = new System.Drawing.Point(421, 45);
+            this.lblVehicleHandlingLabel.Name = "lblVehicleHandlingLabel";
+            this.lblVehicleHandlingLabel.Size = new System.Drawing.Size(52, 13);
+            this.lblVehicleHandlingLabel.TabIndex = 2;
+            this.lblVehicleHandlingLabel.Tag = "Label_Handling";
+            this.lblVehicleHandlingLabel.Text = "Handling:";
+            // 
+            // cmdCancel
+            // 
+            this.cmdCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.cmdCancel.Location = new System.Drawing.Point(567, 378);
+            this.cmdCancel.Name = "cmdCancel";
+            this.cmdCancel.Size = new System.Drawing.Size(75, 23);
+            this.cmdCancel.TabIndex = 37;
+            this.cmdCancel.Tag = "String_Cancel";
+            this.cmdCancel.Text = "Cancel";
+            this.cmdCancel.UseVisualStyleBackColor = true;
+            this.cmdCancel.Click += new System.EventHandler(this.cmdCancel_Click);
+            // 
+            // cmdOK
+            // 
+            this.cmdOK.Location = new System.Drawing.Point(648, 378);
+            this.cmdOK.Name = "cmdOK";
+            this.cmdOK.Size = new System.Drawing.Size(75, 23);
+            this.cmdOK.TabIndex = 35;
+            this.cmdOK.Tag = "String_OK";
+            this.cmdOK.Text = "OK";
+            this.cmdOK.UseVisualStyleBackColor = true;
+            this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
+            // 
+            // lstVehicle
+            // 
+            this.lstVehicle.FormattingEnabled = true;
+            this.lstVehicle.Location = new System.Drawing.Point(12, 33);
+            this.lstVehicle.Name = "lstVehicle";
+            this.lstVehicle.Size = new System.Drawing.Size(403, 368);
+            this.lstVehicle.TabIndex = 32;
+            this.lstVehicle.SelectedIndexChanged += new System.EventHandler(this.lstVehicle_SelectedIndexChanged);
+            this.lstVehicle.DoubleClick += new System.EventHandler(this.lstVehicle_DoubleClick);
+            // 
+            // lblCategory
+            // 
+            this.lblCategory.AutoSize = true;
+            this.lblCategory.Location = new System.Drawing.Point(12, 9);
+            this.lblCategory.Name = "lblCategory";
+            this.lblCategory.Size = new System.Drawing.Size(52, 13);
+            this.lblCategory.TabIndex = 33;
+            this.lblCategory.Tag = "Label_Category";
+            this.lblCategory.Text = "Category:";
+            // 
+            // cboCategory
+            // 
+            this.cboCategory.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.cboCategory.FormattingEnabled = true;
+            this.cboCategory.Location = new System.Drawing.Point(70, 6);
+            this.cboCategory.Name = "cboCategory";
+            this.cboCategory.Size = new System.Drawing.Size(235, 21);
+            this.cboCategory.TabIndex = 34;
+            this.cboCategory.SelectedIndexChanged += new System.EventHandler(this.cboCategory_SelectedIndexChanged);
+            // 
+            // lblVehicleSensor
+            // 
+            this.lblVehicleSensor.AutoSize = true;
+            this.lblVehicleSensor.Location = new System.Drawing.Point(478, 114);
+            this.lblVehicleSensor.Name = "lblVehicleSensor";
+            this.lblVehicleSensor.Size = new System.Drawing.Size(46, 13);
+            this.lblVehicleSensor.TabIndex = 15;
+            this.lblVehicleSensor.Text = "[Sensor]";
+            // 
+            // lblVehicleSensorLabel
+            // 
+            this.lblVehicleSensorLabel.AutoSize = true;
+            this.lblVehicleSensorLabel.Location = new System.Drawing.Point(421, 114);
+            this.lblVehicleSensorLabel.Name = "lblVehicleSensorLabel";
+            this.lblVehicleSensorLabel.Size = new System.Drawing.Size(43, 13);
+            this.lblVehicleSensorLabel.TabIndex = 14;
+            this.lblVehicleSensorLabel.Tag = "Label_Sensor";
+            this.lblVehicleSensorLabel.Text = "Sensor:";
+            // 
+            // cmdOKAdd
+            // 
+            this.cmdOKAdd.Location = new System.Drawing.Point(648, 349);
+            this.cmdOKAdd.Name = "cmdOKAdd";
+            this.cmdOKAdd.Size = new System.Drawing.Size(75, 23);
+            this.cmdOKAdd.TabIndex = 36;
+            this.cmdOKAdd.Tag = "String_AddMore";
+            this.cmdOKAdd.Text = "&Add && More";
+            this.cmdOKAdd.UseVisualStyleBackColor = true;
+            this.cmdOKAdd.Click += new System.EventHandler(this.cmdOKAdd_Click);
+            // 
+            // lblSource
+            // 
+            this.lblSource.AutoSize = true;
+            this.lblSource.Location = new System.Drawing.Point(472, 297);
+            this.lblSource.Name = "lblSource";
+            this.lblSource.Size = new System.Drawing.Size(47, 13);
+            this.lblSource.TabIndex = 31;
+            this.lblSource.Text = "[Source]";
+            this.lblSource.Click += new System.EventHandler(this.lblSource_Click);
+            // 
+            // lblSourceLabel
+            // 
+            this.lblSourceLabel.AutoSize = true;
+            this.lblSourceLabel.Location = new System.Drawing.Point(421, 297);
+            this.lblSourceLabel.Name = "lblSourceLabel";
+            this.lblSourceLabel.Size = new System.Drawing.Size(44, 13);
+            this.lblSourceLabel.TabIndex = 30;
+            this.lblSourceLabel.Tag = "Label_Source";
+            this.lblSourceLabel.Text = "Source:";
+            // 
+            // chkFreeItem
+            // 
+            this.chkFreeItem.AutoSize = true;
+            this.chkFreeItem.Location = new System.Drawing.Point(421, 234);
+            this.chkFreeItem.Name = "chkFreeItem";
+            this.chkFreeItem.Size = new System.Drawing.Size(50, 17);
+            this.chkFreeItem.TabIndex = 26;
+            this.chkFreeItem.Tag = "Checkbox_Free";
+            this.chkFreeItem.Text = "Free!";
+            this.chkFreeItem.UseVisualStyleBackColor = true;
+            this.chkFreeItem.CheckedChanged += new System.EventHandler(this.chkFreeItem_CheckedChanged);
+            // 
+            // chkUsedVehicle
+            // 
+            this.chkUsedVehicle.AutoSize = true;
+            this.chkUsedVehicle.Location = new System.Drawing.Point(421, 207);
+            this.chkUsedVehicle.Name = "chkUsedVehicle";
+            this.chkUsedVehicle.Size = new System.Drawing.Size(89, 17);
+            this.chkUsedVehicle.TabIndex = 22;
+            this.chkUsedVehicle.Tag = "Checkbox_SelectVehicle_UsedVehicle";
+            this.chkUsedVehicle.Text = "Used Vehicle";
+            this.chkUsedVehicle.UseVisualStyleBackColor = true;
+            this.chkUsedVehicle.Visible = false;
+            this.chkUsedVehicle.CheckedChanged += new System.EventHandler(this.chkUsedVehicle_CheckedChanged);
+            // 
+            // lblUsedVehicleDiscountLabel
+            // 
+            this.lblUsedVehicleDiscountLabel.AutoSize = true;
+            this.lblUsedVehicleDiscountLabel.Location = new System.Drawing.Point(519, 208);
+            this.lblUsedVehicleDiscountLabel.Name = "lblUsedVehicleDiscountLabel";
+            this.lblUsedVehicleDiscountLabel.Size = new System.Drawing.Size(52, 13);
+            this.lblUsedVehicleDiscountLabel.TabIndex = 23;
+            this.lblUsedVehicleDiscountLabel.Tag = "Label_SelectVehicle_Discount";
+            this.lblUsedVehicleDiscountLabel.Text = "Discount:";
+            this.lblUsedVehicleDiscountLabel.Visible = false;
+            // 
+            // nudUsedVehicleDiscount
+            // 
+            this.nudUsedVehicleDiscount.Location = new System.Drawing.Point(577, 206);
+            this.nudUsedVehicleDiscount.Maximum = new decimal(new int[] {
             50,
             0,
             0,
             0});
-			this.nudUsedVehicleDiscount.Minimum = new decimal(new int[] {
+            this.nudUsedVehicleDiscount.Minimum = new decimal(new int[] {
             20,
             0,
             0,
             0});
-			this.nudUsedVehicleDiscount.Name = "nudUsedVehicleDiscount";
-			this.nudUsedVehicleDiscount.Size = new System.Drawing.Size(41, 20);
-			this.nudUsedVehicleDiscount.TabIndex = 24;
-			this.nudUsedVehicleDiscount.Value = new decimal(new int[] {
+            this.nudUsedVehicleDiscount.Name = "nudUsedVehicleDiscount";
+            this.nudUsedVehicleDiscount.Size = new System.Drawing.Size(41, 20);
+            this.nudUsedVehicleDiscount.TabIndex = 24;
+            this.nudUsedVehicleDiscount.Value = new decimal(new int[] {
             20,
             0,
             0,
             0});
-			this.nudUsedVehicleDiscount.Visible = false;
-			this.nudUsedVehicleDiscount.ValueChanged += new System.EventHandler(this.nudUsedVehicleDiscount_ValueChanged);
-			// 
-			// lblUsedVehicleDiscountPercentLabel
-			// 
-			this.lblUsedVehicleDiscountPercentLabel.AutoSize = true;
-			this.lblUsedVehicleDiscountPercentLabel.Location = new System.Drawing.Point(617, 208);
-			this.lblUsedVehicleDiscountPercentLabel.Name = "lblUsedVehicleDiscountPercentLabel";
-			this.lblUsedVehicleDiscountPercentLabel.Size = new System.Drawing.Size(15, 13);
-			this.lblUsedVehicleDiscountPercentLabel.TabIndex = 25;
-			this.lblUsedVehicleDiscountPercentLabel.Text = "%";
-			this.lblUsedVehicleDiscountPercentLabel.Visible = false;
-			// 
-			// nudMarkup
-			// 
-			this.nudMarkup.Location = new System.Drawing.Point(481, 257);
-			this.nudMarkup.Maximum = new decimal(new int[] {
+            this.nudUsedVehicleDiscount.Visible = false;
+            this.nudUsedVehicleDiscount.ValueChanged += new System.EventHandler(this.nudUsedVehicleDiscount_ValueChanged);
+            // 
+            // lblUsedVehicleDiscountPercentLabel
+            // 
+            this.lblUsedVehicleDiscountPercentLabel.AutoSize = true;
+            this.lblUsedVehicleDiscountPercentLabel.Location = new System.Drawing.Point(617, 208);
+            this.lblUsedVehicleDiscountPercentLabel.Name = "lblUsedVehicleDiscountPercentLabel";
+            this.lblUsedVehicleDiscountPercentLabel.Size = new System.Drawing.Size(15, 13);
+            this.lblUsedVehicleDiscountPercentLabel.TabIndex = 25;
+            this.lblUsedVehicleDiscountPercentLabel.Text = "%";
+            this.lblUsedVehicleDiscountPercentLabel.Visible = false;
+            // 
+            // nudMarkup
+            // 
+            this.nudMarkup.Location = new System.Drawing.Point(481, 257);
+            this.nudMarkup.Maximum = new decimal(new int[] {
             1000,
             0,
             0,
             0});
-			this.nudMarkup.Minimum = new decimal(new int[] {
+            this.nudMarkup.Minimum = new decimal(new int[] {
             99,
             0,
             0,
             -2147483648});
-			this.nudMarkup.Name = "nudMarkup";
-			this.nudMarkup.Size = new System.Drawing.Size(56, 20);
-			this.nudMarkup.TabIndex = 28;
-			this.nudMarkup.ValueChanged += new System.EventHandler(this.nudMarkup_ValueChanged);
-			// 
-			// lblMarkupLabel
-			// 
-			this.lblMarkupLabel.AutoSize = true;
-			this.lblMarkupLabel.Location = new System.Drawing.Point(421, 259);
-			this.lblMarkupLabel.Name = "lblMarkupLabel";
-			this.lblMarkupLabel.Size = new System.Drawing.Size(46, 13);
-			this.lblMarkupLabel.TabIndex = 27;
-			this.lblMarkupLabel.Tag = "Label_SelectGear_Markup";
-			this.lblMarkupLabel.Text = "Markup:";
-			// 
-			// lblMarkupPercentLabel
-			// 
-			this.lblMarkupPercentLabel.AutoSize = true;
-			this.lblMarkupPercentLabel.Location = new System.Drawing.Point(536, 259);
-			this.lblMarkupPercentLabel.Name = "lblMarkupPercentLabel";
-			this.lblMarkupPercentLabel.Size = new System.Drawing.Size(15, 13);
-			this.lblMarkupPercentLabel.TabIndex = 29;
-			this.lblMarkupPercentLabel.Text = "%";
-			// 
-			// lblTest
-			// 
-			this.lblTest.AutoSize = true;
-			this.lblTest.Location = new System.Drawing.Point(579, 139);
-			this.lblTest.Name = "lblTest";
-			this.lblTest.Size = new System.Drawing.Size(19, 13);
-			this.lblTest.TabIndex = 19;
-			this.lblTest.Text = "[0]";
-			// 
-			// lblTestLabel
-			// 
-			this.lblTestLabel.AutoSize = true;
-			this.lblTestLabel.Location = new System.Drawing.Point(534, 139);
-			this.lblTestLabel.Name = "lblTestLabel";
-			this.lblTestLabel.Size = new System.Drawing.Size(31, 13);
-			this.lblTestLabel.TabIndex = 18;
-			this.lblTestLabel.Tag = "Label_Test";
-			this.lblTestLabel.Text = "Test:";
-			// 
-			// tipTooltip
-			// 
-			this.tipTooltip.AutoPopDelay = 10000;
-			this.tipTooltip.InitialDelay = 250;
-			this.tipTooltip.IsBalloon = true;
-			this.tipTooltip.ReshowDelay = 100;
-			this.tipTooltip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
-			this.tipTooltip.ToolTipTitle = "Chummer Help";
-			// 
-			// chkBlackMarketDiscount
-			// 
-			this.chkBlackMarketDiscount.AutoSize = true;
-			this.chkBlackMarketDiscount.Location = new System.Drawing.Point(421, 184);
-			this.chkBlackMarketDiscount.Name = "chkBlackMarketDiscount";
-			this.chkBlackMarketDiscount.Size = new System.Drawing.Size(163, 17);
-			this.chkBlackMarketDiscount.TabIndex = 38;
-			this.chkBlackMarketDiscount.Tag = "Checkbox_BlackMarketDiscount";
-			this.chkBlackMarketDiscount.Text = "Black Market Discount (10%)";
-			this.chkBlackMarketDiscount.UseVisualStyleBackColor = true;
-			this.chkBlackMarketDiscount.Visible = false;
-			this.chkBlackMarketDiscount.CheckedChanged += new System.EventHandler(this.chkBlackMarketDiscount_CheckedChanged);
-			// 
-			// frmSelectVehicle
-			// 
-			this.AcceptButton = this.cmdOK;
-			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.CancelButton = this.cmdCancel;
-			this.ClientSize = new System.Drawing.Size(735, 412);
-			this.Controls.Add(this.chkBlackMarketDiscount);
-			this.Controls.Add(this.lblTest);
-			this.Controls.Add(this.lblTestLabel);
-			this.Controls.Add(this.nudMarkup);
-			this.Controls.Add(this.lblMarkupLabel);
-			this.Controls.Add(this.lblMarkupPercentLabel);
-			this.Controls.Add(this.nudUsedVehicleDiscount);
-			this.Controls.Add(this.lblUsedVehicleDiscountLabel);
-			this.Controls.Add(this.chkUsedVehicle);
-			this.Controls.Add(this.chkFreeItem);
-			this.Controls.Add(this.lblSource);
-			this.Controls.Add(this.lblSourceLabel);
-			this.Controls.Add(this.cmdOKAdd);
-			this.Controls.Add(this.lblVehicleSensor);
-			this.Controls.Add(this.lblVehicleSensorLabel);
-			this.Controls.Add(this.txtSearch);
-			this.Controls.Add(this.lblSearchLabel);
-			this.Controls.Add(this.lblVehiclePilot);
-			this.Controls.Add(this.lblVehiclePilotLabel);
-			this.Controls.Add(this.lblVehicleArmor);
-			this.Controls.Add(this.lblVehicleArmorLabel);
-			this.Controls.Add(this.lblVehicleBody);
-			this.Controls.Add(this.lblVehicleBodyLabel);
-			this.Controls.Add(this.lblVehicleSpeed);
-			this.Controls.Add(this.lblVehicleSpeedLabel);
-			this.Controls.Add(this.lblVehicleCost);
-			this.Controls.Add(this.lblVehicleCostLabel);
-			this.Controls.Add(this.lblVehicleAvail);
-			this.Controls.Add(this.lblVehicleAvailLabel);
-			this.Controls.Add(this.lblVehicleAccel);
-			this.Controls.Add(this.lblVehicleAccelLabel);
-			this.Controls.Add(this.lblVehicleHandling);
-			this.Controls.Add(this.lblVehicleHandlingLabel);
-			this.Controls.Add(this.cmdCancel);
-			this.Controls.Add(this.cmdOK);
-			this.Controls.Add(this.lstVehicle);
-			this.Controls.Add(this.lblCategory);
-			this.Controls.Add(this.cboCategory);
-			this.Controls.Add(this.lblUsedVehicleDiscountPercentLabel);
-			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
-			this.MaximizeBox = false;
-			this.MinimizeBox = false;
-			this.Name = "frmSelectVehicle";
-			this.ShowInTaskbar = false;
-			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
-			this.Tag = "Title_SelectVehicle";
-			this.Text = "Select a Vehicle";
-			this.Load += new System.EventHandler(this.frmSelectVehicle_Load);
-			((System.ComponentModel.ISupportInitialize)(this.nudUsedVehicleDiscount)).EndInit();
-			((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).EndInit();
-			this.ResumeLayout(false);
-			this.PerformLayout();
+            this.nudMarkup.Name = "nudMarkup";
+            this.nudMarkup.Size = new System.Drawing.Size(56, 20);
+            this.nudMarkup.TabIndex = 28;
+            this.nudMarkup.ValueChanged += new System.EventHandler(this.nudMarkup_ValueChanged);
+            // 
+            // lblMarkupLabel
+            // 
+            this.lblMarkupLabel.AutoSize = true;
+            this.lblMarkupLabel.Location = new System.Drawing.Point(421, 259);
+            this.lblMarkupLabel.Name = "lblMarkupLabel";
+            this.lblMarkupLabel.Size = new System.Drawing.Size(46, 13);
+            this.lblMarkupLabel.TabIndex = 27;
+            this.lblMarkupLabel.Tag = "Label_SelectGear_Markup";
+            this.lblMarkupLabel.Text = "Markup:";
+            // 
+            // lblMarkupPercentLabel
+            // 
+            this.lblMarkupPercentLabel.AutoSize = true;
+            this.lblMarkupPercentLabel.Location = new System.Drawing.Point(536, 259);
+            this.lblMarkupPercentLabel.Name = "lblMarkupPercentLabel";
+            this.lblMarkupPercentLabel.Size = new System.Drawing.Size(15, 13);
+            this.lblMarkupPercentLabel.TabIndex = 29;
+            this.lblMarkupPercentLabel.Text = "%";
+            // 
+            // lblTest
+            // 
+            this.lblTest.AutoSize = true;
+            this.lblTest.Location = new System.Drawing.Point(579, 139);
+            this.lblTest.Name = "lblTest";
+            this.lblTest.Size = new System.Drawing.Size(19, 13);
+            this.lblTest.TabIndex = 19;
+            this.lblTest.Text = "[0]";
+            // 
+            // lblTestLabel
+            // 
+            this.lblTestLabel.AutoSize = true;
+            this.lblTestLabel.Location = new System.Drawing.Point(534, 139);
+            this.lblTestLabel.Name = "lblTestLabel";
+            this.lblTestLabel.Size = new System.Drawing.Size(31, 13);
+            this.lblTestLabel.TabIndex = 18;
+            this.lblTestLabel.Tag = "Label_Test";
+            this.lblTestLabel.Text = "Test:";
+            // 
+            // tipTooltip
+            // 
+            this.tipTooltip.AutoPopDelay = 10000;
+            this.tipTooltip.InitialDelay = 250;
+            this.tipTooltip.IsBalloon = true;
+            this.tipTooltip.ReshowDelay = 100;
+            this.tipTooltip.ToolTipIcon = System.Windows.Forms.ToolTipIcon.Info;
+            this.tipTooltip.ToolTipTitle = "Chummer Help";
+            // 
+            // chkBlackMarketDiscount
+            // 
+            this.chkBlackMarketDiscount.AutoSize = true;
+            this.chkBlackMarketDiscount.Location = new System.Drawing.Point(421, 184);
+            this.chkBlackMarketDiscount.Name = "chkBlackMarketDiscount";
+            this.chkBlackMarketDiscount.Size = new System.Drawing.Size(163, 17);
+            this.chkBlackMarketDiscount.TabIndex = 38;
+            this.chkBlackMarketDiscount.Tag = "Checkbox_BlackMarketDiscount";
+            this.chkBlackMarketDiscount.Text = "Black Market Discount (10%)";
+            this.chkBlackMarketDiscount.UseVisualStyleBackColor = true;
+            this.chkBlackMarketDiscount.Visible = false;
+            this.chkBlackMarketDiscount.CheckedChanged += new System.EventHandler(this.chkBlackMarketDiscount_CheckedChanged);
+            // 
+            // lblVehicleSeatsLabel
+            // 
+            this.lblVehicleSeatsLabel.AutoSize = true;
+            this.lblVehicleSeatsLabel.Location = new System.Drawing.Point(572, 114);
+            this.lblVehicleSeatsLabel.Name = "lblVehicleSeatsLabel";
+            this.lblVehicleSeatsLabel.Size = new System.Drawing.Size(37, 13);
+            this.lblVehicleSeatsLabel.TabIndex = 39;
+            this.lblVehicleSeatsLabel.Tag = "Label_Seat";
+            this.lblVehicleSeatsLabel.Text = "Seats:";
+            // 
+            // lblVehicleSeats
+            // 
+            this.lblVehicleSeats.AutoSize = true;
+            this.lblVehicleSeats.Location = new System.Drawing.Point(628, 114);
+            this.lblVehicleSeats.Name = "lblVehicleSeats";
+            this.lblVehicleSeats.Size = new System.Drawing.Size(40, 13);
+            this.lblVehicleSeats.TabIndex = 40;
+            this.lblVehicleSeats.Text = "[Seats]";
+            // 
+            // frmSelectVehicle
+            // 
+            this.AcceptButton = this.cmdOK;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.cmdCancel;
+            this.ClientSize = new System.Drawing.Size(735, 412);
+            this.Controls.Add(this.lblVehicleSeats);
+            this.Controls.Add(this.lblVehicleSeatsLabel);
+            this.Controls.Add(this.chkBlackMarketDiscount);
+            this.Controls.Add(this.lblTest);
+            this.Controls.Add(this.lblTestLabel);
+            this.Controls.Add(this.nudMarkup);
+            this.Controls.Add(this.lblMarkupLabel);
+            this.Controls.Add(this.lblMarkupPercentLabel);
+            this.Controls.Add(this.nudUsedVehicleDiscount);
+            this.Controls.Add(this.lblUsedVehicleDiscountLabel);
+            this.Controls.Add(this.chkUsedVehicle);
+            this.Controls.Add(this.chkFreeItem);
+            this.Controls.Add(this.lblSource);
+            this.Controls.Add(this.lblSourceLabel);
+            this.Controls.Add(this.cmdOKAdd);
+            this.Controls.Add(this.lblVehicleSensor);
+            this.Controls.Add(this.lblVehicleSensorLabel);
+            this.Controls.Add(this.txtSearch);
+            this.Controls.Add(this.lblSearchLabel);
+            this.Controls.Add(this.lblVehiclePilot);
+            this.Controls.Add(this.lblVehiclePilotLabel);
+            this.Controls.Add(this.lblVehicleArmor);
+            this.Controls.Add(this.lblVehicleArmorLabel);
+            this.Controls.Add(this.lblVehicleBody);
+            this.Controls.Add(this.lblVehicleBodyLabel);
+            this.Controls.Add(this.lblVehicleSpeed);
+            this.Controls.Add(this.lblVehicleSpeedLabel);
+            this.Controls.Add(this.lblVehicleCost);
+            this.Controls.Add(this.lblVehicleCostLabel);
+            this.Controls.Add(this.lblVehicleAvail);
+            this.Controls.Add(this.lblVehicleAvailLabel);
+            this.Controls.Add(this.lblVehicleAccel);
+            this.Controls.Add(this.lblVehicleAccelLabel);
+            this.Controls.Add(this.lblVehicleHandling);
+            this.Controls.Add(this.lblVehicleHandlingLabel);
+            this.Controls.Add(this.cmdCancel);
+            this.Controls.Add(this.cmdOK);
+            this.Controls.Add(this.lstVehicle);
+            this.Controls.Add(this.lblCategory);
+            this.Controls.Add(this.cboCategory);
+            this.Controls.Add(this.lblUsedVehicleDiscountPercentLabel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.MinimizeBox = false;
+            this.Name = "frmSelectVehicle";
+            this.ShowInTaskbar = false;
+            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
+            this.Tag = "Title_SelectVehicle";
+            this.Text = "Select a Vehicle";
+            this.Load += new System.EventHandler(this.frmSelectVehicle_Load);
+            ((System.ComponentModel.ISupportInitialize)(this.nudUsedVehicleDiscount)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudMarkup)).EndInit();
+            this.ResumeLayout(false);
+            this.PerformLayout();
 
 		}
 
@@ -601,5 +623,7 @@
 		private System.Windows.Forms.Label lblTestLabel;
 		private System.Windows.Forms.ToolTip tipTooltip;
 		private System.Windows.Forms.CheckBox chkBlackMarketDiscount;
-	}
+        private System.Windows.Forms.Label lblVehicleSeatsLabel;
+        private System.Windows.Forms.Label lblVehicleSeats;
+    }
 }

--- a/Chummer/Selection Forms/frmSelectVehicle.cs
+++ b/Chummer/Selection Forms/frmSelectVehicle.cs
@@ -378,7 +378,8 @@ namespace Chummer
 			lblVehiclePilot.Text = objXmlVehicle["pilot"].InnerText;
 			lblVehicleBody.Text = objXmlVehicle["body"].InnerText;
 			lblVehicleArmor.Text = objXmlVehicle["armor"].InnerText;
-			lblVehicleSensor.Text = objXmlVehicle["sensor"].InnerText;
+            lblVehicleSeats.Text = objXmlVehicle["seats"].InnerText;
+            lblVehicleSensor.Text = objXmlVehicle["sensor"].InnerText;
 
 			if (chkUsedVehicle.Checked)
 			{
@@ -484,15 +485,18 @@ namespace Chummer
 
 			intWidth = Math.Max(lblVehicleAccelLabel.Width, lblVehiclePilotLabel.Width);
 			intWidth = Math.Max(intWidth, lblVehicleArmorLabel.Width);
+            intWidth = Math.Max(intWidth, lblVehicleSeatsLabel.Width);
 
-			lblVehicleAccelLabel.Left = lblVehicleHandling.Left + 60;
+            lblVehicleAccelLabel.Left = lblVehicleHandling.Left + 60;
 			lblVehicleAccel.Left = lblVehicleAccelLabel.Left + intWidth + 6;
 			lblVehiclePilotLabel.Left = lblVehicleHandling.Left + 60;
 			lblVehiclePilot.Left = lblVehiclePilotLabel.Left + intWidth + 6;
 			lblVehicleArmorLabel.Left = lblVehicleHandling.Left + 60;
 			lblVehicleArmor.Left = lblVehicleArmorLabel.Left + intWidth + 6;
+            lblVehicleSeatsLabel.Left = lblVehicleHandling.Left + 60;
+            lblVehicleSeats.Left = lblVehicleSeatsLabel.Left + intWidth + 6;
 
-			lblUsedVehicleDiscountLabel.Left = chkUsedVehicle.Left + chkUsedVehicle.Width + 6;
+            lblUsedVehicleDiscountLabel.Left = chkUsedVehicle.Left + chkUsedVehicle.Width + 6;
 			nudUsedVehicleDiscount.Left = lblUsedVehicleDiscountLabel.Left + lblUsedVehicleDiscountLabel.Width + 6;
 			lblUsedVehicleDiscountPercentLabel.Left = nudUsedVehicleDiscount.Left + nudUsedVehicleDiscount.Width;
 

--- a/Chummer/Selection Forms/frmSelectVehicleMod.cs
+++ b/Chummer/Selection Forms/frmSelectVehicleMod.cs
@@ -47,9 +47,10 @@ namespace Chummer
 		private bool _blnBlackMarketDiscount;
 		private string _strLimitToCategories;
 		private List<ListItem> _lstCategory = new List<ListItem>();
+        private List<VehicleMod> _lstMods;
 
-		#region Control Events
-		public frmSelectVehicleMod(Character objCharacter, bool blnCareer = false)
+        #region Control Events
+        public frmSelectVehicleMod(Character objCharacter, bool blnCareer = false)
 		{
 			InitializeComponent();
 			LanguageManager.Instance.Load(GlobalOptions.Instance.Language, this);
@@ -137,7 +138,12 @@ namespace Chummer
 
 		private void cboCategory_SelectedIndexChanged(object sender, EventArgs e)
 		{
-			List<ListItem> lstMods = new List<ListItem>();
+            // Load the Vehicle information.
+            _objXmlDocument = XmlManager.Instance.Load("vehicles.xml");
+
+            XmlNode objXmlVehicleNode = _objXmlDocument.SelectSingleNode("/chummer/vehicles/vehicle[name = \"" + _objVehicle.Name + "\"]");
+
+            List<ListItem> lstMods = new List<ListItem>();
 			XmlNodeList objXmlModList = null;
 			// Populate the Mod list.
 			if (cboCategory.SelectedValue.ToString() != "All")
@@ -154,6 +160,62 @@ namespace Chummer
 			{
                 if (objXmlMod["hidden"] != null)
                     continue;
+
+                if (objXmlMod["forbidden"]?["vehicledetails"] != null)
+                {
+                    // Assumes topmost parent is an AND node
+                    if (Chummer.Backend.XmlNodeExtensions.processFilterOperationNode(objXmlVehicleNode, objXmlMod["forbidden"]["vehicledetails"], false))
+                    {
+                        continue;
+                    }
+                }
+                if (objXmlMod["required"]?["vehicledetails"] != null)
+                {
+                    // Assumes topmost parent is an AND node
+                    if (!Chummer.Backend.XmlNodeExtensions.processFilterOperationNode(objXmlVehicleNode, objXmlMod["required"]["vehicledetails"], false))
+                    {
+                        continue;
+                    }
+                }
+
+                if (objXmlMod["forbidden"]?["oneof"] != null)
+                {
+                    XmlNodeList objXmlForbiddenList = objXmlMod.SelectNodes("forbidden/oneof/mods");
+                    //Add to set for O(N log M) runtime instead of O(N * M)
+
+                    HashSet<String> objForbiddenAccessory = new HashSet<String>();
+                    foreach (XmlNode node in objXmlForbiddenList)
+                    {
+                        objForbiddenAccessory.Add(node.InnerText);
+                    }
+
+                    foreach (VehicleMod objAccessory in _lstMods.Where(objAccessory => objForbiddenAccessory.Contains(objAccessory.Name)))
+                    {
+                        goto NextItem;
+                    }
+                }
+
+                if (objXmlMod["required"]?["oneof"] != null)
+                {
+                    bool boolCanAdd = false;
+                    XmlNodeList objXmlRequiredList = objXmlMod.SelectNodes("required/oneof/mods");
+                    //Add to set for O(N log M) runtime instead of O(N * M)
+
+                    HashSet<String> objRequiredAccessory = new HashSet<String>();
+                    foreach (XmlNode node in objXmlRequiredList)
+                    {
+                        objRequiredAccessory.Add(node.InnerText);
+                    }
+
+                    foreach (VehicleMod objAccessory in _lstMods.Where(objAccessory => objRequiredAccessory.Contains(objAccessory.Name)))
+                    {
+                        boolCanAdd = true;
+                        break;
+                    }
+                    if (!boolCanAdd)
+                        continue;
+                }
+
                 ListItem objItem = new ListItem();
 					objItem.Value = objXmlMod["name"].InnerText;
 					if (objXmlMod["translate"] != null)
@@ -161,6 +223,7 @@ namespace Chummer
 					else
 						objItem.Name = objXmlMod["name"].InnerText;
 					lstMods.Add(objItem);
+            NextItem:;
 			}
 			lstMod.DataSource = null;
 			lstMod.ValueMember = "Value";
@@ -444,13 +507,24 @@ namespace Chummer
 				return _intMarkup;
 			}
 		}
-		#endregion
 
-		#region Methods
-		/// <summary>
-		/// Build the list of Mods.
+        /// <summary>
+		/// Currently Installed Accessories
 		/// </summary>
-		private void BuildModList()
+		public List<VehicleMod> InstalledMods
+        {
+            set
+            {
+                _lstMods = value;
+            }
+        }
+        #endregion
+
+        #region Methods
+        /// <summary>
+        /// Build the list of Mods.
+        /// </summary>
+        private void BuildModList()
 		{
 
 			// Select the first Category in the list.
@@ -471,34 +545,93 @@ namespace Chummer
 			// Load the Mod information.
 			_objXmlDocument = XmlManager.Instance.Load(_strInputFile + ".xml");
 
-			// Retrieve the list of Mods for the selected Category.
-			if (txtSearch.Text == "")
+            // Load the Vehicle information.
+            _objXmlDocument = XmlManager.Instance.Load("vehicles.xml");
+
+            XmlNode objXmlVehicleNode = _objXmlDocument.SelectSingleNode("/chummer/vehicles/vehicle[name = \"" + _objVehicle.Name + "\"]");
+
+            // Retrieve the list of Mods for the selected Category.
+            if (txtSearch.Text == "")
 				objXmlModList = _objXmlDocument.SelectNodes("/chummer/mods/mod[(" + _objCharacter.Options.BookXPath() + ") and category != \"Special\"]");
 			else
 				objXmlModList = _objXmlDocument.SelectNodes("/chummer/mods/mod[(" + _objCharacter.Options.BookXPath() + ") and category != \"Special\" and ((contains(translate(name,'abcdefghijklmnopqrstuvwxyzàáâãäåçèéêëìíîïñòóôõöùúûüýß','ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝß'), \"" + txtSearch.Text.ToUpper() + "\") and not(translate)) or contains(translate(translate,'abcdefghijklmnopqrstuvwxyzàáâãäåçèéêëìíîïñòóôõöùúûüýß','ABCDEFGHIJKLMNOPQRSTUVWXYZÀÁÂÃÄÅÇÈÉÊËÌÍÎÏÑÒÓÔÕÖÙÚÛÜÝß'), \"" + txtSearch.Text.ToUpper() + "\"))]");
-			bool blnAdd = true;
 			List<ListItem> lstMods = new List<ListItem>();
 			if (objXmlModList != null)
 				foreach (XmlNode objXmlMod in objXmlModList)
 				{
-					blnAdd = true;
+                    if (objXmlMod["hidden"] != null)
+                        continue;
+
+                    if (objXmlMod["forbidden"]?["vehicledetails"] != null)
+                    {
+                        // Assumes topmost parent is an AND node
+                        if (Chummer.Backend.XmlNodeExtensions.processFilterOperationNode(objXmlVehicleNode, objXmlMod["forbidden"]["vehicledetails"], false))
+                        {
+                            continue;
+                        }
+                    }
+                    if (objXmlMod["required"]?["vehicledetails"] != null)
+                    {
+                        // Assumes topmost parent is an AND node
+                        if (!Chummer.Backend.XmlNodeExtensions.processFilterOperationNode(objXmlVehicleNode, objXmlMod["required"]["vehicledetails"], false))
+                        {
+                            continue;
+                        }
+                    }
+
+                    if (objXmlMod["forbidden"]?["oneof"] != null)
+                    {
+                        XmlNodeList objXmlForbiddenList = objXmlMod.SelectNodes("forbidden/oneof/mods");
+                        //Add to set for O(N log M) runtime instead of O(N * M)
+
+                        HashSet<String> objForbiddenAccessory = new HashSet<String>();
+                        foreach (XmlNode node in objXmlForbiddenList)
+                        {
+                            objForbiddenAccessory.Add(node.InnerText);
+                        }
+
+                        foreach (VehicleMod objAccessory in _lstMods.Where(objAccessory => objForbiddenAccessory.Contains(objAccessory.Name)))
+                        {
+                            goto NextItem;
+                        }
+                    }
+
+                    if (objXmlMod["required"]?["oneof"] != null)
+                    {
+                        bool boolCanAdd = false;
+                        XmlNodeList objXmlRequiredList = objXmlMod.SelectNodes("required/oneof/mods");
+                        //Add to set for O(N log M) runtime instead of O(N * M)
+
+                        HashSet<String> objRequiredAccessory = new HashSet<String>();
+                        foreach (XmlNode node in objXmlRequiredList)
+                        {
+                            objRequiredAccessory.Add(node.InnerText);
+                        }
+
+                        foreach (VehicleMod objAccessory in _lstMods.Where(objAccessory => objRequiredAccessory.Contains(objAccessory.Name)))
+                        {
+                            boolCanAdd = true;
+                            break;
+                        }
+                        if (!boolCanAdd)
+                            continue;
+                    }
+
 					XmlNode objXmlRequirements = objXmlMod.SelectSingleNode("requires");
 					if (objXmlRequirements != null)
 					{
 						if (_objVehicle.Seats < Convert.ToInt32(objXmlRequirements["seats"]?.InnerText))
 						{
-							blnAdd = false;
+                            continue;
 						}
 					}
 
-					if (blnAdd)
-					{
-						ListItem objItem = new ListItem();
-						objItem.Value = objXmlMod["name"].InnerText;
-						objItem.Name = objXmlMod["translate"]?.InnerText ?? objXmlMod["name"].InnerText;
-						lstMods.Add(objItem);
-					}
-				}
+					ListItem objItem = new ListItem();
+					objItem.Value = objXmlMod["name"].InnerText;
+					objItem.Name = objXmlMod["translate"]?.InnerText ?? objXmlMod["name"].InnerText;
+					lstMods.Add(objItem);
+                NextItem:;
+                }
 			SortListItem objSort = new SortListItem();
 			lstMods.Sort(objSort.Compare);
 			lstMod.DataSource = null;

--- a/Chummer/Selection Forms/frmSelectVehicleMod.cs
+++ b/Chummer/Selection Forms/frmSelectVehicleMod.cs
@@ -661,7 +661,7 @@ namespace Chummer
 				//Used for Metahuman Adjustments.
 				else if (objXmlMod["rating"].InnerText.ToLower() == "seats")
 				{
-					nudRating.Maximum = _objVehicle.Seats;
+					nudRating.Maximum = _objVehicle.TotalSeats;
 					nudRating.Minimum = 1;
 					nudRating.Enabled = true;
 					lblRatingLabel.Text = LanguageManager.Instance.GetString("Label_Qty");
@@ -794,9 +794,11 @@ namespace Chummer
 			strInput = strInput.Replace("Handling", _objVehicle.Handling.ToString());
 			strInput = strInput.Replace("Offroad Handling", _objVehicle.OffroadHandling.ToString());
 			strInput = strInput.Replace("Speed", _objVehicle.Speed.ToString());
-			strInput = strInput.Replace("Acceleration", _objVehicle.Accel.ToString());
+            strInput = strInput.Replace("Offroad Speed", _objVehicle.OffroadSpeed.ToString());
+            strInput = strInput.Replace("Acceleration", _objVehicle.Accel.ToString());
+            strInput = strInput.Replace("Offroad Acceleration", _objVehicle.OffroadAccel.ToString());
 
-			return strInput;
+            return strInput;
 		}
 		#endregion
 

--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
@@ -530,7 +530,7 @@ namespace Chummer
 		}
 
 		/// <summary>
-		/// Markup percentage.
+		/// Currently Installed Accessories
 		/// </summary>
 		public List<WeaponAccessory> InstalledAccessories
 		{

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -36,6 +36,9 @@ Application Changes:
 - Fixed the filtering behaviour of cyberware subsystems to properly filter down to those subsystems. This shouldn't impact existing cyberware in any noticeable way, but this will allow adding subsystems to bioware. 
 - Weapon accessories now only need to contain "Expanded Clip" in their name for the application to recognize the accessory as an expanded clip.
 - Added a prototypical, custom, XML node filtering system that checks raw XML. Currently, this is only used for weapon accessories to hide ineligible ones from the selection menu, but it should be flexible enough to support anything.
+- Added the ability to distinguish between primary and offroad speed and acceleration, in addition to primary and offroad handling.
+- Added the ability for vehicle mods to alter seat count.
+- Added the ability for vehicle mods that alter speed, handling, and/or acceleration to properly subtract values and also to support percentage modifications instead of just flat ones.
 
 Data Changes: 
 
@@ -122,6 +125,11 @@ Data Changes:
 - Made the Advanced Safety System accessories mutually exclusive with one another.
 - Made the Safe Target System addons require the Safe Target System, Base accessory.
 - Made the Sawed Off/Shortbarrel and Stock Removal accessory entry mutually exclusive with both the Sawed Off/Shortbarrel accessory and the Stock Removal accessory.
+- Added the Coriolis complex form from Chrome Flesh.
+- Added vehicle entries for the Cocotaxi and the Camellos from Hard Targets and the Ares Garuda and the Evo Aquavida 2 from Rigger 5.0.
+- Added stats for secondary acceleration and speed (i.e. offroad acceleration and speed for ground vehicles, alternate locomotion for all others) where they were missing, e.g. from the Evo Falcon-EX, the Corsair Trident, and the Evo Krokodil.
+- Corrected the seats for all vehicles that have separate front/back sections so that Chummer always displays the total seat count, not just the seat count for the larger section.
+- Corrected the availability of most vehicles from Stolen Souls (to 4) and the Ares Roadmaster (to 8).
 
 Build 187
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -35,10 +35,12 @@ Application Changes:
 - Fixed a crash issue where changing metatypes or the magic priority mid-creation would not take essence loss into account when setting new values for magic or resonance. Fixes #1229.
 - Fixed the filtering behaviour of cyberware subsystems to properly filter down to those subsystems. This shouldn't impact existing cyberware in any noticeable way, but this will allow adding subsystems to bioware. 
 - Weapon accessories now only need to contain "Expanded Clip" in their name for the application to recognize the accessory as an expanded clip.
-- Added a prototypical, custom, XML node filtering system that checks raw XML. Currently, this is only used for weapon accessories to hide ineligible ones from the selection menu, but it should be flexible enough to support anything.
+- Added a prototypical, custom, XML node filtering system that checks raw XML. Currently, this is only used for weapon accessories and vehicle/drone mods to hide ineligible ones from the selection menu, but it should be flexible enough to support anything.
 - Added the ability to distinguish between primary and offroad speed and acceleration, in addition to primary and offroad handling.
 - Added the ability for vehicle mods to alter seat count.
 - Added the ability for vehicle mods that alter speed, handling, and/or acceleration to properly subtract values and also to support percentage modifications instead of just flat ones.
+- Added a label for seats to the vehicle selection screen.
+- Vehicle mods can now be configured to be mutually exclusive with other vehicle mods.
 
 Data Changes: 
 
@@ -130,6 +132,7 @@ Data Changes:
 - Added stats for secondary acceleration and speed (i.e. offroad acceleration and speed for ground vehicles, alternate locomotion for all others) where they were missing, e.g. from the Evo Falcon-EX, the Corsair Trident, and the Evo Krokodil.
 - Corrected the seats for all vehicles that have separate front/back sections so that Chummer always displays the total seat count, not just the seat count for the larger section.
 - Corrected the availability of most vehicles from Stolen Souls (to 4) and the Ares Roadmaster (to 8).
+- Added custom filters to relevant vehicle/drone mods to stop them from showing up in the list of vehicle/drone mods unless specific conditions are fulfilled (e.g. drone mods only appear when modifying drones, Horseman modpods only appear when modifying a Horseman, etc.).
 
 Build 187
 

--- a/Chummer/data/complexforms.xml
+++ b/Chummer/data/complexforms.xml
@@ -196,6 +196,15 @@
       <fv>L+2</fv>
       <source>DT</source>
       <page>58</page>
+    </complexform>
+	<complexform>
+      <id>f9a63582-6858-4b83-a76f-6daa52b127c5</id>
+      <name>Coriolis</name>
+      <target>Persona</target>
+      <duration>E</duration>
+      <fv>L+3</fv>
+      <source>CF</source>
+      <page>25</page>
     </complexform>    
   </complexforms>
 </chummer>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -38,6 +38,7 @@
 		<category>Drones: Anthro</category>
 		<category>Drones: Large</category>
 		<category>Drones: Huge</category>
+		<category>Drones: Missile</category>
 	</categories>
   	<modcategories>
     		<category>All</category>
@@ -148,8 +149,8 @@
 			<name>Evo Falcon-EX</name>
 			<category>Bikes</category>
 			<handling>3/5</handling>
-			<accel>2</accel>
-			<speed>3</speed>
+			<accel>1/2</accel>
+			<speed>2/3</speed>
 			<pilot>1</pilot>
 			<body>7</body>
 			<armor>9</armor>
@@ -345,7 +346,7 @@
 			<category>Cars</category>
 			<handling>3/2</handling>
 			<accel>2</accel>
-			<speed>4</speed>
+			<speed>4/3</speed>
 			<pilot>2</pilot>
 			<body>8</body>
 			<armor>6</armor>
@@ -492,7 +493,7 @@
 			<category>Cars</category>
 			<handling>3/3</handling>
 			<accel>2</accel>
-			<speed>4</speed>
+			<speed>4/3</speed>
 			<pilot>2</pilot>
 			<body>12</body>
 			<armor>10</armor>
@@ -538,11 +539,11 @@
 			<category>Cars</category>
 			<handling>5/3</handling>
 			<accel>2</accel>
-			<speed>5</speed>
+			<speed>5/3</speed>
 			<pilot>3</pilot>
 			<body>16</body>
 			<armor>12</armor>
-			<seats>8</seats>
+			<seats>10</seats>
 			<sensor>4</sensor>
 			<gears>
 				<gear rating="4" maxrating="7">Sensor Array</gear>
@@ -616,7 +617,7 @@
 			<pilot>1</pilot>
 			<body>13</body>
 			<armor>10</armor>
-			<seats>2</seats>
+			<seats>6</seats>
 			<sensor>2</sensor>
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
@@ -696,11 +697,11 @@
 			<category>Cars</category>
 			<handling>3/3</handling>
 			<accel>1</accel>
-			<speed>4</speed>
+			<speed>4/3</speed>
 			<pilot>2</pilot>
 			<body>16</body>
 			<armor>8</armor>
-			<seats>4</seats>
+			<seats>8</seats>
 			<sensor>2</sensor>
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
@@ -807,11 +808,11 @@
 			<category>Cars</category>
 			<handling>3/3</handling>
 			<accel>1</accel>
-			<speed>4</speed>
+			<speed>4/3</speed>
 			<pilot>3</pilot>
 			<body>14</body>
 			<armor>8</armor>
-			<seats>14</seats>
+			<seats>16</seats>
 			<sensor>2</sensor>
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
@@ -1167,7 +1168,7 @@
 			<category>Trucks</category>
 			<handling>3/2</handling>
 			<accel>1</accel>
-			<speed>4</speed>
+			<speed>4/3</speed>
 			<pilot>2</pilot>
 			<body>14</body>
 			<armor>12</armor>
@@ -1193,7 +1194,7 @@
 			<category>Trucks</category>
 			<handling>3/3</handling>
 			<accel>1</accel>
-			<speed>4</speed>
+			<speed>4/4</speed>
 			<pilot>2</pilot>
 			<body>16</body>
 			<armor>12</armor>
@@ -1219,7 +1220,7 @@
 			<category>Trucks</category>
 			<handling>3/4</handling>
 			<accel>1</accel>
-			<speed>3</speed>
+			<speed>3/4</speed>
 			<pilot>2</pilot>
 			<body>14</body>
 			<armor>12</armor>
@@ -1246,7 +1247,7 @@
 			<category>Trucks</category>
 			<handling>3/2</handling>
 			<accel>1</accel>
-			<speed>4</speed>
+			<speed>4/3</speed>
 			<pilot>3</pilot>
 			<body>20</body>
 			<armor>15</armor>
@@ -1453,7 +1454,7 @@
 			<pilot>3</pilot>
 			<body>14</body>
 			<armor>9</armor>
-			<seats>12</seats>
+			<seats>14</seats>
 			<sensor>3</sensor>
 			<gears>
 				<gear rating="3" maxrating="7">Sensor Array</gear>
@@ -2020,7 +2021,7 @@
 			<pilot>1</pilot>
 			<body>10</body>
 			<armor>6</armor>
-			<seats>6</seats>
+			<seats>8</seats>
 			<sensor>1</sensor>
 			<gears>
 				<gear rating="1" maxrating="7">Sensor Array</gear>
@@ -2106,9 +2107,9 @@
 			<id>9dfc2603-8289-474c-842b-dd74ac406fb7</id>
 			<name>Corsair Elysium</name>
 			<category>Boats</category>
-			<handling>3</handling>
-			<accel>2</accel>
-			<speed>4</speed>
+			<handling>1/3</handling>
+			<accel>1/2</accel>
+			<speed>1/4</speed>
 			<pilot>2</pilot>
 			<body>14</body>
 			<armor>10</armor>
@@ -2131,9 +2132,9 @@
 			<id>c7d3a2bb-bad0-49a3-964f-b48911b37dcc</id>
 			<name>Corsair Panther</name>
 			<category>Boats</category>
-			<handling>3</handling>
-			<accel>3</accel>
-			<speed>5</speed>
+			<handling>1/3</handling>
+			<accel>1/3</accel>
+			<speed>2/5</speed>
 			<pilot>2</pilot>
 			<body>18</body>
 			<armor>10</armor>
@@ -2159,9 +2160,9 @@
 			<id>db3526df-3370-4b28-84cd-e113ad69ee5a</id>
 			<name>Corsair Trident</name>
 			<category>Boats</category>
-			<handling>3</handling>
-			<accel>3</accel>
-			<speed>5</speed>
+			<handling>1/3</handling>
+			<accel>2/3</accel>
+			<speed>4/5</speed>
 			<pilot>2</pilot>
 			<body>16</body>
 			<armor>10</armor>
@@ -2283,7 +2284,7 @@
 		</vehicle>
 		<vehicle>
 			<id>1312f26a-4cac-45a9-a8f2-f74b2a80a468</id>
-			<name>Evo Aquavida</name>
+			<name>Evo Aquavida 1</name>
 			<category>Boats</category>
 			<handling>2</handling>
 			<accel>2</accel>
@@ -2291,7 +2292,7 @@
 			<pilot>1</pilot>
 			<body>20</body>
 			<armor>16</armor>
-			<seats>8</seats>
+			<seats>10</seats>
 			<sensor>3</sensor>
 			<gears>
 				<gear rating="3" maxrating="7">Sensor Array</gear>
@@ -2302,6 +2303,30 @@
 			</mods>
 			<avail>10</avail>
 			<cost>115000</cost>
+			<source>R5</source>
+			<page>90</page>
+		</vehicle>
+		<vehicle>
+			<id>ea80540c-83e1-4ff3-b411-a990e19fdc33</id>
+			<name>Evo Aquavida 2</name>
+			<category>Boats</category>
+			<handling>2</handling>
+			<accel>2</accel>
+			<speed>1</speed>
+			<pilot>1</pilot>
+			<body>20</body>
+			<armor>16</armor>
+			<seats>12</seats>
+			<sensor>3</sensor>
+			<gears>
+				<gear rating="3" maxrating="7">Sensor Array</gear>
+			</gears>
+			<mods>
+				<name>Amenities (Middle)</name>
+				<name>Winch (Basic)</name>
+			</mods>
+			<avail>10</avail>
+			<cost>135000</cost>
 			<source>R5</source>
 			<page>90</page>
 		</vehicle>
@@ -3039,8 +3064,8 @@
 			<gears>
 				<gear rating="4" maxrating="4">Sensor Array</gear>
 			</gears>
-			<avail>8</avail>
-			<cost>4000</cost>
+			<avail>12</avail>
+			<cost>30000</cost>
 			<source>R5</source>
 			<page>131</page>
 		</vehicle>
@@ -3105,8 +3130,8 @@
 			<name>Festo Sewer Snake (Small)</name>
 			<category>Drones: Small</category>
 			<handling>3</handling>
-			<accel>1</accel>
-			<speed>1</speed>
+			<accel>1/1</accel>
+			<speed>1/1</speed>
 			<pilot>2</pilot>
 			<body>2</body>
 			<armor>0</armor>
@@ -3605,7 +3630,7 @@
 			<category>Drones: Medium</category>
 			<handling>3</handling>
 			<accel>1</accel>
-			<speed>2</speed>
+			<speed>2/3</speed>
 			<pilot>2</pilot>
 			<body>3</body>
 			<armor>6</armor>
@@ -4203,7 +4228,7 @@
 			<category>Bikes</category>
 			<handling>4/5</handling>
 			<accel>1</accel>
-			<speed>3</speed>
+			<speed>3/4</speed>
 			<pilot>1</pilot>
 			<body>5</body>
 			<armor>5</armor>
@@ -4399,7 +4424,7 @@
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
 			</gears>
-			<avail>0</avail>
+			<avail>4</avail>
 			<cost>51000</cost>
 			<source>SS</source>
 			<page>186</page>
@@ -4419,7 +4444,7 @@
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
 			</gears>
-			<avail>0</avail>
+			<avail>4</avail>
 			<cost>49000</cost>
 			<source>SS</source>
 			<page>186</page>
@@ -4439,7 +4464,7 @@
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
 			</gears>
-			<avail>0</avail>
+			<avail>4</avail>
 			<cost>40000</cost>
 			<source>SS</source>
 			<page>186</page>
@@ -4609,7 +4634,7 @@
 			<gears>
 				<gear rating="2" maxrating="7">Sensor Array</gear>
 			</gears>
-			<avail>0</avail>
+			<avail>4</avail>
 			<cost>33000</cost>
 			<source>SS</source>
 			<page>186</page>
@@ -4629,7 +4654,7 @@
 			<gears>
 				<gear rating="3" maxrating="7">Sensor Array</gear>
 			</gears>
-			<avail>4</avail>
+			<avail>8</avail>
 			<cost>52000</cost>
 			<source>SR5</source>
 			<page>464</page>
@@ -5522,6 +5547,66 @@
 			<page>23</page>
 		</vehicle>
 		<vehicle>
+			<id>57f83415-4b13-47d2-8a80-20483d356a09</id>
+			<name>Cocotaxi</name>
+			<category>Bikes</category>
+			<handling>4/2</handling>
+			<accel>2</accel>
+			<speed>3</speed>
+			<pilot>1</pilot>
+			<body>5</body>
+			<armor>4</armor>
+			<seats>3</seats>
+			<sensor>1</sensor>
+			<gears>
+				<gear rating="1" maxrating="7">Sensor Array</gear>
+			</gears>
+			<avail>0</avail>
+			<cost>4000</cost>
+			<source>HT</source>
+			<page>139</page>
+		</vehicle>
+		<vehicle>
+			<id>b5f962ae-d541-4271-812b-3a4d0eb812e4</id>
+			<name>Camellos</name>
+			<category>Municipal/Construction</category>
+			<handling>3/2</handling>
+			<accel>1</accel>
+			<speed>3</speed>
+			<pilot>1</pilot>
+			<body>16</body>
+			<armor>5</armor>
+			<seats>200</seats>
+			<sensor>2</sensor>
+			<gears>
+				<gear rating="2" maxrating="7">Sensor Array</gear>
+			</gears>
+			<avail>0</avail>
+			<cost>150000</cost>
+			<source>HT</source>
+			<page>139</page>
+		</vehicle>
+		<vehicle>
+			<id>b5f962ae-d541-4271-812b-3a4d0eb812e4</id>
+			<name>Ares Garuda</name>
+			<category>Drones: Missile</category>
+			<handling>6</handling>
+			<accel>2/4</accel>
+			<speed>3/6</speed>
+			<pilot>4</pilot>
+			<body>2</body>
+			<armor>2</armor>
+			<seats>0</seats>
+			<sensor>3</sensor>
+			<gears>
+				<gear rating="3" maxrating="6">Sensor Array</gear>
+			</gears>
+			<avail>20F</avail>
+			<cost>8500</cost>
+			<source>R5</source>
+			<page>149</page>
+		</vehicle>
+		<vehicle>
 			<id>2013dff9-f313-441b-9207-3fdb8a44c8ba</id>
 			<name>Ammo Drone (Small)</name>
 			<category>Drones: Small</category>
@@ -5848,6 +5933,7 @@
 			<cost>FixedValues(Acceleration * 10000,Acceleration * 25000)</cost>
 			<bonus>
 				<accel>+Rating</accel>
+				<offroadaccel>+Rating</offroadaccel>
 			</bonus>
 			<source>R5</source>
 			<page>154</page>
@@ -6092,6 +6178,7 @@
 			<cost>FixedValues(Speed * 2000,Speed * 5000,Speed * 12000)</cost>
 			<bonus>
 				<speed>+Rating</speed>
+				<offroadspeed>+Rating</offroadspeed>
 			</bonus>
 			<source>R5</source>
 			<page>157</page>
@@ -7288,7 +7375,9 @@
 			<cost>0</cost>
 			<bonus>
 				<accel>0</accel>
+				<offroadaccel>0</offroadaccel>
 				<speed>0</speed>
+				<offroadspeed>0</offroadspeed>
 			</bonus>
 			<source>R5</source>
 			<page>126</page>
@@ -7379,6 +7468,7 @@
 			<cost>Body * Rating * 200</cost>
 			<bonus>
 				<handling>Rating</handling>
+				<offroadhandling>Rating</offroadhandling>
 			</bonus>
 			<source>R5</source>
 			<page>123</page>
@@ -7395,6 +7485,7 @@
 			<cost>Body * Rating * 400</cost>
 			<bonus>
 				<speed>Rating</speed>
+				<offroadspeed>Rating</offroadspeed>
 			</bonus>
 			<source>R5</source>
 			<page>123</page>
@@ -7411,6 +7502,7 @@
 			<cost>Body * Rating * 200</cost>
 			<bonus>
 				<accel>Rating</accel>
+				<offroadaccel>Rating</offroadaccel>
 			</bonus>
 			<source>R5</source>
 			<page>123</page>
@@ -7531,7 +7623,9 @@
 			<cost>6000</cost>
 			<bonus>
 				<speed>-1</speed>
+				<offroadspeed>-1</offroadspeed>
 				<accel>-1</accel>
+				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 				<seats>+1</seats>
 			</bonus>
@@ -7548,7 +7642,9 @@
 			<cost>6000</cost>
 			<bonus>
 				<speed>-1</speed>
+				<offroadspeed>-1</offroadspeed>
 				<accel>-1</accel>
+				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
 			<source>R5</source>
@@ -7564,7 +7660,9 @@
 			<cost>5000</cost>
 			<bonus>
 				<speed>-1</speed>
+				<offroadspeed>-1</offroadspeed>
 				<accel>-1</accel>
+				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
 			<source>R5</source>
@@ -7580,7 +7678,9 @@
 			<cost>4000</cost>
 			<bonus>
 				<speed>-1</speed>
+				<offroadspeed>-1</offroadspeed>
 				<accel>-1</accel>
+				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
 			<source>R5</source>
@@ -7598,7 +7698,9 @@
 			<cost>5500</cost>
 			<bonus>
 				<speed>-1</speed>
+				<offroadspeed>-1</offroadspeed>
 				<accel>-1</accel>
+				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
 			<source>R5</source>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -5876,6 +5876,15 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>0</cost>
+			<required>
+				<vehicledetails>
+					<OR>
+						<name>Daihatsu-Caterpillar Horseman</name>
+						<name>Echo Motors Metaway</name>
+						<name>Ruhrmetal Wolf II</name>
+					</OR>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>?</page>
 		</mod>
@@ -5887,6 +5896,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>0</cost>
+			<required>
+				<vehicledetails>
+					<name>Mack Hellhound</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>?</page>
 		</mod>
@@ -5898,6 +5912,15 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>0</cost>
+			<required>
+				<vehicledetails>
+					<OR>
+						<name>Ares-Segway Terrier</name>
+						<name>Horizon-Doble Revolution</name>
+						<name>Entertainment Systems Cyclops</name>
+					</OR>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>?</page>
 		</mod>
@@ -5909,6 +5932,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>0</cost>
+			<required>
+				<vehicledetails>
+					<name>Horizon-Doble Revolution</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>?</page>
 		</mod>
@@ -5920,6 +5948,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>0</cost>
+			<required>
+				<vehicledetails>
+					<name operation="contains">Aeroquip M.E.D.-1 'Dustoff' Medical Evacuation Drone</name>
+				</vehicledetails>
+			</required>
 			<source>BB</source>
 			<page>23</page>
 		</mod>
@@ -7098,6 +7131,11 @@
 			<slots>0</slots>
 			<avail>8R</avail>
 			<cost>400</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7111,6 +7149,11 @@
 			<weaponmountcategories>Tasers,Holdouts,Light Pistols,Grenades,Blades,Clubs</weaponmountcategories>
 			<avail>4R</avail>
 			<cost>800</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7123,6 +7166,11 @@
 			<slots>1</slots>
 			<avail>4R</avail>
 			<cost>Body * 150</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7136,6 +7184,11 @@
 			<weaponmountcategories>Melee,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols</weaponmountcategories>
 			<avail>8R</avail>
 			<cost>1600</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7149,6 +7202,11 @@
 			<weaponmountcategories>Melee,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Grenade Launchers</weaponmountcategories>
 			<avail>10F</avail>
 			<cost>2400</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7162,6 +7220,11 @@
 			<weaponmountcategories>Melee,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Shotguns,Machine Guns,Cannons,Grenade Launchers,Sporting Rifles</weaponmountcategories>
 			<avail>12F</avail>
 			<cost>3200</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7175,6 +7238,11 @@
 			<weaponmountcategories>Melee,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Shotguns,Machine Guns,Cannons,Grenade Launchers,Missile Launchers,Laser Weapons,Light Machine Guns,Medium Machine Guns,Sporting Rifles,Sniper Rifles</weaponmountcategories>
 			<avail>16F</avail>
 			<cost>4000</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7187,6 +7255,11 @@
 			<slots>6</slots>
 			<avail>20F</avail>
 			<cost>4800</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7199,6 +7272,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>25</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7211,6 +7289,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>Rating * 100</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>124</page>
 		</mod>
@@ -7223,6 +7306,11 @@
 			<slots>0</slots>
 			<avail>FixedValues(2,4,8,12R)</avail>
 			<cost>FixedValues(Body * Body * 100,Body * Body * 500,Body * Body * 1000,Body * Body * 5000)</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7235,6 +7323,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>Body * Body * 100</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7247,6 +7340,11 @@
 			<slots>2</slots>
 			<avail>0</avail>
 			<cost>Body * Body * 1000</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7259,6 +7357,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>Body * 100</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7271,6 +7374,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>Variable(10-10000)</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7289,6 +7397,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>7500</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7307,6 +7420,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>10000</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7325,6 +7443,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>1500</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7343,6 +7466,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>7500</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7361,6 +7489,11 @@
 			<slots>1</slots>
 			<avail>0</avail>
 			<cost>10000</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>125</page>
 		</mod>
@@ -7379,6 +7512,11 @@
 				<speed>0</speed>
 				<offroadspeed>0</offroadspeed>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>126</page>
 		</mod>
@@ -7391,6 +7529,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>5</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>126</page>
 		</mod>
@@ -7403,6 +7546,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>50</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>126</page>
 		</mod>
@@ -7415,6 +7563,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>Body * 300</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>126</page>
 		</mod>
@@ -7427,6 +7580,11 @@
 			<slots>0</slots>
 			<avail>0</avail>
 			<cost>Body * 75</cost>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>126</page>
 		</mod>
@@ -7442,6 +7600,11 @@
 			<bonus>
 				<pilot>Rating</pilot>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>126</page>
 		</mod>
@@ -7470,6 +7633,11 @@
 				<handling>Rating</handling>
 				<offroadhandling>Rating</offroadhandling>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7487,6 +7655,11 @@
 				<speed>Rating</speed>
 				<offroadspeed>Rating</offroadspeed>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7504,6 +7677,11 @@
 				<accel>Rating</accel>
 				<offroadaccel>Rating</offroadaccel>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7519,6 +7697,11 @@
 			<bonus>
 				<body>-Rating</body>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7535,6 +7718,11 @@
 			<bonus>
 				<armor>Rating</armor>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7551,6 +7739,11 @@
 			<bonus>
 				<armor>Rating</armor>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7567,6 +7760,11 @@
 			<bonus>
 				<armor>Rating</armor>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7583,6 +7781,11 @@
 			<bonus>
 				<sensor>Rating</sensor>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7599,6 +7802,11 @@
 			<bonus>
 				<sensor>Rating</sensor>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<category operation="contains">Drones</category>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>123</page>
 		</mod>
@@ -7629,6 +7837,11 @@
 				<handling>-1</handling>
 				<seats>+1</seats>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<name>Daihatsu-Caterpillar Horseman</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>42</page>
 		</mod>
@@ -7647,6 +7860,11 @@
 				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<name>Daihatsu-Caterpillar Horseman</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>42</page>
 		</mod>
@@ -7665,6 +7883,11 @@
 				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<name>Daihatsu-Caterpillar Horseman</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>42</page>
 		</mod>
@@ -7683,6 +7906,11 @@
 				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<name>Daihatsu-Caterpillar Horseman</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>42</page>
 		</mod>
@@ -7703,6 +7931,11 @@
 				<offroadaccel>-1</offroadaccel>
 				<handling>-1</handling>
 			</bonus>
+			<required>
+				<vehicledetails>
+					<name>Daihatsu-Caterpillar Horseman</name>
+				</vehicledetails>
+			</required>
 			<source>R5</source>
 			<page>42</page>
 		</mod>

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -9032,8 +9032,9 @@ namespace Chummer
 			frmSelectVehicleMod frmPickVehicleMod = new frmSelectVehicleMod(_objCharacter, true);
 			// Pass the selected vehicle on to the form.
 			frmPickVehicleMod.SelectedVehicle = objSelectedVehicle;
+            frmPickVehicleMod.InstalledMods = objSelectedVehicle.Mods;
 
-			frmPickVehicleMod.ShowDialog(this);
+            frmPickVehicleMod.ShowDialog(this);
 
 			// Make sure the dialogue window was not canceled.
 			if (frmPickVehicleMod.DialogResult == DialogResult.Cancel)

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -23808,7 +23808,7 @@ namespace Chummer
 				lblVehiclePilot.Text = objVehicle.Pilot.ToString();
 				lblVehicleBody.Text = objVehicle.TotalBody.ToString();
 				lblVehicleArmor.Text = objVehicle.TotalArmor.ToString();
-				lblVehicleSeats.Text = objVehicle.Seats.ToString();
+				lblVehicleSeats.Text = objVehicle.TotalSeats.ToString();
 
 				lblVehicleSeatsLabel.Visible = true;
 				lblVehicleSeats.Visible = true;

--- a/Chummer/frmTest.cs
+++ b/Chummer/frmTest.cs
@@ -101,7 +101,7 @@ namespace Chummer
 					}
 					try
 					{
-						int objValue = objTemp.TotalAccel;
+                        string objValue = objTemp.TotalAccel;
 					}
 					catch
 					{
@@ -133,7 +133,7 @@ namespace Chummer
 					}
 					try
 					{
-						int objValue = objTemp.TotalSpeed;
+						string objValue = objTemp.TotalSpeed;
 					}
 					catch
 					{

--- a/Chummer/lang/de.xml
+++ b/Chummer/lang/de.xml
@@ -149,6 +149,10 @@
       <key>Label_Armor</key>
       <text>Panzerung:</text>
     </string>
+	<string>
+		<key>Label_Seats</key>
+		<text>Sitzplätze:</text>
+	</string>
     <string>
       <key>Label_Sensor</key>
       <text>Sensor:</text>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -463,6 +463,10 @@
 			<text>Armor:</text>
 		</string>
 		<string>
+			<key>Label_Seats</key>
+			<text>Seats:</text>
+		</string>
+		<string>
 			<key>Label_Sensor</key>
 			<text>Sensor:</text>
 		</string>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -162,6 +162,10 @@
       <key>Label_Armor</key>
       <text>Blindage :</text>
     </string>
+	<string>
+      <key>Label_Seats</key>
+      <text>Sièges :</text>
+    </string>
     <string>
       <key>Label_Sensor</key>
       <text>Senseurs :</text>

--- a/Chummer/lang/jp.xml
+++ b/Chummer/lang/jp.xml
@@ -168,6 +168,10 @@
       <key>Label_Armor</key>
       <text>装甲値:</text>
     </string>
+	<string>
+      <key>Label_Seats</key>
+      <text>席値:</text>
+    </string>
     <string>
       <key>Label_Sensor</key>
       <text>センサー:</text>


### PR DESCRIPTION
Application Changes to within Nightly version:

- Extended prototype XML node filtering to vehicle/drone mods.

Application Changes:

- Added the ability to distinguish between primary and offroad speed and acceleration, in addition to primary and offroad handling.
- Added the ability for vehicle mods to alter seat count.
- Added the ability for vehicle mods that alter speed, handling, and/or acceleration to properly subtract values and also to support percentage modifications instead of just flat ones.
- Added a label for seats to the vehicle selection screen.
- Vehicle mods can now be configured to be mutually exclusive with other vehicle mods.

Data Changes:

- Added the Coriolis complex form from Chrome Flesh.
- Added vehicle entries for the Cocotaxi and the Camellos from Hard Targets and the Ares Garuda and the Evo Aquavida 2 from Rigger 5.0.
- Added stats for secondary acceleration and speed (i.e. offroad acceleration and speed for ground vehicles, alternate locomotion for all others) where they were missing, e.g. from the Evo Falcon-EX, the Corsair Trident, and the Evo Krokodil.
- Corrected the seats for all vehicles that have separate front/back sections so that Chummer always displays the total seat count, not just the seat count for the larger section.
- Corrected the availability of most vehicles from Stolen Souls (to 4) and the Ares Roadmaster (to 8).
- Added custom filters to relevant vehicle/drone mods to stop them from showing up in the list of vehicle/drone mods unless specific conditions are fulfilled (e.g. drone mods only appear when modifying drones, Horseman modpods only appear when modifying a Horseman, etc.).