### PR TITLE
Howling Shadows, Critter, AI Additions

### DIFF
--- a/Chummer/Backend/Skills/Skill.cs
+++ b/Chummer/Backend/Skills/Skill.cs
@@ -427,6 +427,12 @@ namespace Chummer.Skills
 		{
 			get
 			{
+                if (Name.Contains("Flight"))
+                {
+                    string strFlyString = CharacterObject.Fly;
+                    if (strFlyString == "" || strFlyString == "0" || strFlyString.Contains("Special"))
+                        return false;
+                }
 				//TODO: This is a temporary workaround until proper support for selectively enabling or disabling skills works, as above.
 				if (CharacterObject.Metatype == "A.I.")
 				{

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -1032,49 +1032,17 @@ namespace Chummer
             // Merge the ToolStrips.
             ToolStripManager.RevertMerge("toolStrip");
             ToolStripManager.Merge(toolStrip, "toolStrip");
-
-            // If this is a Sprite, re-label the Mental CharacterAttribute Labels.
-            if (_objCharacter.Metatype.EndsWith("Sprite"))
+            
+            if (_objCharacter.Metatype.EndsWith("Sprite") || _objCharacter.DEPEnabled)
             {
-                lblBODLabel.Enabled = false;
-                nudBOD.Enabled = false;
-                lblAGILabel.Enabled = false;
-                nudAGI.Enabled = false;
-                lblREALabel.Enabled = false;
-                nudREA.Enabled = false;
-                lblSTRLabel.Enabled = false;
-                nudSTR.Enabled = false;
-                lblCHALabel.Text = LanguageManager.Instance.GetString("String_AttributePilot");
-                lblINTLabel.Text = LanguageManager.Instance.GetString("String_AttributeResponse");
-                lblLOGLabel.Text = LanguageManager.Instance.GetString("String_AttributeFirewall");
-                lblWILLabel.Enabled = false;
-                nudWIL.Enabled = false;
-            }
-            else if (_objCharacter.Metatype.Contains("A.I.") || _objCharacter.MetatypeCategory == "Protosapients")
-            {
-                lblRatingLabel.Visible = true;
-                lblRating.Visible = true;
-                lblSystemLabel.Visible = true;
-                lblSystem.Visible = true;
-                lblFirewallLabel.Visible = true;
-                lblFirewall.Visible = true;
-                lblResponseLabel.Visible = true;
-                nudResponse.Visible = true;
-                nudResponse.Enabled = true;
-                nudResponse.Value = _objCharacter.Response;
-                lblSignalLabel.Visible = true;
-                nudSignal.Visible = true;
-                nudSignal.Enabled = true;
-                nudSignal.Value = _objCharacter.Signal;
-
                 // Disable the Physical CharacterAttribute controls.
                 lblBODLabel.Enabled = false;
-                lblAGILabel.Enabled = false;
-                lblREALabel.Enabled = false;
-                lblSTRLabel.Enabled = false;
                 nudBOD.Enabled = false;
+                lblAGILabel.Enabled = false;
                 nudAGI.Enabled = false;
+                lblREALabel.Enabled = false;
                 nudREA.Enabled = false;
+                lblSTRLabel.Enabled = false;
                 nudSTR.Enabled = false;
             }
 

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -70,6 +70,7 @@ namespace Chummer
 			// Add EventHandlers for the various events MAG, RES, Qualities, etc.
 			_objCharacter.MAGEnabledChanged += objCharacter_MAGEnabledChanged;
             _objCharacter.RESEnabledChanged += objCharacter_RESEnabledChanged;
+            _objCharacter.DEPEnabledChanged += objCharacter_DEPEnabledChanged;
             _objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
             _objCharacter.MagicianTabEnabledChanged += objCharacter_MagicianTabEnabledChanged;
             _objCharacter.TechnomancerTabEnabledChanged += objCharacter_TechnomancerTabEnabledChanged;
@@ -368,17 +369,14 @@ namespace Chummer
 	        lblAdeptWayDiscount.Visible = _objCharacter.MAGEnabled;
             cmdCreateStackedFocus.Visible = _objCharacter.MAGEnabled;
 
-			if (_objCharacter.Metatype == "A.I.")
-			{
-				lblDEPAug.Enabled = true;
-				lblDEPLabel.Enabled = true;
-				if ((_objCharacter.BuildMethod != CharacterBuildMethod.Karma) && (_objCharacter.BuildMethod != CharacterBuildMethod.LifeModule))
-				{ 
-					nudDEP.Enabled = true;
-				}
-				nudKDEP.Enabled = true;
-				lblDEPMetatype.Enabled = true;
-			}
+			lblDEPAug.Enabled = _objCharacter.DEPEnabled;
+			lblDEPLabel.Enabled = _objCharacter.DEPEnabled;
+            if ((_objCharacter.BuildMethod != CharacterBuildMethod.Karma) && (_objCharacter.BuildMethod != CharacterBuildMethod.LifeModule))
+			{ 
+				nudDEP.Enabled = _objCharacter.DEPEnabled;
+            }
+			nudKDEP.Enabled = _objCharacter.DEPEnabled;
+            lblDEPMetatype.Enabled = _objCharacter.DEPEnabled;
 
             lblRESLabel.Enabled = _objCharacter.RESEnabled;
             lblRESAug.Enabled = _objCharacter.RESEnabled;
@@ -1052,7 +1050,7 @@ namespace Chummer
                 lblWILLabel.Enabled = false;
                 nudWIL.Enabled = false;
             }
-            else if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
+            else if (_objCharacter.Metatype.Contains("A.I.") || _objCharacter.MetatypeCategory == "Protosapients")
             {
                 lblRatingLabel.Visible = true;
                 lblRating.Visible = true;
@@ -1148,6 +1146,7 @@ namespace Chummer
                 // Unsubscribe from events.
                 _objCharacter.MAGEnabledChanged -= objCharacter_MAGEnabledChanged;
                 _objCharacter.RESEnabledChanged -= objCharacter_RESEnabledChanged;
+                _objCharacter.DEPEnabledChanged -= objCharacter_DEPEnabledChanged;
                 _objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
                 _objCharacter.MagicianTabEnabledChanged -= objCharacter_MagicianTabEnabledChanged;
                 _objCharacter.TechnomancerTabEnabledChanged -= objCharacter_TechnomancerTabEnabledChanged;
@@ -1447,6 +1446,38 @@ namespace Chummer
                 // Put RES back to the Metatype minimum.
                 nudRES.Value = nudRES.Minimum;
                 nudKRES.Value = nudKRES.Minimum;
+            }
+        }
+
+        private void objCharacter_DEPEnabledChanged(object sender)
+        {
+            if (_blnReapplyImprovements)
+                return;
+
+            // Change to the status of DEP being enabled.
+            lblDEPLabel.Enabled = _objCharacter.DEPEnabled;
+            lblDEPAug.Enabled = _objCharacter.DEPEnabled;
+            if (_objCharacter.BuildMethod != CharacterBuildMethod.Karma)
+            {
+                nudDEP.Enabled = _objCharacter.DEPEnabled;
+            }
+            nudKDEP.Enabled = _objCharacter.DEPEnabled;
+            lblDEPMetatype.Enabled = _objCharacter.DEPEnabled;
+
+            if (_objCharacter.DEPEnabled)
+            {
+                int intEssenceLoss = 0;
+                if (!_objOptions.ESSLossReducesMaximumOnly)
+                    intEssenceLoss = _objCharacter.EssencePenalty;
+                nudDEP.Minimum = _objCharacter.DEP.MetatypeMinimum;
+                nudDEP.Maximum = _objCharacter.DEP.MetatypeMaximum + intEssenceLoss;
+                nudKDEP.Maximum = _objCharacter.DEP.MetatypeMaximum + intEssenceLoss;
+            }
+            else
+            {
+                // Put DEP back to the Metatype minimum.
+                nudDEP.Value = nudDEP.Minimum;
+                nudKDEP.Value = nudKDEP.Minimum;
             }
         }
 
@@ -1898,8 +1929,9 @@ namespace Chummer
             _objCharacter.LOG.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.LOG.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
             _objCharacter.WIL.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.WIL.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
             _objCharacter.EDG.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.EDG.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.MAG.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.CHA.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
-            _objCharacter.RES.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.REA.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
+            _objCharacter.MAG.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.MAG.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
+            _objCharacter.RES.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.RES.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
+            _objCharacter.DEP.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.DEP.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
 
             _objCharacter.BOD.MetatypeMinimum = _objCharacter.BOD.Value;
             _objCharacter.AGI.MetatypeMinimum = _objCharacter.AGI.Value;
@@ -1912,6 +1944,7 @@ namespace Chummer
             _objCharacter.EDG.MetatypeMinimum = _objCharacter.EDG.Value;
             _objCharacter.MAG.MetatypeMinimum = _objCharacter.MAG.Value;
             _objCharacter.RES.MetatypeMinimum = _objCharacter.RES.Value;
+            _objCharacter.DEP.MetatypeMinimum = _objCharacter.DEP.Value;
 
             // Count the number of Skill points the Critter currently has.
             foreach (Skill objSkill in _objCharacter.SkillsSection.Skills)
@@ -2108,6 +2141,7 @@ namespace Chummer
             // Record the status of any flags that normally trigger character events.
             bool blnMAGEnabled = _objCharacter.MAGEnabled;
             bool blnRESEnabled = _objCharacter.RESEnabled;
+            bool blnDEPEnabled = _objCharacter.DEPEnabled;
             bool blnUneducated = _objCharacter.SkillsSection.Uneducated;
             bool blnUncouth = _objCharacter.SkillsSection.Uncouth;
             bool blnFriendsInHighPlaces = _objCharacter.FriendsInHighPlaces;
@@ -2586,6 +2620,8 @@ namespace Chummer
                 objCharacter_MAGEnabledChanged(this);
             if (blnRESEnabled != _objCharacter.RESEnabled)
                 objCharacter_RESEnabledChanged(this);
+            if (blnDEPEnabled != _objCharacter.DEPEnabled)
+                objCharacter_DEPEnabledChanged(this);
             if (blnUneducated != _objCharacter.SkillsSection.Uneducated)
                 objCharacter_UneducatedChanged(this);
             if (blnUncouth != _objCharacter.SkillsSection.Uncouth)
@@ -13817,6 +13853,7 @@ namespace Chummer
             {
                 nudMAG.Value = _objCharacter.MAG.Base;
                 nudRES.Value = _objCharacter.RES.Base;
+                nudDEP.Value = _objCharacter.DEP.Base;
             }
 
 			// Metatypes cost Karma.
@@ -14081,7 +14118,7 @@ namespace Chummer
 			        intAtt += Convert.ToInt32(nudMAG.Value - _objCharacter.MAG.TotalMinimum);
 		        if (_objCharacter.RESEnabled)
 			        intAtt += Convert.ToInt32(nudRES.Value - nudRES.Minimum);
-	            if (_objCharacter.Metatype == "A.I.")
+	            if (_objCharacter.DEPEnabled)
 	                intAtt += Convert.ToInt32(nudDEP.Value - nudDEP.Minimum);
 	        }
 
@@ -14108,7 +14145,7 @@ namespace Chummer
 				        intRES += ((Convert.ToInt32(nudRES.Value) + i)*_objOptions.KarmaAttribute);
 			        }
 		        }
-		        if (_objCharacter.Metatype == "A.I.")
+		        if (_objCharacter.DEPEnabled)
 		        {
 			        for (int i = 1; i <= nudKDEP.Value; i++)
 			        {
@@ -14137,7 +14174,7 @@ namespace Chummer
 						intRES += ((1 + i) * _objOptions.KarmaAttribute);
 					}
 				}
-				if (_objCharacter.Metatype == "A.I.")
+				if (_objCharacter.DEPEnabled)
 				{
 					for (int i = 1; i <= nudKDEP.Value; i++)
 					{
@@ -14160,6 +14197,10 @@ namespace Chummer
                 {
                     intRES += intEssenceLoss * Convert.ToInt32(nudRES.Value + nudKRES.Value) * _objOptions.KarmaAttribute;
                 }
+                if (_objCharacter.DEPEnabled && !_objCharacter.Options.ESSLossReducesMaximumOnly)
+                {
+                    intDEP += intEssenceLoss * Convert.ToInt32(nudDEP.Value + nudKDEP.Value) * _objOptions.KarmaAttribute;
+                }
             }
 
             string strTooltip = _objCharacter.EDG.Abbrev + "\t" + intEDG + "\n";
@@ -14171,7 +14212,7 @@ namespace Chummer
             {
                 strTooltip += _objCharacter.RES.Abbrev + "\t" + intRES + "\n";
             }
-            if (_objCharacter.Metatype == "A.I.")
+            if (_objCharacter.DEPEnabled)
             {
                 strTooltip += _objCharacter.DEP.Abbrev + "\t" + intDEP + "\n";
             }
@@ -14736,10 +14777,8 @@ namespace Chummer
 	            RedlinerCheck(); 
 
                 // If the character is an A.I., set the Edge MetatypeMaximum to their Rating.
-                if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
+                if (_objCharacter.DEPEnabled)
                     _objCharacter.EDG.MetatypeMaximum = _objCharacter.DEP.Value;
-
-                
 
                 // Calculate Free Contacts Points. Free points = (CHA) * 2.
 	            if (_objCharacter.BuildMethod == CharacterBuildMethod.Priority ||
@@ -14802,6 +14841,7 @@ namespace Chummer
                 {
                     _objImprovementManager.CreateImprovement("MAG", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, "", 0, 1, 0, intReduction * -1);
                     _objImprovementManager.CreateImprovement("RES", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, "", 0, 1, 0, intReduction * -1);
+                    _objImprovementManager.CreateImprovement("DEP", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, "", 0, 1, 0, intReduction * -1);
                 }
 
                 // If the character is Cyberzombie, adjust their Attributes based on their Essence.
@@ -14953,33 +14993,22 @@ namespace Chummer
                 }
 
                 // Update Living Persona values.
-                if (_objCharacter.RESEnabled)
+                if (_objCharacter.RESEnabled || _objCharacter.DEPEnabled)
                 {
+                    int intMainAttribute = _objCharacter.RES.TotalValue;
+                    if (_objCharacter.DEPEnabled)
+                        intMainAttribute = _objCharacter.DEP.TotalValue;
                     string strPersonaTip = "";
                     int intFirewall = _objCharacter.WIL.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaFirewall);
                     int intResponse = _objCharacter.INT.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaResponse);
-                    int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(_objCharacter.RES.TotalValue, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
+                    int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(intMainAttribute, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
                     int intSystem = _objCharacter.LOG.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSystem);
                     int intBiofeedback = _objCharacter.CHA.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaBiofeedback);
 
-                    // If this is a Technocritter, their Matrix Attributes always equal their RES.
-                    if (_objCharacter.MetatypeCategory == "Technocritters")
-                    {
-                        intFirewall = _objCharacter.RES.TotalValue;
-                        intSystem = _objCharacter.RES.TotalValue;
-                        intResponse = _objCharacter.RES.TotalValue;
-                        intSignal = _objCharacter.RES.TotalValue;
-                        intBiofeedback = _objCharacter.RES.TotalValue;
-                    }
-
-                    // Make sure none of the Attributes exceed the Technomancer's RES.
-                    intFirewall = Math.Min(intFirewall, _objCharacter.RES.TotalValue);
-                    intResponse = Math.Min(intResponse, _objCharacter.RES.TotalValue);
-                    intSignal = Math.Min(intSignal, _objCharacter.RES.TotalValue);
-                    intSystem = Math.Min(intSystem, _objCharacter.RES.TotalValue);
-
-                    lblLivingPersonaDeviceRating.Text = _objCharacter.RES.TotalValue.ToString();
-                    strPersonaTip = "RES (" + _objCharacter.RES.TotalValue.ToString() + ")";
+                    lblLivingPersonaDeviceRating.Text = intMainAttribute.ToString();
+                    strPersonaTip = "RES (" + intMainAttribute.ToString() + ")";
+                    if (_objCharacter.DEPEnabled)
+                        strPersonaTip = "DEP (" + intMainAttribute.ToString() + ")";
                     tipTooltip.SetToolTip(lblLivingPersonaDeviceRating, strPersonaTip);
 
                     lblLivingPersonaAttack.Text = _objCharacter.CHA.TotalValue.ToString();
@@ -15125,14 +15154,6 @@ namespace Chummer
                 if (_objImprovementManager.ValueOf(Improvement.ImprovementType.Memory) != 0)
                     strTip += " + " + LanguageManager.Instance.GetString("Tip_Modifiers") + " (" + _objImprovementManager.ValueOf(Improvement.ImprovementType.Memory).ToString() + ")";
                 tipTooltip.SetToolTip(lblMemory, strTip);
-
-                // Update A.I. Attributes.
-                if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
-                {
-                    lblRating.Text = _objCharacter.Rating.ToString();
-                    lblSystem.Text = _objCharacter.System.ToString();
-                    lblFirewall.Text = _objCharacter.Firewall.ToString();
-                }
 
                 // If this is a Mutant Critter, determine their Essence loss: -1 for each of: Every 2 points added to a Skill, Each Quality (or Quality Rating). This can be offset by a Negative Quality (or Quality Rating)
                 if (_objCharacter.MetatypeCategory == "Mutant Critters")
@@ -16686,12 +16707,14 @@ namespace Chummer
             //}
 
             // If the character has an Essence Penalty, this needs to be added as a positive value to the character's MAG/RES so that it's correctly shown in Career Mode.
-            if (_objCharacter.EssencePenalty > 0 && (_objCharacter.MAGEnabled || _objCharacter.RESEnabled))
+            if (_objCharacter.EssencePenalty > 0 && (_objCharacter.MAGEnabled || _objCharacter.RESEnabled || _objCharacter.DEPEnabled))
             {
                 if (_objCharacter.MAGEnabled)
                     _objCharacter.MAG.Value += _objCharacter.EssencePenalty;
                 if (_objCharacter.RESEnabled)
                     _objCharacter.RES.Value += _objCharacter.EssencePenalty;
+                if (_objCharacter.DEPEnabled)
+                    _objCharacter.DEP.Value += _objCharacter.EssencePenalty;
             }
 
             // Create an Expense Entry for Starting Nuyen.
@@ -16950,7 +16973,7 @@ namespace Chummer
             XmlNode objXmlGear = objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"" + objSelectedGear.Name + "\" and category = \"" + objSelectedGear.Category + "\"]");
 
             bool blnFakeCareerMode = false;
-            if (_objCharacter.Metatype == "A.I." || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
+            if (_objCharacter.Metatype.Contains("A.I.") || _objCharacter.MetatypeCategory == "Protosapients")
                 blnFakeCareerMode = true;
             frmSelectGear frmPickGear = new frmSelectGear(_objCharacter, blnFakeCareerMode, objSelectedGear.ChildAvailModifier, objSelectedGear.ChildCostMultiplier);
             try
@@ -17161,7 +17184,7 @@ namespace Chummer
             XmlNode objXmlGear = objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"" + objSelectedGear.Name + "\" and category = \"" + objSelectedGear.Category + "\"]");
 
             bool blnFakeCareerMode = false;
-            if (_objCharacter.Metatype == "A.I." || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
+            if (_objCharacter.Metatype.Contains("A.I.") || _objCharacter.MetatypeCategory == "Protosapients")
                 blnFakeCareerMode = true;
             frmSelectGear frmPickGear = new frmSelectGear(_objCharacter, blnFakeCareerMode);
             frmPickGear.ShowArmorCapacityOnly = blnShowArmorCapacityOnly;
@@ -17724,7 +17747,7 @@ namespace Chummer
                 chkVehicleWeaponAccessoryInstalled.Enabled = false;
                 chkVehicleIncludedInWeapon.Checked = false;
 
-                if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
+                if (_objCharacter.Metatype.Contains("A.I.") || _objCharacter.MetatypeCategory == "Protosapients")
                 {
                     chkVehicleHomeNode.Visible = true;
                     chkVehicleHomeNode.Checked = objVehicle.HomeNode;

--- a/Chummer/Character Creation/frmKarmaMetatype.cs
+++ b/Chummer/Character Creation/frmKarmaMetatype.cs
@@ -48,7 +48,12 @@ namespace Chummer
 			// Do nothing. This is just an Event trap so an exception doesn't get thrown.
 		}
 
-		private void objCharacter_AdeptTabEnabledChanged(object sender)
+        private void objCharacter_DEPEnabledChanged(object sender)
+        {
+            // Do nothing. This is just an Event trap so an exception doesn't get thrown.
+        }
+
+        private void objCharacter_AdeptTabEnabledChanged(object sender)
 		{
 			// Do nothing. This is just an Event trap so an exception doesn't get thrown.
 		}
@@ -97,7 +102,8 @@ namespace Chummer
 			// Attach EventHandlers for MAGEnabledChange and RESEnabledChanged since some Metatypes can enable these.
 			_objCharacter.MAGEnabledChanged += objCharacter_MAGEnabledChanged;
 			_objCharacter.RESEnabledChanged += objCharacter_RESEnabledChanged;
-			_objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
+            _objCharacter.DEPEnabledChanged += objCharacter_DEPEnabledChanged;
+            _objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
 			_objCharacter.MagicianTabEnabledChanged += objCharacter_MagicianTabEnabledChanged;
 			_objCharacter.TechnomancerTabEnabledChanged += objCharacter_TechnomancerTabEnabledChanged;
 			_objCharacter.InitiationTabEnabledChanged += objCharacter_InitiationTabEnabledChanged;
@@ -109,7 +115,8 @@ namespace Chummer
 			// Detach EventHandlers for MAGEnabledChange and RESEnabledChanged since some Metatypes can enable these.
 			_objCharacter.MAGEnabledChanged -= objCharacter_MAGEnabledChanged;
 			_objCharacter.RESEnabledChanged -= objCharacter_RESEnabledChanged;
-			_objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
+            _objCharacter.DEPEnabledChanged -= objCharacter_DEPEnabledChanged;
+            _objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
 			_objCharacter.MagicianTabEnabledChanged -= objCharacter_MagicianTabEnabledChanged;
 			_objCharacter.TechnomancerTabEnabledChanged -= objCharacter_TechnomancerTabEnabledChanged;
 			_objCharacter.InitiationTabEnabledChanged -= objCharacter_InitiationTabEnabledChanged;
@@ -605,10 +612,7 @@ namespace Chummer
                     _objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetavariant["resmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["resmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["resaug"].InnerText, intForce, 0));
                     _objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetavariant["edgmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["edgmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["edgaug"].InnerText, intForce, 0));
                     _objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetavariant["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["essaug"].InnerText, intForce, 0));
-					if (lstMetatypes.SelectedValue.ToString() == "A.I.")
-					{
-						_objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetavariant["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["depaug"].InnerText, intForce, 0));
-					}
+					_objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetavariant["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["depaug"].InnerText, intForce, 0));
 				}
 				else if (_strXmlFile != "critters.xml" || lstMetatypes.SelectedValue.ToString() == "Ally Spirit")
 				{
@@ -625,34 +629,34 @@ namespace Chummer
 					_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["resmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["resaug"].InnerText, intForce, 0));
 					_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["edgmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["edgaug"].InnerText, intForce, 0));
 					_objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
-					if (lstMetatypes.SelectedValue.ToString() == "A.I.")
-					{
-						_objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depaug"].InnerText, intForce, 0));
-					}
+					_objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depaug"].InnerText, intForce, 0));
 				}
 				else
 				{
-					int intMinModifier = -3;
-					if (cboCategory.SelectedValue.ToString() == "Mutant Critters")
-						intMinModifier = 0;
-					_objCharacter.BOD.AssignLimits(ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, 3));
-					_objCharacter.AGI.AssignLimits(ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, 3));
-					_objCharacter.REA.AssignLimits(ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, 3));
-					_objCharacter.STR.AssignLimits(ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, 3));
-					_objCharacter.CHA.AssignLimits(ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, 3));
-					_objCharacter.INT.AssignLimits(ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, 3));
-					_objCharacter.LOG.AssignLimits(ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, 3));
-					_objCharacter.WIL.AssignLimits(ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, 3));
-					_objCharacter.INI.AssignLimits(ExpressionToString(objXmlMetatype["inimin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["iniaug"].InnerText, intForce, 0));
-					_objCharacter.MAG.AssignLimits(ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, 3));
-					_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 3));
-					_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 3));
-					_objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
-					if (lstMetatypes.SelectedValue.ToString() == "A.I.")
-					{
-						_objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depaug"].InnerText, intForce, 0));
-					}
-				}
+                    int intMinModifier = -3;
+                    int intMaxModifier = 3;
+                    if (cboCategory.SelectedValue.ToString() == "Mutant Critters")
+                        intMinModifier = 0;
+                    if (cboCategory.SelectedValue.ToString() == "Technocritters")
+                    {
+                        intMinModifier = -1;
+                        intMaxModifier = 1;
+                    }
+                    _objCharacter.BOD.AssignLimits(ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.AGI.AssignLimits(ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.REA.AssignLimits(ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.STR.AssignLimits(ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.CHA.AssignLimits(ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.INT.AssignLimits(ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.LOG.AssignLimits(ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.WIL.AssignLimits(ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.INI.AssignLimits(ExpressionToString(objXmlMetatype["inimin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["iniaug"].InnerText, intForce, 0));
+                    _objCharacter.MAG.AssignLimits(ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMaxModifier));
+                    _objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
+                    _objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMaxModifier));
+                }
 
 				// If we're working with a Critter, set the Attributes to their default values.
 				if (_strXmlFile == "critters.xml")
@@ -669,29 +673,19 @@ namespace Chummer
 					_objCharacter.RES.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 0));
 					_objCharacter.EDG.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 0));
 					_objCharacter.ESS.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0));
-					if (lstMetatypes.SelectedValue.ToString() == "A.I.")
-					{
-						_objCharacter.DEP.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["depmax"].InnerText, intForce, 0));
-					}
+					_objCharacter.DEP.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0));
 				}
 
-				// Sprites can never have Physical Attributes or WIL.
-				if ((lstMetatypes.SelectedValue.ToString().EndsWith("Sprite") || cboCategory.SelectedValue.ToString().EndsWith("A.I.")))
+				// Sprites can never have Physical Attributes
+				if (_objCharacter.DEPEnabled || lstMetatypes.SelectedValue.ToString().EndsWith("Sprite"))
 				{
 					_objCharacter.BOD.AssignLimits("0", "0", "0");
 					_objCharacter.AGI.AssignLimits("0", "0", "0");
 					_objCharacter.REA.AssignLimits("0", "0", "0");
 					_objCharacter.STR.AssignLimits("0", "0", "0");
-					_objCharacter.WIL.AssignLimits("0", "0", "0");
-					_objCharacter.INI.MetatypeMinimum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
+                    _objCharacter.MAG.AssignLimits("0", "0", "0");
+                    _objCharacter.INI.MetatypeMinimum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
 					_objCharacter.INI.MetatypeMaximum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
-				}
-
-				// Sprites can never have MAG or RES attributes.
-				if (cboCategory.SelectedValue.ToString().EndsWith("A.I."))
-				{
-					_objCharacter.MAG.AssignLimits("0", "0", "0");
-					_objCharacter.RES.AssignLimits("0", "0", "0");
 				}
 
 				// If this is a Shapeshifter, a Metavariant must be selected. Default to Human if None is selected.

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -41,7 +41,12 @@ namespace Chummer
 			// Do nothing. This is just an Event trap so an exception doesn't get thrown.
 		}
 
-		private void objCharacter_AdeptTabEnabledChanged(object sender)
+        private void objCharacter_DEPEnabledChanged(object sender)
+        {
+            // Do nothing. This is just an Event trap so an exception doesn't get thrown.
+        }
+
+        private void objCharacter_AdeptTabEnabledChanged(object sender)
 		{
 			// Do nothing. This is just an Event trap so an exception doesn't get thrown.
 		}
@@ -213,7 +218,8 @@ namespace Chummer
 			// Attach EventHandlers for MAGEnabledChange and RESEnabledChanged since some Metatypes can enable these.
 			_objCharacter.MAGEnabledChanged += objCharacter_MAGEnabledChanged;
 			_objCharacter.RESEnabledChanged += objCharacter_RESEnabledChanged;
-			_objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
+            _objCharacter.DEPEnabledChanged += objCharacter_DEPEnabledChanged;
+            _objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
 			_objCharacter.MagicianTabEnabledChanged += objCharacter_MagicianTabEnabledChanged;
 			_objCharacter.TechnomancerTabEnabledChanged += objCharacter_TechnomancerTabEnabledChanged;
 			_objCharacter.InitiationTabEnabledChanged += objCharacter_InitiationTabEnabledChanged;
@@ -225,7 +231,8 @@ namespace Chummer
 			// Detach EventHandlers for MAGEnabledChange and RESEnabledChanged since some Metatypes can enable these.
 			_objCharacter.MAGEnabledChanged -= objCharacter_MAGEnabledChanged;
 			_objCharacter.RESEnabledChanged -= objCharacter_RESEnabledChanged;
-			_objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
+            _objCharacter.DEPEnabledChanged -= objCharacter_DEPEnabledChanged;
+            _objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
 			_objCharacter.MagicianTabEnabledChanged -= objCharacter_MagicianTabEnabledChanged;
 			_objCharacter.TechnomancerTabEnabledChanged -= objCharacter_TechnomancerTabEnabledChanged;
 			_objCharacter.InitiationTabEnabledChanged -= objCharacter_InitiationTabEnabledChanged;
@@ -989,7 +996,7 @@ namespace Chummer
                     _objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetavariant["resmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["resmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["resaug"].InnerText, intForce, 0));
                     _objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetavariant["edgmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["edgmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["edgaug"].InnerText, intForce, 0));
                     _objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetavariant["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["essaug"].InnerText, intForce, 0));
-                    
+                    _objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetavariant["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetavariant["depaug"].InnerText, intForce, 0));
                 }
                 else if (_strXmlFile != "critters.xml" || lstMetatypes.SelectedValue.ToString() == "Ally Spirit")
 				{
@@ -1006,26 +1013,34 @@ namespace Chummer
 					_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["resmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["resaug"].InnerText, intForce, 0));
 					_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["edgmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["edgaug"].InnerText, intForce, 0));
 					_objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
-				}
+                    _objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depaug"].InnerText, intForce, 0));
+                }
 				else
 				{
 					int intMinModifier = -3;
-					if (cboCategory.SelectedValue.ToString() == "Mutant Critters")
-						intMinModifier = 0;
-					_objCharacter.BOD.AssignLimits(ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, 3));
-					_objCharacter.AGI.AssignLimits(ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, 3));
-					_objCharacter.REA.AssignLimits(ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, 3));
-					_objCharacter.STR.AssignLimits(ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, 3));
-					_objCharacter.CHA.AssignLimits(ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, 3));
-					_objCharacter.INT.AssignLimits(ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, 3));
-					_objCharacter.LOG.AssignLimits(ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, 3));
-					_objCharacter.WIL.AssignLimits(ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, 3));
+                    int intMaxModifier = 3;
+                    if (cboCategory.SelectedValue.ToString() == "Mutant Critters")
+                        intMinModifier = 0;
+                    if (cboCategory.SelectedValue.ToString() == "Technocritters")
+                    {
+                        intMinModifier = -1;
+                        intMaxModifier = 1;
+                    }
+                    _objCharacter.BOD.AssignLimits(ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["bodmin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.AGI.AssignLimits(ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["agimin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.REA.AssignLimits(ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["reamin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.STR.AssignLimits(ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["strmin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.CHA.AssignLimits(ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["chamin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.INT.AssignLimits(ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["intmin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.LOG.AssignLimits(ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["logmin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.WIL.AssignLimits(ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["wilmin"].InnerText, intForce, intMaxModifier));
 					_objCharacter.INI.AssignLimits(ExpressionToString(objXmlMetatype["inimin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["iniaug"].InnerText, intForce, 0));
-					_objCharacter.MAG.AssignLimits(ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, 3));
-					_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 3));
-					_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 3));
+					_objCharacter.MAG.AssignLimits(ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["magmin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMaxModifier));
+					_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMaxModifier));
 					_objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
-				}
+                    _objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMaxModifier), ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMaxModifier));
+                }
 
 				// If we're working with a Critter, set the Attributes to their default values.
 				if (_strXmlFile == "critters.xml")
@@ -1042,17 +1057,18 @@ namespace Chummer
 					_objCharacter.RES.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 0));
 					_objCharacter.EDG.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 0));
 					_objCharacter.ESS.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0));
-				}
+                    _objCharacter.DEP.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0));
+                }
 
-				// Sprites can never have Physical Attributes or WIL.
-				if (lstMetatypes.SelectedValue.ToString().EndsWith("Sprite"))
+				// Sprites can never have Physical Attributes
+				if (_objCharacter.DEPEnabled || lstMetatypes.SelectedValue.ToString().EndsWith("Sprite"))
 				{
 					_objCharacter.BOD.AssignLimits("0", "0", "0");
 					_objCharacter.AGI.AssignLimits("0", "0", "0");
 					_objCharacter.REA.AssignLimits("0", "0", "0");
 					_objCharacter.STR.AssignLimits("0", "0", "0");
-					_objCharacter.WIL.AssignLimits("0", "0", "0");
-					_objCharacter.INI.MetatypeMinimum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
+                    _objCharacter.MAG.AssignLimits("0", "0", "0");
+                    _objCharacter.INI.MetatypeMinimum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
 					_objCharacter.INI.MetatypeMaximum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
 				}
 				

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -1562,6 +1562,17 @@ namespace Chummer
                 if (objXmlTalentList[0]["maxresonance"] != null)
                     _objCharacter.RES.MetatypeMaximum = Convert.ToInt32(objXmlTalentList[0]["resonance"].InnerText);
 
+                // Set starting depth
+                objXmlTalentList = objXmlDocumentPriority.SelectNodes("/chummer/priorities/priority[category = \"Talent\" and value = \"" + cboTalent.SelectedValue + "\"]/talents/talent[value = \"" + cboTalents.SelectedValue + "\"]");
+                if (objXmlTalentList[0]["depth"] != null)
+                {
+                    _objCharacter.DEP.MetatypeMinimum = Convert.ToInt32(objXmlTalentList[0]["depth"].InnerText);
+                    _objCharacter.CFPLimit = Convert.ToInt32(objXmlTalentList[0]["cfp"].InnerText);
+                }
+
+                if (objXmlTalentList[0]["maxdepth"] != null)
+                    _objCharacter.DEP.MetatypeMaximum = Convert.ToInt32(objXmlTalentList[0]["depth"].InnerText);
+
                 // Set Free Skills/Skill Groups
                 int intFreeLevels = 0;
                 switch ((cboTalent.SelectedValue.ToString().Split(',')[0]))

--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -112,7 +112,14 @@ namespace Chummer.Classes
 				CreateImprovement("RES", _objImprovementSource, SourceName, Improvement.ImprovementType.Attribute,
 					"enableattribute", 0, 0);
 			}
-		}
+            else if (bonusNode["name"].InnerText == "DEP")
+            {
+                _objCharacter.DEPEnabled = true;
+                Log.Info("Calling CreateImprovement for DEP");
+                CreateImprovement("DEP", _objImprovementSource, SourceName, Improvement.ImprovementType.Attribute,
+                    "enableattribute", 0, 0);
+            }
+        }
 
 		// Add an Attribute Replacement.
 		public void replaceattributes(XmlNode bonusNode)
@@ -464,8 +471,10 @@ namespace Chummer.Classes
 					frmPickAttribute.AddMAG();
 				if (_objCharacter.RESEnabled)
 					frmPickAttribute.AddRES();
+                if (_objCharacter.DEPEnabled)
+                    frmPickAttribute.AddDEP();
 
-				Log.Info("selectattribute = " + bonusNode.OuterXml.ToString());
+                Log.Info("selectattribute = " + bonusNode.OuterXml.ToString());
 
 				if (objXmlAttribute.InnerXml.Contains("<attribute>"))
 				{
@@ -556,8 +565,10 @@ namespace Chummer.Classes
 				frmPickAttribute.AddMAG();
 			if (_objCharacter.RESEnabled)
 				frmPickAttribute.AddRES();
+            if (_objCharacter.DEPEnabled)
+                frmPickAttribute.AddDEP();
 
-			Log.Info("selectattribute = " + bonusNode.OuterXml.ToString());
+            Log.Info("selectattribute = " + bonusNode.OuterXml.ToString());
 
 			if (bonusNode.InnerXml.Contains("<attribute>"))
 			{
@@ -2509,8 +2520,10 @@ namespace Chummer.Classes
 						frmPickAttribute.AddMAG();
 					if (_objCharacter.RESEnabled)
 						frmPickAttribute.AddRES();
+                    if (_objCharacter.DEPEnabled)
+                        frmPickAttribute.AddDEP();
 
-					if (nodSkill["selectattribute"].InnerXml.Contains("<attribute>"))
+                    if (nodSkill["selectattribute"].InnerXml.Contains("<attribute>"))
 					{
 						List<string> strValue = new List<string>();
 						foreach (XmlNode objXmlAttribute in nodSkill["selectattribute"].SelectNodes("attribute"))
@@ -2950,8 +2963,10 @@ namespace Chummer.Classes
 								frmPickAttribute.AddMAG();
 							if (_objCharacter.RESEnabled)
 								frmPickAttribute.AddRES();
+                            if (_objCharacter.DEPEnabled)
+                                frmPickAttribute.AddDEP();
 
-							if (nodSkill["selectattribute"].InnerXml.Contains("<attribute>"))
+                            if (nodSkill["selectattribute"].InnerXml.Contains("<attribute>"))
 							{
 								List<string> strValue = new List<string>();
 								foreach (XmlNode objXmlAttribute in nodSkill["selectattribute"].SelectNodes("attribute"))

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -1288,7 +1288,28 @@ namespace Chummer
 						if (!blnFound)
 							_objCharacter.RESEnabled = false;
 					}
-				}
+                    else if (objImprovement.ImprovedName == "DEP")
+                    {
+                        // See if the character has anything else that is granting them access to RES.
+                        bool blnFound = false;
+                        foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
+                        {
+                            // Skip items from the current Improvement source.
+                            if (objCharacterImprovement.SourceName != objImprovement.SourceName)
+                            {
+                                if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Attribute &&
+                                    objCharacterImprovement.UniqueName == "enableattribute" && objCharacterImprovement.ImprovedName == "DEP")
+                                {
+                                    blnFound = true;
+                                    break;
+                                }
+                            }
+                        }
+
+                        if (!blnFound)
+                            _objCharacter.DEPEnabled = false;
+                    }
+                }
 
 				// Determine if access to any special tabs have been lost.
 				if (objImprovement.ImproveType == Improvement.ImprovementType.SpecialTab && objImprovement.UniqueName == "enabletab")

--- a/Chummer/Classes/clsUnique.cs
+++ b/Chummer/Classes/clsUnique.cs
@@ -141,8 +141,8 @@ namespace Chummer
 			{
 				_intMetatypeMin = value;
 				// If changing the Minimum would cause the current value to be outside of its bounds, bring it back within acceptable limits.
-				if (Value < value)
-					Value = value;
+				if (Value < value + MinimumModifiers)
+					Value = value + MinimumModifiers;
 			}
 		}
 
@@ -164,8 +164,8 @@ namespace Chummer
 			{
 				_intMetatypeMax = value;
 				// If changing the Maximum would cause the current value to be outside of its bounds, bring it back within acceptable limits.
-				if (Value > value)
-					Value = value;
+				if (Value > value + MaximumModifiers)
+					Value = value + MaximumModifiers;
 			}
 		}
 
@@ -641,7 +641,7 @@ namespace Chummer
 					intReturn = TotalAugmentedMaximum;
 
 				// An Attribute cannot go below 1 unless it is EDG, MAG, or RES, the character is a Critter, or the Metatype Maximum is 0.
-				if (_objCharacter.CritterEnabled || _strAbbrev == "EDG" || _intMetatypeMax == 0 || (_objCharacter.EssencePenalty != 0 && (_strAbbrev == "MAG" || _strAbbrev == "RES")) || (_objCharacter.MetatypeCategory != "A.I." && _strAbbrev == "DEP"))
+				if (_objCharacter.CritterEnabled || _strAbbrev == "EDG" || _intMetatypeMax == 0 || (_objCharacter.EssencePenalty != 0 && (_strAbbrev == "MAG" || _strAbbrev == "RES" || _strAbbrev == "DEP")))
 				{
 					if (intReturn < 0)
 						return 0;
@@ -694,7 +694,7 @@ namespace Chummer
 					intReturn = 0;
 				}*/
 
-				if (_objCharacter.EssencePenalty != 0 && (_strAbbrev == "MAG" || _strAbbrev == "RES"))
+				if (_objCharacter.EssencePenalty != 0 && (_strAbbrev == "MAG" || _strAbbrev == "RES" || _strAbbrev == "DEP"))
 				{
 					if (_objCharacter.Options.ESSLossReducesMaximumOnly || _objCharacter.OverrideSpecialAttributeEssenceLoss)
 					{
@@ -743,8 +743,8 @@ namespace Chummer
 			get
 			{
 				int intReturn = 0;
-				if (_strAbbrev == "EDG" || _strAbbrev == "MAG" || _strAbbrev == "RES")
-					intReturn = TotalMaximum + AugmentedMaximumModifiers;
+				if (_strAbbrev == "EDG" || _strAbbrev == "MAG" || _strAbbrev == "RES" || _strAbbrev == "DEP")
+                    intReturn = TotalMaximum + AugmentedMaximumModifiers;
 				else
 					intReturn = TotalMaximum + 4 + AugmentedMaximumModifiers;
                     // intReturn = TotalMaximum + Convert.ToInt32(Math.Floor((Convert.ToDecimal(TotalMaximum, GlobalOptions.Instance.CultureInfo) / 2))) + AugmentedMaximumModifiers;
@@ -972,7 +972,7 @@ namespace Chummer
 		{
 			int intBP = 0;
 
-			if (_strAbbrev != "EDG" && _strAbbrev != "MAG" && _strAbbrev != "RES")
+			if (_strAbbrev != "EDG" && _strAbbrev != "MAG" && _strAbbrev != "RES" && _strAbbrev != "DEP")
 			{
 				if (_objCharacter.Options.AlternateMetatypeAttributeKarma)
 				{

--- a/Chummer/Selection Forms/frmSelectAttribute.cs
+++ b/Chummer/Selection Forms/frmSelectAttribute.cs
@@ -180,11 +180,26 @@ namespace Chummer
 			cboAttribute.DisplayMember = "Name";
         }
 
-		/// <summary>
-		/// Limit the list to a single Attribute.
-		/// </summary>
-		/// <param name="strValue">Single Attribute to display.</param>
-		public void SingleAttribute(string strValue)
+        /// <summary>
+        /// Add DEP to the list of selectable Attributes.
+        /// </summary>
+        public void AddDEP()
+        {
+            ListItem objDEP = new ListItem();
+            objDEP.Value = "DEP";
+            objDEP.Name = LanguageManager.Instance.GetString("String_AttributeDEPShort");
+            _lstAttributes.Add(objDEP);
+            cboAttribute.DataSource = null;
+            cboAttribute.DataSource = _lstAttributes;
+            cboAttribute.ValueMember = "Value";
+            cboAttribute.DisplayMember = "Name";
+        }
+
+        /// <summary>
+        /// Limit the list to a single Attribute.
+        /// </summary>
+        /// <param name="strValue">Single Attribute to display.</param>
+        public void SingleAttribute(string strValue)
 		{
 			List<ListItem> lstItems = new List<ListItem>();
 			ListItem objItem = new ListItem();

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -43,6 +43,8 @@ Application Changes:
 - Vehicle mods can now be configured to be mutually exclusive with other vehicle mods.
 - Vehicles now properly show their total Seats, rather than their base Seats.
 - New Improvement Type: UnarmedReach. Used for granting bonuses to the Unarmed Attack weapon. 
+- Fixed the bug where Matrix entities would have SR4 stats in career mode.
+- Depth is now properly handled in ways similar to Resonance and Magic. While this currently only affects critters, it should be a precursor to AI chargen.
 
 Data Changes: 
 
@@ -137,6 +139,11 @@ Data Changes:
 - Added custom filters to relevant vehicle/drone mods to stop them from showing up in the list of vehicle/drone mods unless specific conditions are fulfilled (e.g. drone mods only appear when modifying drones, Horseman modpods only appear when modifying a Horseman, etc.).
 - Added a variety of knowledge skills, courtesy of Lochabar. 
 - Added a bonus node to the Kick Attack martial art technique that grants additional Reach to the Unarmed Attack weapon. 
+- Added and/or updated all critter powers to SR5, complete with proper references.
+- Added the Flight skill as described by the core rulebook. It will only show up for characters with a non-zero Fly speed.
+- Added and/or updated the following critter types from SR5: mundane critters from both CRB and HS, paracritters from both CRB and HS, technocritters from HS, insect spirits from SG, sprites from CRB, protosapients from HS, infected critters from HS, toxic spirits from SG, shadow spirits from SG, shedim from SG, and blood spirits from SG. Currently, the following entries are missing: toxic critters from HS, otherworldly beings from HS, and the Manananggal and Engkanto from SG.
+- Added all missing Critter Gear from HS.
+- Added Specialized Biodrone Cyberware from HS.
 
 Sheet Changes: 
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -45,6 +45,9 @@ Application Changes:
 - New Improvement Type: UnarmedReach. Used for granting bonuses to the Unarmed Attack weapon. 
 - Fixed the bug where Matrix entities would have SR4 stats in career mode.
 - Depth is now properly handled in ways similar to Resonance and Magic. While this currently only affects critters, it should be a precursor to AI chargen.
+- Fixed a bug where setting the metatype maximum of an attribute to a value lower than the current value would lower the current value, even if the current value was not higher than the total maximum.
+- Removed SR4 labels from Matrix entities in Create mode.
+- Added the ability for priorities to add to Depth.
 
 Data Changes: 
 

--- a/Chummer/data/critterpowers.xml
+++ b/Chummer/data/critterpowers.xml
@@ -1063,8 +1063,8 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>216</page>
+			<source>HS</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>818bf01a-b959-4bb9-b202-45efd3b9819b</id>
@@ -1074,8 +1074,8 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>216</page>
+			<source>HS</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>5aa8f042-2180-43f9-8f46-7053a20cbe45</id>
@@ -1085,19 +1085,19 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>216</page>
+			<source>HS</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>b561f86f-683c-4ae3-b867-9c628d5f8953</id>
 			<name>Diagnostics</name>
 			<category>Emergent</category>
 			<type />
-			<action />
+			<action>Simple</action>
 			<range />
-			<duration />
-			<source>RF</source>
-			<page>216</page>
+			<duration>Sustained</duration>
+			<source>SR5</source>
+			<page>257</page>
 		</power>
 		<power>
 			<id>4dc7af87-675c-4014-aa05-de6246fc8c14</id>
@@ -1107,19 +1107,30 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>216</page>
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>f8ae2d3f-cd93-47d3-bf4c-652464a871ba</id>
+			<name>Gremlins (Sprite)</name>
+			<category>Emergent</category>
+			<type>Device</type>
+			<action>Complex</action>
+			<range />
+			<duration>Instant</duration>
+			<source>SR5</source>
+			<page>257</page>
+		</power>
+		<power>
+			<id>b947d60a-8ac6-4185-8a5c-fc7a24ef69eb</id>
 			<name>Gremlins</name>
 			<category>Emergent</category>
 			<type />
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>217</page>
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>c04021ed-c7c8-4138-881f-30c86f01e43c</id>
@@ -1140,8 +1151,19 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>217</page>
+			<source>HS</source>
+			<page>195</page>
+		</power>
+		<power>
+			<id>f861c488-9818-4a40-a985-0138d3f164d5</id>
+			<name>Resonance Feed</name>
+			<category>Emergent</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>fb24283f-c6d2-4f06-a380-16edb6982cb2</id>
@@ -1173,19 +1195,19 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>218</page>
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>f4026d71-afcb-430f-9336-56a280a77d36</id>
 			<name>Suppression</name>
 			<category>Emergent</category>
-			<type />
-			<action />
+			<type>Host</type>
+			<action>Complex</action>
 			<range />
-			<duration />
-			<source>RF</source>
-			<page>218</page>
+			<duration>Sustained</duration>
+			<source>SR5</source>
+			<page>257</page>
 		</power>
 		<power>
 			<id>faa5e5c8-aa8a-45d5-b3f5-dd18c454ba07</id>
@@ -1209,8 +1231,8 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>218</page>
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>7a2a318f-4c30-46e0-9603-7b58dcb48150</id>
@@ -1220,8 +1242,8 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>218</page>
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>e08eeffc-6350-4e4d-9365-6f8530801d12</id>
@@ -1231,8 +1253,8 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>218</page>
+			<source>HS</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>25316188-db17-4504-b422-07332e908d07</id>
@@ -1564,37 +1586,48 @@
 			<page>304</page>
 		</power>
 		<power>
+			<id>83289bc7-6c5d-4782-9523-bc8e08b0f521</id>
+			<name>Camouflage</name>
+			<category>Emergent</category>
+			<type>File</type>
+			<action>Complex</action>
+			<range />
+			<duration>Permanent</duration>
+			<source>SR5</source>
+			<page>256</page>
+		</power>
+		<power>
 			<id>fc132915-118e-4fd2-a443-2f9799a83b4a</id>
 			<name>Cookie</name>
 			<category>Emergent</category>
-			<type />
-			<action>OT</action>
-			<range>Node</range>
+			<type>Persona</type>
+			<action>Complex</action>
+			<range />
 			<duration>Predetermined by Sprite</duration>
-			<source>SR4</source>
-			<page>242</page>
+			<source>SR5</source>
+			<page>256</page>
 		</power>
 		<power>
 			<id>db290d50-c208-4de6-ad30-85b1b078370c</id>
 			<name>Electron Storm</name>
 			<category>Emergent</category>
-			<type>S</type>
-			<action>C</action>
-			<range>Node</range>
-			<duration>Instant</duration>
-			<source>SR4</source>
-			<page>242</page>
+			<type>Persona</type>
+			<action>Complex</action>
+			<range />
+			<duration>Sustained</duration>
+			<source>SR5</source>
+			<page>257</page>
 		</power>
 		<power>
 			<id>93507c52-d8fc-4b03-9e27-b24048d87526</id>
 			<name>Hash</name>
 			<category>Emergent</category>
-			<type />
-			<action>Complex</action>
-			<range>Node</range>
-			<duration>Sustained</duration>
-			<source>SR4</source>
-			<page>243</page>
+			<type>File</type>
+			<action>Special</action>
+			<range />
+			<duration>F x 10 Combat Turns</duration>
+			<source>SR5</source>
+			<page>257</page>
 		</power>
 		<power>
 			<id>384dd7b0-d639-4eeb-894b-31fdc1cbf578</id>
@@ -1611,23 +1644,23 @@
 			<id>b733200f-9911-489d-b555-ebacd16110b0</id>
 			<name>Stability</name>
 			<category>Emergent</category>
-			<type />
+			<type>Persona or Device</type>
 			<action>Complex</action>
-			<range>Node</range>
+			<range />
 			<duration>Sustained</duration>
-			<source>SR4</source>
-			<page>243</page>
+			<source>SR5</source>
+			<page>257</page>
 		</power>
 		<power>
 			<id>c8840b92-07ae-40a3-bd04-20152bae16b8</id>
 			<name>Watermark</name>
 			<category>Emergent</category>
-			<type />
+			<type>Icon</type>
 			<action>Complex</action>
-			<range>Node</range>
-			<duration>Indefinate</duration>
-			<source>SR4</source>
-			<page>243</page>
+			<range />
+			<duration>Permanent</duration>
+			<source>SR5</source>
+			<page>257</page>
 		</power>
 		<power>
 			<id>a94dba2a-7699-4eb4-80a8-862f07beb6f6</id>
@@ -2302,6 +2335,257 @@
 			</bonus>
 			<source>HS</source>
 			<page>164</page>
+		</power>
+		<power>
+			<id>64437e82-ac50-40f3-8916-751c124e5676</id>
+			<name>Alienate</name>
+			<category>Paranormal</category>
+			<type>P</type>
+			<action>None</action>
+			<range>LOS</range>
+			<duration>Sustained</duration>
+			<source>HS</source>
+			<page>188</page>
+		</power>
+		<power>
+			<id>adf34ad4-0040-49df-a6dd-bde198c44a44</id>
+			<name>Astral Venom</name>
+			<category>Paranormal</category>
+			<type>M</type>
+			<action>Auto</action>
+			<range>Self</range>
+			<duration>Always</duration>
+			<source>HS</source>
+			<page>188</page>
+		</power>
+		<power>
+			<id>2cf990bd-f80b-4e56-803d-b8595ef96244</id>
+			<name>Brachiation</name>
+			<category>Mundane</category>
+			<type>P</type>
+			<action>Auto</action>
+			<range>Self</range>
+			<duration>Always</duration>
+			<source>HS</source>
+			<page>188</page>
+		</power>
+		<power>
+			<id>6bd03b55-d6fb-4ecb-a098-1c01017bc81c</id>
+			<name>Create Alchera</name>
+			<category>Paranormal</category>
+			<type>P</type>
+			<action>Complex</action>
+			<range>LOS</range>
+			<duration>Sustained</duration>
+			<source>HS</source>
+			<page>189</page>
+		</power>
+		<power>
+			<id>8af6b45a-ed52-4063-a60e-7428a818a7ab</id>
+			<name>Darkness</name>
+			<category>Paranormal</category>
+			<type>P</type>
+			<action>Complex</action>
+			<range>LOS</range>
+			<duration>Sustained</duration>
+			<source>HS</source>
+			<page>189</page>
+		</power>
+		<power>
+			<id>4b017336-7806-4905-a1ca-f540cf88b7b9</id>
+			<name>Deathlock</name>
+			<category>Paranormal</category>
+			<type>P</type>
+			<action>Auto</action>
+			<range>Self</range>
+			<duration>Always</duration>
+			<source>HS</source>
+			<page>190</page>
+		</power>
+		<power>
+			<id>d769a388-1f25-4ec0-9a7f-9bd37585723b</id>
+			<name>Dive Attack</name>
+			<category>Mundane</category>
+			<type>P</type>
+			<action>Complex</action>
+			<range>Touch</range>
+			<duration>Instant</duration>
+			<source>HS</source>
+			<page>190</page>
+		</power>
+		<power>
+			<id>faf2f307-c094-4139-ab88-e06f0804d282</id>
+			<name>Entropic Aura</name>
+			<category>Paranormal</category>
+			<type>P</type>
+			<action>Auto</action>
+			<range>Self</range>
+			<duration>Always</duration>
+			<source>HS</source>
+			<page>190</page>
+		</power>
+		<power>
+			<id>9c80e4ad-5999-4795-a890-0d6a1e5b542e</id>
+			<name>Extra Fragile</name>
+			<category>Weakness</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>RF</source>
+			<page>191</page>
+		</power>
+		<power>
+			<id>ce067614-a47e-4536-a13d-09d02b918d3a</id>
+			<name>Flay Touch</name>
+			<category>Paranormal</category>
+			<type>P</type>
+			<action>Complex</action>
+			<range>Touch</range>
+			<duration>Instant</duration>
+			<source>HS</source>
+			<page>191</page>
+		</power>
+		<power>
+			<id>685c4e5c-d21a-4485-aa12-7deb3377d0c5</id>
+			<name>Ghost Chain</name>
+			<category>Paranormal</category>
+			<type>M</type>
+			<action>Auto</action>
+			<range>Special</range>
+			<duration>Always</duration>
+			<source>HS</source>
+			<page>192</page>
+		</power>
+		<power>
+			<id>fa15d90c-5e9d-4c3f-b92a-b9cd772091b6</id>
+			<name>Haunt</name>
+			<category>Paranormal</category>
+			<type>M</type>
+			<action>Auto</action>
+			<range>Special</range>
+			<duration>Always</duration>
+			<source>HS</source>
+			<page>192</page>
+		</power>
+		<power>
+			<id>9c04aead-af8d-4b17-a6b3-016c855db186</id>
+			<name>Innate Ritual</name>
+			<category>Paranormal</category>
+			<type>As ritual</type>
+			<action>As ritual</action>
+			<range>As ritual</range>
+			<duration>As ritual</duration>
+			<bonus>
+				<selecttext />
+			</bonus>
+			<source>HS</source>
+			<page>193</page>
+		</power>
+		<power>
+			<id>5edec7e8-281d-46f8-bb06-c332e8b1ba59</id>
+			<name>Manipulate Magic</name>
+			<category>Paranormal</category>
+			<type>M</type>
+			<action>Auto</action>
+			<range>Touch</range>
+			<duration>Permanent</duration>
+			<source>HS</source>
+			<page>193</page>
+		</power>
+		<power>
+			<id>9c59fb9c-85b4-449a-978a-a07d6ccf31a2</id>
+			<name>Pounce</name>
+			<category>Mundane</category>
+			<type>P</type>
+			<action>Complex</action>
+			<range>Touch</range>
+			<duration>Instant</duration>
+			<source>HS</source>
+			<page>193</page>
+		</power>
+		<power>
+			<id>fc522b4a-e281-4de0-a824-b1d636fff59b</id>
+			<name>Toughness</name>
+			<category>Mundane</category>
+			<rating>yes</rating>
+			<type>P</type>
+			<action>Auto</action>
+			<range>Self</range>
+			<duration>Always</duration>
+			<bonus>
+				<conditionmonitor>
+					<physical>Rating</physical>
+				</conditionmonitor>
+			</bonus>
+			<source>HS</source>
+			<page>194</page>
+		</power>
+		<power>
+			<id>6be87e77-1073-47fd-a137-b536a8700009</id>
+			<name>Domesticated</name>
+			<category>Mundane</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>186</page>
+		</power>
+		<power>
+			<id>fbeb215d-fb20-4151-9fd1-4d3259db9402</id>
+			<name>Gliding</name>
+			<category>Mundane</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>186</page>
+		</power>
+		<power>
+			<id>f5515a8b-4c5e-4917-881a-363777ba03e9</id>
+			<name>Critter Cyberpsychosis</name>
+			<category>Weakness</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>186</page>
+		</power>
+		<power>
+			<id>bfa9a7ec-f184-44cb-8599-96c5c7787595</id>
+			<name>CI3D (Critter Implant Induced Immune Deficiency)</name>
+			<category>Weakness</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>186</page>
+		</power>
+		<power>
+			<id>03c9acab-d172-4633-8dbf-23ec3b7faf7e</id>
+			<name>CTLE-X (Critter Temporal Lobe Epilepsy)</name>
+			<category>Weakness</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>186</page>
+		</power>
+		<power>
+			<id>f1a36576-1664-413b-a65f-e3b6115c266e</id>
+			<name>Precarious Physiology</name>
+			<category>Weakness</category>
+			<type />
+			<action />
+			<range />
+			<duration />
+			<source>HS</source>
+			<page>186</page>
 		</power>
 	</powers>
 </chummer>

--- a/Chummer/data/critterpowers.xml
+++ b/Chummer/data/critterpowers.xml
@@ -62,6 +62,9 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
+			<bonus>
+				<selecttext />
+			</bonus>
 			<source>SR5</source>
 			<page>394</page>
 		</power>
@@ -168,18 +171,6 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>SR5</source>
-			<page>396</page>
-		</power>
-		<power>
-			<id>33be7248-a267-4085-a5d8-b15bd79d7e5f</id>
-			<name>Engulf</name>
-			<category>Mundane</category>
-			<toxic>yes</toxic>
-			<type>P</type>
-			<action>Complex</action>
-			<range>Touch</range>
-			<duration>Sustained</duration>
 			<source>SR5</source>
 			<page>396</page>
 		</power>

--- a/Chummer/data/critterpowers.xml
+++ b/Chummer/data/critterpowers.xml
@@ -50,8 +50,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SR5</source>
+			<page>394</page>
 		</power>
 		<power>
 			<id>1814f970-111f-4d56-9402-f584daa02663</id>
@@ -62,8 +62,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SR5</source>
+			<page>394</page>
 		</power>
 		<power>
 			<id>0ea84be4-a293-44bf-bc60-52314495cc9a</id>
@@ -73,8 +73,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SR5</source>
+			<page>394</page>
 		</power>
 		<power>
 			<id>aca5b1a9-6b7f-49fa-aee4-ba20b4ee2f26</id>
@@ -84,8 +84,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Instant</duration>
-			<source>SR4</source>
-			<page>293</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>f6631c45-a705-434c-b4a6-ba2a889d38ff</id>
@@ -95,8 +95,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>1898d408-116a-4f98-b413-939660692ce7</id>
@@ -106,8 +106,8 @@
 			<action>Simple</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>4517126f-6dcf-4c73-b7f5-cac77532c1f5</id>
@@ -118,8 +118,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>1ddf4e08-8249-477c-ba8b-1b910428bf45</id>
@@ -130,8 +130,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>6ca4a4af-7da0-4cc2-b545-0fe0396cfb46</id>
@@ -141,8 +141,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>37e62625-1099-426f-94c9-2750aaa9902b</id>
@@ -156,8 +156,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>210</page>
+			<source>SR5</source>
+			<page>396</page>
 		</power>
 		<power>
 			<id>37bc7c80-beb9-424d-a4b4-db8d3a31612c</id>
@@ -168,8 +168,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>SR5</source>
+			<page>396</page>
 		</power>
 		<power>
 			<id>33be7248-a267-4085-a5d8-b15bd79d7e5f</id>
@@ -180,8 +180,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Sustained</duration>
-			<source>SR4</source>
-			<page>294</page>
+			<source>SR5</source>
+			<page>396</page>
 		</power>
 		<power>
 			<id>b289f6de-dc68-49a2-9d08-a9dcafdf9bac</id>
@@ -195,8 +195,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>204</page>
+			<source>SR5</source>
+			<page>396</page>
 		</power>
 		<power>
 			<id>24455a2c-c98c-4748-a720-1403a726fd57</id>
@@ -206,8 +206,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Permanent</duration>
-			<source>RF</source>
-			<page>211</page>
+			<source>SR5</source>
+			<page>396</page>
 		</power>
 		<power>
 			<id>953d3e23-cba0-440d-bab4-4234f1090ac5</id>
@@ -218,8 +218,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>212</page>
+			<source>SR5</source>
+			<page>397</page>
 		</power>
 		<power>
 			<id>13dc5c5d-ef46-433e-b27b-5775a57035a8</id>
@@ -229,8 +229,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>212</page>
+			<source>SR5</source>
+			<page>397</page>
 		</power>
 		<power>
 			<id>08b3b1bd-94cc-4468-a61f-31baade2a08e</id>
@@ -244,8 +244,8 @@
 			<bonus>
 				<armor>Rating</armor>
 			</bonus>
-			<source>RF</source>
-			<page>212</page>
+			<source>SR5</source>
+			<page>397</page>
 		</power>
 		<power>
 			<id>c8ad6b5e-5520-4ea6-a472-a1fa51634c74</id>
@@ -259,8 +259,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>212</page>
+			<source>SR5</source>
+			<page>397</page>
 		</power>
 		<power>
 			<id>951cb295-b6c6-4ff2-9a9e-2a49cc047fd1</id>
@@ -270,8 +270,8 @@
 			<action>Auto</action>
 			<range>Touch</range>
 			<duration>Permanent</duration>
-			<source>RF</source>
-			<page>212</page>
+			<source>SR5</source>
+			<page>398</page>
 		</power>
 		<power>
 			<id>e8013773-9497-472e-b2af-e96e49405290</id>
@@ -281,8 +281,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>398</page>
 		</power>
 		<power>
 			<id>fe38ce43-3cf2-456d-aec2-0029e0bf173f</id>
@@ -295,8 +295,8 @@
 			<bonus>
 				<selectspell />
 			</bonus>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>398</page>
 		</power>
 		<power>
 			<id>bf6c7543-0fa6-4297-8690-8230db5e46a8</id>
@@ -306,8 +306,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>398</page>
 		</power>
 		<power>
 			<id>153bc9aa-1a5e-41ac-877d-751470624bc7</id>
@@ -317,8 +317,8 @@
 			<action>Simple</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>398</page>
 		</power>
 		<power>
 			<id>b43373c3-5006-4396-bbbb-a154b8c92eae</id>
@@ -328,8 +328,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>398</page>
 		</power>
 		<power>
 			<id>5090e9d2-07ba-4fb0-965c-5d5de29062b7</id>
@@ -339,8 +339,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>399</page>
 		</power>
 		<power>
 			<id>aa886ded-bf17-43e6-a7b5-82d77ed96a9c</id>
@@ -351,8 +351,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>399</page>
 		</power>
 		<power>
 			<id>9fc065db-9d63-4e8b-aba9-e19dfba07652</id>
@@ -365,8 +365,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>206</page>
+			<source>SR5</source>
+			<page>399</page>
 		</power>
 		<power>
 			<id>4709630d-f2d0-40cc-915b-4f41eb8a4092</id>
@@ -377,8 +377,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>399</page>
 		</power>
 		<power>
 			<id>f2c04372-d264-42fa-b0b4-534035888ad7</id>
@@ -388,8 +388,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SR5</source>
+			<page>399</page>
 		</power>
 		<power>
 			<id>46ee1218-4b63-458d-b9b9-ec5b2bb607f0</id>
@@ -399,8 +399,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>214</page>
+			<source>SR5</source>
+			<page>400</page>
 		</power>
 		<power>
 			<id>244ccf0f-fc77-4690-9441-1cfeb7a6dc2a</id>
@@ -410,8 +410,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>215</page>
+			<source>SR5</source>
+			<page>400</page>
 		</power>
 		<power>
 			<id>4f694634-7c91-4534-a9ff-7f8ae3002a1e</id>
@@ -421,8 +421,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>215</page>
+			<source>SR5</source>
+			<page>400</page>
 		</power>
 		<power>
 			<id>bd881fa0-89e4-4734-816f-7ffe7cf5f35f</id>
@@ -432,8 +432,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>206</page>
+			<source>SR5</source>
+			<page>400</page>
 		</power>
 		<power>
 			<id>5e45dcc0-ec66-4bd5-a855-d3ce577dd2b4</id>
@@ -444,8 +444,8 @@
 			<action>Auto</action>
 			<range>Touch</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>8b460350-fca3-427d-90af-4648666e8723</id>
@@ -458,8 +458,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>215</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>5dad2b71-d7b0-443f-9871-ea01a381b9d0</id>
@@ -469,8 +469,8 @@
 			<action>Complex</action>
 			<range>LOS (A)</range>
 			<duration>Sustained</duration>
-			<source>SM</source>
-			<page>98</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>89ad414a-9854-44b0-b505-ad0186ccb29f</id>
@@ -480,8 +480,8 @@
 			<action>Free</action>
 			<range>Self</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>ae00c4e4-c036-44b2-894b-1a5cd3fc8fae</id>
@@ -491,8 +491,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>c3e2ee0c-7c4d-479f-997d-7079cb4dee7a</id>
@@ -502,8 +502,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>cf03e546-90d9-4c3d-8246-19bf57821731</id>
@@ -513,8 +513,8 @@
 			<action>Special</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>de152825-2002-4a58-b2a7-08247aae72be</id>
@@ -524,8 +524,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Sustained</duration>
-			<source>SM</source>
-			<page>99</page>
+			<source>SG</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>d10138cc-924a-4f2b-a59b-44e0611fb019</id>
@@ -535,8 +535,8 @@
 			<action>Complex</action>
 			<range>Touch or LOS</range>
 			<duration>Permanent</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>SG</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>f6fb5ceb-91f8-418b-99ee-413e8c16230e</id>
@@ -546,8 +546,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>SR5</source>
+			<page>396</page>
 		</power>
 		<power>
 			<id>30918b00-6dae-4989-9b6e-219c4bd6ac7e</id>
@@ -557,8 +557,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>SM</source>
-			<page>100</page>
+			<source>SG</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>f5a654a0-91e3-4555-aa22-792d012348b8</id>
@@ -568,8 +568,8 @@
 			<action>Free</action>
 			<range>LOS</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SG</source>
+			<page>196</page>
 		</power>
 		<power>
 			<id>033185f0-bade-4824-8569-8604a734e02b</id>
@@ -579,8 +579,8 @@
 			<action>Simple</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SG</source>
+			<page>196</page>
 		</power>
 		<power>
 			<id>a142b612-2f4c-4c97-8b1b-fd15c9f68866</id>
@@ -590,8 +590,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>214</page>
+			<source>SG</source>
+			<page>197</page>
 		</power>
 		<power>
 			<id>21768675-ea17-48f4-abdc-301c3441bf8c</id>
@@ -601,8 +601,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>214</page>
+			<source>SG</source>
+			<page>197</page>
 		</power>
 		<power>
 			<id>2381a322-1b0c-4282-b3af-b28828cdf786</id>
@@ -623,8 +623,8 @@
 			<action>Free</action>
 			<range>Self</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>215</page>
+			<source>SG</source>
+			<page>198</page>
 		</power>
 		<power>
 			<id>4881c2cc-1e45-43ad-89df-9e5b264648f2</id>
@@ -634,8 +634,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>215</page>
+			<source>SG</source>
+			<page>199</page>
 		</power>
 		<power>
 			<id>ea7d01c8-50f5-4d2a-9fac-a750b189ca36</id>
@@ -645,8 +645,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>215</page>
+			<source>SG</source>
+			<page>199</page>
 		</power>
 		<power>
 			<id>f1750d16-5dc2-4c4e-afae-1ad86c520fc6</id>
@@ -656,8 +656,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>SM</source>
-			<page>109</page>
+			<source>SG</source>
+			<page>204</page>
 		</power>
 		<power>
 			<id>189ab2b7-9688-414b-b8ec-35a01db372d4</id>
@@ -667,8 +667,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SG</source>
+			<page>204</page>
 		</power>
 		<power>
 			<id>37a152ee-83ce-4a32-b81b-31e79b42c970</id>
@@ -678,8 +678,8 @@
 			<action>Auto</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>214</page>
+			<source>SG</source>
+			<page>205</page>
 		</power>
 		<power>
 			<id>8e1d96d9-53c9-4924-855c-059815ef973c</id>
@@ -689,8 +689,8 @@
 			<action>Special</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>SM</source>
-			<page>110</page>
+			<source>SG</source>
+			<page>205</page>
 		</power>
 		<power>
 			<id>e6add326-0ed1-41bd-9d00-40ad5b17a35d</id>
@@ -700,8 +700,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Permanent</duration>
-			<source>RF</source>
-			<page>212</page>
+			<source>SG</source>
+			<page>205</page>
 		</power>
 		<power>
 			<id>9942f3f2-b486-44ff-ad34-c56fd9453d41</id>
@@ -711,8 +711,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Instant</duration>
-			<source>SM</source>
-			<page>110</page>
+			<source>SG</source>
+			<page>205</page>
 		</power>
 		<power>
 			<id>ad40556c-6632-4287-bd69-94ff25c7280e</id>
@@ -722,8 +722,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>216</page>
+			<source>SG</source>
+			<page>205</page>
 		</power>
 		<power>
 			<id>44dd8deb-891e-4361-bc0c-47c4258ea6fd</id>
@@ -734,8 +734,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>SG</source>
+			<page>193</page>
 		</power>
 		<power>
 			<id>3c6b961c-cac8-4e45-91ec-03cf612ac3c3</id>
@@ -746,8 +746,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>SG</source>
+			<page>196</page>
 		</power>
 		<power>
 			<id>e525a62b-5762-477d-b242-6e166fdcd6e9</id>
@@ -758,8 +758,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>ea6c345d-1df6-42b9-92bb-b94fef3360f7</id>
@@ -769,8 +769,8 @@
 			<action>Auto</action>
 			<range>Special</range>
 			<duration>Always</duration>
-			<source>SM</source>
-			<page>154</page>
+			<source>SG</source>
+			<page>195</page>
 		</power>
 		<power>
 			<id>ecbab218-1ba9-41b6-9add-897ccbbf1d52</id>
@@ -781,8 +781,8 @@
 			<action>Auto</action>
 			<range>Touch</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>206</page>
+			<source>SG</source>
+			<page>197</page>
 		</power>
 		<power>
 			<id>e5859447-89ad-40f1-aea0-8c5f1e53e9de</id>
@@ -792,8 +792,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Special</duration>
-			<source>SM</source>
-			<page>154</page>
+			<source>SG</source>
+			<page>198</page>
 		</power>
 		<power>
 			<id>d9fdc768-9ce4-4c19-8744-b46833349cea</id>
@@ -803,19 +803,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>215</page>
-		</power>
-		<power>
-			<id>ffd80da4-dd7f-40e3-9374-7ccbfe19ada2</id>
-			<name>Adaptive Camouflage</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Auto</action>
-			<range>Self</range>
-			<duration>Always</duration>
-			<source>RF</source>
-			<page>204</page>
+			<source>SG</source>
+			<page>199</page>
 		</power>
 		<power>
 			<id>94e58008-2ab1-41ed-886c-74773ec60067</id>
@@ -825,8 +814,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>205</page>
+			<source>HS</source>
+			<page>192</page>
 		</power>
 		<power>
 			<id>c5a7a660-a036-4b52-a8ab-1e9d7705e65d</id>
@@ -836,12 +825,12 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>205</page>
+			<source>HS</source>
+			<page>192</page>
 		</power>
 		<power>
 			<id>224f6093-af49-4fd4-a30a-b0c38673ffb7</id>
-			<name>Substance Extrusion</name>
+			<name>Secretion/Substance Extrusion</name>
 			<category>Mundane</category>
 			<type>P</type>
 			<action>Auto</action>
@@ -850,8 +839,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>207</page>
+			<source>HS</source>
+			<page>193</page>
 		</power>
 		<power>
 			<id>7cdbe90b-b16a-43c0-a20e-b4a54b83c6ed</id>
@@ -861,8 +850,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>HS</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>7f98220b-95c4-4b76-aca7-6f0308cf25a7</id>
@@ -872,8 +861,8 @@
 			<action>Auto</action>
 			<range>Self</range>
 			<duration>Always</duration>
-			<source>RF</source>
-			<page>208</page>
+			<source>HS</source>
+			<page>188</page>
 		</power>
 		<power>
 			<id>71a78fd2-c75a-46a8-a0f3-320e268a9b4d</id>
@@ -884,8 +873,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>73b0e681-fa65-4253-9010-4bac1f7c3179</id>
@@ -895,20 +884,8 @@
 			<action>Auto</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>209</page>
-		</power>
-		<power>
-			<id>43599de0-dd30-4525-b524-9952283aeb42</id>
-			<name>Corrosive Secretions</name>
-			<category>Paranormal</category>
-			<toxic>yes</toxic>
-			<type>P</type>
-			<action>Auto</action>
-			<range>Self</range>
-			<duration>Always</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>HS</source>
+			<page>188</page>
 		</power>
 		<power>
 			<id>f654869b-d381-4f90-82d6-835f5a4aa0ab</id>
@@ -918,8 +895,8 @@
 			<action>Simple</action>
 			<range>Special</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>209</page>
+			<source>SG</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>6bd7dbfd-1603-4333-86aa-b4b798caf9d1</id>
@@ -929,8 +906,8 @@
 			<action>Auto</action>
 			<range>LOS</range>
 			<duration>Instant</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>SR5</source>
+			<page>395</page>
 		</power>
 		<power>
 			<id>8df0b8ba-ef4e-41ea-a571-8c21f221cfde</id>
@@ -940,8 +917,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>210</page>
+			<source>HS</source>
+			<page>190</page>
 		</power>
 		<power>
 			<id>ca80b896-a524-435f-a787-8df807567de8</id>
@@ -951,8 +928,8 @@
 			<action>Complex</action>
 			<range>Special</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>212</page>
+			<source>HS</source>
+			<page>191</page>
 		</power>
 		<power>
 			<id>e36812c9-c918-4d38-a71f-79f04a77a924</id>
@@ -963,8 +940,8 @@
 			<action>Auto</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>213</page>
+			<source>HS</source>
+			<page>193</page>
 		</power>
 		<power>
 			<id>525746a4-bd59-4150-8861-2eb2fc7665ac</id>
@@ -985,8 +962,8 @@
 			<action>Complex</action>
 			<range>Touch</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>214</page>
+			<source>SR5</source>
+			<page>400</page>
 		</power>
 		<power>
 			<id>90c79eb4-665a-4844-90f3-e495f8cd3e61</id>
@@ -996,19 +973,8 @@
 			<action>Complex</action>
 			<range>LOS</range>
 			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>214</page>
-		</power>
-		<power>
-			<id>775ee1b0-9e70-4006-8e5c-c1588ac9bfd6</id>
-			<name>Phasing</name>
-			<category>Paranormal</category>
-			<type>P</type>
-			<action>Complex</action>
-			<range>Self</range>
-			<duration>Sustained</duration>
-			<source>RF</source>
-			<page>214</page>
+			<source>SR5</source>
+			<page>400</page>
 		</power>
 		<power>
 			<id>2cadebe7-a32d-4852-ac94-e8b86ca3619a</id>
@@ -1018,20 +984,8 @@
 			<action>Special</action>
 			<range>Special</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>215</page>
-		</power>
-		<power>
-			<id>fb19be93-d1dc-408f-86ca-bc57f25e4790</id>
-			<name>Taint</name>
-			<category>Paranormal</category>
-			<toxic>yes</toxic>
-			<type>M</type>
-			<action>Complex</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<source>RF</source>
-			<page>215</page>
+			<source>SG</source>
+			<page>205</page>
 		</power>
 		<power>
 			<id>a8090271-057c-41d5-bd68-df117ea15b7d</id>
@@ -1041,19 +995,8 @@
 			<action>Free</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RF</source>
-			<page>215</page>
-		</power>
-		<power>
-			<id>4998785a-154e-48f4-98db-c36d3b8f28a3</id>
-			<name>Anthropomorphism</name>
-			<category>Emergent</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<source>RF</source>
-			<page>216</page>
+			<source>HS</source>
+			<page>194</page>
 		</power>
 		<power>
 			<id>bfe55ba6-5625-425d-ad5c-08dd84ef07ca</id>
@@ -1133,17 +1076,6 @@
 			<page>195</page>
 		</power>
 		<power>
-			<id>c04021ed-c7c8-4138-881f-30c86f01e43c</id>
-			<name>Hardening</name>
-			<category>Emergent</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<source>RF</source>
-			<page>217</page>
-		</power>
-		<power>
 			<id>f66e1630-7b3a-4595-868a-9143b372e6f4</id>
 			<name>Holographic Concealment</name>
 			<category>Emergent</category>
@@ -1166,28 +1098,6 @@
 			<page>195</page>
 		</power>
 		<power>
-			<id>fb24283f-c6d2-4f06-a380-16edb6982cb2</id>
-			<name>Resonance Bond</name>
-			<category>Emergent</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<source>RF</source>
-			<page>217</page>
-		</power>
-		<power>
-			<id>adc687c3-1af1-430d-bdbb-53b4f4bc943b</id>
-			<name>Resonant Conditioning</name>
-			<category>Emergent</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<source>RF</source>
-			<page>217</page>
-		</power>
-		<power>
 			<id>cf509fe7-6b69-4996-8e79-8105e02c2855</id>
 			<name>Spraying</name>
 			<category>Emergent</category>
@@ -1208,20 +1118,6 @@
 			<duration>Sustained</duration>
 			<source>SR5</source>
 			<page>257</page>
-		</power>
-		<power>
-			<id>faa5e5c8-aa8a-45d5-b3f5-dd18c454ba07</id>
-			<name>Technovantage [Echo]</name>
-			<category>Emergent</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<bonus>
-				<selecttext />
-			</bonus>
-			<source>RF</source>
-			<page>218</page>
 		</power>
 		<power>
 			<id>1629d45d-f64e-4a39-a2d4-a07f7844f1e4</id>
@@ -1255,17 +1151,6 @@
 			<duration />
 			<source>HS</source>
 			<page>195</page>
-		</power>
-		<power>
-			<id>25316188-db17-4504-b422-07332e908d07</id>
-			<name>Virtual Mimicry</name>
-			<category>Emergent</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<source>RF</source>
-			<page>218</page>
 		</power>
 		<power>
 			<id>cc29cf63-fd2b-47bc-8f68-c0c84c4e2986</id>
@@ -1476,8 +1361,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>219</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>f4de6eca-de5c-436b-955d-b322a9ce1a08</id>
@@ -1490,8 +1375,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>219</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>f4865138-c3f0-46e8-8010-6003b1491b96</id>
@@ -1501,8 +1386,8 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>219</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>95dcc093-88b8-4182-b62a-575428b84c84</id>
@@ -1512,25 +1397,25 @@
 			<action />
 			<range />
 			<duration />
-			<source>RF</source>
-			<page>219</page>
+			<source>SG</source>
+			<page>101</page>
 		</power>
 		<power>
 			<id>031c2ae5-80d4-4cda-a2ce-65525970f281</id>
 			<name>Fragile</name>
 			<category>Weakness</category>
-			<type />
-			<action />
-			<range />
-			<duration />
+			<rating>20</rating>
+			<type>P</type>
+			<action>Auto</action>
+			<range>Self</range>
+			<duration>Always</duration>
 			<bonus>
 				<conditionmonitor>
-					<physical>Rating * -2</physical>
-					<stun>Rating * -2</stun>
+					<physical>-Rating</physical>
 				</conditionmonitor>
 			</bonus>
-			<source>RF</source>
-			<page>219</page>
+			<source>HS</source>
+			<page>192</page>
 		</power>
 		<power>
 			<id>e44f268f-de46-4a03-93e8-69570dd7a2eb</id>
@@ -1543,8 +1428,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>219</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>a38a6e6e-c8be-477b-91a9-f285ec1941fa</id>
@@ -1557,8 +1442,8 @@
 			<bonus>
 				<uneducated />
 			</bonus>
-			<source>RF</source>
-			<page>219</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>cc5d600e-c1fd-47d2-affd-38a939cc21ab</id>
@@ -1571,19 +1456,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RF</source>
-			<page>219</page>
-		</power>
-		<power>
-			<id>dc81347f-7516-42b2-a3fb-e2676dedec1f</id>
-			<name>Twist Fate</name>
-			<category>Dracoforms</category>
-			<type />
-			<action />
-			<range />
-			<duration />
-			<source>SR4</source>
-			<page>304</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>83289bc7-6c5d-4782-9523-bc8e08b0f521</id>
@@ -1630,17 +1504,6 @@
 			<page>257</page>
 		</power>
 		<power>
-			<id>384dd7b0-d639-4eeb-894b-31fdc1cbf578</id>
-			<name>Steganography</name>
-			<category>Emergent</category>
-			<type />
-			<action>Complex</action>
-			<range>Node</range>
-			<duration>Indefinate</duration>
-			<source>SR4</source>
-			<page>243</page>
-		</power>
-		<power>
 			<id>b733200f-9911-489d-b555-ebacd16110b0</id>
 			<name>Stability</name>
 			<category>Emergent</category>
@@ -1670,8 +1533,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RC</source>
-			<page>85</page>
+			<source>RF</source>
+			<page>102</page>
 		</power>
 		<power>
 			<id>9f4e4ee5-5d7b-4360-b91a-15a0c97b2fd9</id>
@@ -1681,8 +1544,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RC</source>
-			<page>85</page>
+			<source>RF</source>
+			<page>102</page>
 		</power>
 		<power>
 			<id>6b9cb5f4-cf9a-4cf2-bfd1-dc585f96e66d</id>
@@ -1692,8 +1555,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RC</source>
-			<page>85</page>
+			<source>RF</source>
+			<page>102</page>
 		</power>
 		<power>
 			<id>3215688d-7c67-46da-ab78-d7c6c6196e65</id>
@@ -1703,8 +1566,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RC</source>
-			<page>85</page>
+			<source>RF</source>
+			<page>102</page>
 		</power>
 		<power>
 			<id>6c64785b-f9f7-4f6b-80de-4065867a9a74</id>
@@ -1714,8 +1577,8 @@
 			<action>Complex</action>
 			<range>Self</range>
 			<duration>Special</duration>
-			<source>RC</source>
-			<page>85</page>
+			<source>RF</source>
+			<page>102</page>
 		</power>
 		<power>
 			<id>14d33e71-88c5-4fdb-8456-0b61ab70e8f4</id>
@@ -1739,8 +1602,8 @@
 			<bonus>
 				<selecttext />
 			</bonus>
-			<source>RC</source>
-			<page>83</page>
+			<source>SR5</source>
+			<page>401</page>
 		</power>
 		<power>
 			<id>e6ca8880-91eb-4a09-acee-478bddca145a</id>
@@ -1752,100 +1615,6 @@
 			<duration />
 			<source>RC</source>
 			<page>85</page>
-		</power>
-		<power>
-			<id>f266d2fe-21c7-4ea5-88b2-b346021f26bb</id>
-			<name>Attribute Enhancement</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus>
-				<selectattribute />
-			</bonus>
-			<source>RF</source>
-			<page>28</page>
-		</power>
-		<power>
-			<id>425bdf7b-8587-4506-8c78-f3d4ba959b5a</id>
-			<name>Skill Enhancement</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus>
-				<selectskill>
-					<val>2</val>
-				</selectskill>
-			</bonus>
-			<source>RF</source>
-			<page>28</page>
-		</power>
-		<power>
-			<id>52211b54-9dd0-4eed-9737-643b993c06aa</id>
-			<name>Thicker Hide</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus />
-			<source>RF</source>
-			<page>28</page>
-		</power>
-		<power>
-			<id>66620f18-d1aa-4496-a4c2-3dc538f84a5f</id>
-			<name>Pheromone Coding</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus />
-			<source>RF</source>
-			<page>28</page>
-		</power>
-		<power>
-			<id>f991778b-a46f-42cc-a05d-826aa926e0cb</id>
-			<name>Potent Venom</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus />
-			<source>RF</source>
-			<page>28</page>
-		</power>
-		<power>
-			<id>7e387a67-9e03-4054-aa58-32cafeb2b6f9</id>
-			<name>Chimeric Ability</name>
-			<category>Mundane</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus />
-			<source>RF</source>
-			<page>28</page>
-		</power>
-		<power>
-			<id>e5500bd1-bb07-42bc-b69f-cfc4116548bd</id>
-			<name>Firewall Upgrade</name>
-			<category>Echoes</category>
-			<type>P</type>
-			<action>Special</action>
-			<range>Special</range>
-			<duration>Special</duration>
-			<bonus>
-				<livingpersona>
-					<firewall>1</firewall>
-				</livingpersona>
-			</bonus>
-			<source>SR4</source>
-			<page>243</page>
 		</power>
 		<power>
 			<id>9c5bcd33-ef29-487a-8f3d-5c4f3b314723</id>
@@ -2432,6 +2201,12 @@
 			<action />
 			<range />
 			<duration />
+			<bonus>
+				<conditionmonitor>
+					<physical>-20</physical>
+					<stun>-20</stun>
+				</conditionmonitor>
+			</bonus>
 			<source>RF</source>
 			<page>191</page>
 		</power>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -15202,7 +15202,6 @@
 				<power>Engulf</power>
 				<power select="Shatter">Innate Spell</power>
 				<power select="Bite: DV 2P, AP 0, -1 Reach">Natural Weapon</power>
-				<power>Phasing</power>
 			</powers>
 			<skills>
 				<skill rating="2">Perception</skill>
@@ -16071,7 +16070,6 @@
 				</enabletab>
 			</bonus>
 			<powers>
-				<power>Corrosive Secretions</power>
 				<power>Venom</power>
 			</powers>
 			<skills>
@@ -16442,7 +16440,6 @@
 				<power select="Tremorsense">Enhanced Senses</power>
 				<power select="Bite: DV 4P, AP 0">Natural Weapon</power>
 				<power>Regeneration</power>
-				<power>Taint</power>
 				<power select="Sunlight, Mild">Allergy</power>
 			</powers>
 			<skills>
@@ -17490,7 +17487,6 @@
       </bonus>
       <powers>
         <power>Binding</power>
-        <power>Corrosive Secretions</power>
         <power select="Fire">Immunity</power>
         <power select="Cold, Mild">Allergy</power>
       </powers>
@@ -27201,7 +27197,6 @@
         <reach>-1</reach>
       </bonus>
       <powers>
-        <power>Corrosive Secretions</power>
         <power>Engulf</power>
         <power select="Pathogens, Toxins">Immunity</power>
         <power select="Bite: DV 2P, AP 0">Natural Weapon</power>
@@ -32187,7 +32182,6 @@
         <power>Materialization</power>
         <power>Movement</power>
         <power>Personal Domain</power>
-        <power>Phasing</power>
         <power>Sapience</power>
         <power>Search</power>
       </powers>
@@ -33015,8 +33009,6 @@
         <power>Influence</power>
         <power>Noxious Breath</power>
         <power>Venom</power>
-        <power>Metahuman Form</power>
-        <power>Twist Fate</power>
       </powers>
       <skills>
         <skill rating="8">Assensing</skill>
@@ -33110,8 +33102,6 @@
         <power>Influence</power>
         <power>Noxious Breath</power>
         <power>Venom</power>
-        <power>Metahuman Form</power>
-        <power>Twist Fate</power>
       </powers>
       <skills>
         <skill rating="8">Assensing</skill>
@@ -33205,8 +33195,6 @@
         <power>Influence</power>
         <power>Noxious Breath</power>
         <power>Venom</power>
-        <power>Metahuman Form</power>
-        <power>Twist Fate</power>
       </powers>
       <skills>
         <skill rating="8">Assensing</skill>
@@ -33300,8 +33288,6 @@
         <power>Influence</power>
         <power>Noxious Breath</power>
         <power>Venom</power>
-        <power>Metahuman Form</power>
-        <power>Twist Fate</power>
       </powers>
       <skills>
         <skill rating="8">Assensing</skill>
@@ -33881,7 +33867,6 @@
         <power>Dragonspeech</power>
         <power>Engulf</power>
         <power rating="12">Hardened Armor</power>
-        <power>Metahuman Form</power>
         <power rating="12">Mystic Armor</power>
       </powers>
       <optionalpowers>
@@ -34204,7 +34189,7 @@
         </positive>
         <negative>
           <quality>Fragmentation</quality>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -34277,7 +34262,7 @@
         </positive>
         <negative>
           <quality>Fragmentation</quality>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -34351,7 +34336,7 @@
         </positive>
         <negative>
           <quality>Corruptor</quality>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -34427,7 +34412,7 @@
           <quality>Snooper</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -34502,7 +34487,7 @@
           <quality>Rootkit</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -34578,7 +34563,7 @@
           <quality>Spawn</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -34654,7 +34639,7 @@
           <quality>Improved Realignment</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <skills>
@@ -36212,7 +36197,6 @@
       <powers>
         <power rating="3">Armor (Ballistic)</power>
         <power rating="3">Armor (Impact)</power>
-        <power>Corrosive Secretions</power>
         <power>Magical Guard</power>
         <power select="Calws/Bite: (STR/2)+1P, AP 0">Natural Weapon</power>
         <power>Sapience</power>
@@ -36975,6 +36959,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
 		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
@@ -37062,6 +37049,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
       </bonus>
       <powers>
         <power rating="2">Fragile</power>
@@ -37146,6 +37136,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
@@ -37230,6 +37223,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
 		<initiativepass>1</initiativepass>
         <reach>-1</reach>
       </bonus>
@@ -37313,6 +37309,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
         <reach>-1</reach>
 		<initiativepass>1</initiativepass>
       </bonus>
@@ -37396,6 +37395,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
       </bonus>
       <powers>
         <power select="Sonar">Enhanced Senses</power>
@@ -37481,6 +37483,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
       </bonus>
       <powers>
         <power select="Smell">Enhanced Senses</power>
@@ -37563,6 +37568,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
         <reach>-1</reach>
       </bonus>
       <powers>
@@ -37646,6 +37654,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
       </bonus>
       <powers>
 		<power>Domesticated</power>
@@ -37726,6 +37737,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
@@ -37806,6 +37820,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
 		<initiativepass>1</initiativepass>
         <reach>-1</reach>
       </bonus>
@@ -37973,6 +37990,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
         <reach>-1</reach>
       </bonus>
       <powers>
@@ -38051,6 +38071,9 @@
           <name>critter</name>
 		  <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>RES</name>
+        </enableattribute>
       </bonus>
       <powers>
         <power select="Bite/Claw: DV (STR+2)P, AP 0">Natural Weapon</power>
@@ -38130,13 +38153,16 @@
           <quality>Munge</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="3">Computer</skill>
@@ -38203,13 +38229,16 @@
           <quality>Snooper</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="4">Computer</skill>
@@ -38273,13 +38302,16 @@
           <quality>Munge</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="5">Computer</skill>
@@ -38343,7 +38375,7 @@
           <quality>Teergrube</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -38351,6 +38383,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F-1">Computer</skill>
@@ -38421,7 +38456,7 @@
           <quality select="Specific Color in Images">Datavore</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -38429,6 +38464,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -38499,7 +38537,7 @@
           <quality>Redundancy</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -38507,6 +38545,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -38577,13 +38618,16 @@
           <quality>Munge</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="2">Computer</skill>
@@ -38647,13 +38691,16 @@
           <quality>Munge</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="3">Computer</skill>
@@ -38717,13 +38764,16 @@
           <quality>Munge</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="3">Computer</skill>
@@ -38787,7 +38837,7 @@
           <quality select="Unused Process Memory">Datavore</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -38795,6 +38845,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -38863,13 +38916,16 @@
           <quality>Munge</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="3">Computer</skill>
@@ -38939,6 +38995,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -39018,6 +39077,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -39090,7 +39152,7 @@
           <quality>Uncertainty</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -39098,6 +39160,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -39166,7 +39231,7 @@
           <quality select="Running Programs">Datavore</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -39174,6 +39239,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -39244,7 +39312,7 @@
           <quality>Uncertainty</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -39252,6 +39320,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -39324,13 +39395,16 @@
           <quality>Redundancy</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="4">Computer</skill>
@@ -39394,7 +39468,7 @@
           <quality>Sapper</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -39402,6 +39476,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill rating="F">Computer</skill>
@@ -39474,7 +39551,7 @@
           <quality>Redundancy</quality>
         </positive>
         <negative>
-          <quality>Real World Naivete</quality>
+          <quality>Real World Naiveté</quality>
         </negative>
       </qualities>
       <bonus>
@@ -39482,6 +39559,9 @@
           <name>critter</name>
           <name>technomancer</name>
         </enabletab>
+		<enableattribute>
+          <name>DEP</name>
+        </enableattribute>
       </bonus>
       <skills>
         <skill>Computer</skill>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -24639,7 +24639,7 @@
 		<power rating="2">Fragile</power>
       </powers>
 	  <optionalpowers>
-		<power select="Flammable Oils">Secretion/Substance Extrusion</power>
+		<optionalpower select="Flammable Oils">Secretion/Substance Extrusion</optionalpower>
 	  </optionalpowers>
       <skills>
         <skill rating="5">Flight</skill>
@@ -24714,8 +24714,8 @@
         <power select="Sunlight, Mild">Allergy</power>
       </powers>
 	  <optionalpowers>
-		<power>Fear</power>
-		<power>Paralyzing Howl</power>
+		<optionalpower>Fear</optionalpower>
+		<optionalpower>Paralyzing Howl</optionalpower>
 	  </optionalpowers>
       <skills>
         <skill rating="8">Intimidation</skill>
@@ -25018,7 +25018,7 @@
         <power select="Salt">Dietary Requirement</power>
       </powers>
 	  <optionalpowers>
-		<power>Venom</power>
+		<optionalpower>Venom</optionalpower>
 	  </optionalpowers>
       <skills>
         <skill rating="5">Gymnastics</skill>
@@ -25483,9 +25483,9 @@
         <power select="Sunlight, Moderate">Allergy</power>
       </powers>
 	  <optionalpowers>
-		<power>Pestilence</power>
-        <power>Regeneration</power>
-		<power select="Electricity">Elemental Attack</power>
+		<optionalpower>Pestilence</optionalpower>
+        <optionalpower>Regeneration</optionalpower>
+		<optionalpower select="Electricity">Elemental Attack</optionalpower>
 	  </optionalpowers>
       <skills>
         <skill rating="5">Gymnastics</skill>
@@ -27528,6 +27528,96 @@
       <source>SG</source>
       <page>193</page>
     </metatype>
+	<metatype>
+      <id>692ad3f7-a7e7-4f28-b72b-08d17085e462</id>
+      <name>Blood Spirit</name>
+      <category>Spirits</category>
+      <forcecreature />
+      <karma>0</karma>
+      <bodmin>F+2</bodmin>
+      <bodmax>F+2</bodmax>
+      <bodaug>F+2</bodaug>
+      <agimin>F+2</agimin>
+      <agimax>F+2</agimax>
+      <agiaug>F+2</agiaug>
+      <reamin>F</reamin>
+      <reamax>F</reamax>
+      <reaaug>F</reaaug>
+      <strmin>F+2</strmin>
+      <strmax>F+2</strmax>
+      <straug>F+2</straug>
+      <chamin>F</chamin>
+      <chamax>F</chamax>
+      <chaaug>F</chaaug>
+      <intmin>F</intmin>
+      <intmax>F</intmax>
+      <intaug>F</intaug>
+      <logmin>F-1</logmin>
+      <logmax>F-1</logmax>
+      <logaug>F-1</logaug>
+      <wilmin>F</wilmin>
+      <wilmax>F</wilmax>
+      <wilaug>F</wilaug>
+      <inimin>(F*2)+2</inimin>
+      <inimax>(F*2)+2</inimax>
+      <iniaug>(F*2)+2</iniaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
+      <magmin>F</magmin>
+      <magmax>F</magmax>
+      <magaug>F</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>F</min>
+          <max>F</max>
+          <aug>F</aug>
+          <val>F</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+        <initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+        <power>Astral Form</power>
+        <power>Binding</power>
+		<power>Energy Drain</power>
+		<power>Fear</power>
+        <power>Materialization</power>
+		<power>Essence Loss</power>
+      </powers>
+      <optionalpowers>
+				<optionalpower>Concealment</optionalpower>
+				<optionalpower>Confusion</optionalpower>
+				<optionalpower>Guard</optionalpower>
+				<optionalpower>Movement</optionalpower>
+				<optionalpower select="DV (Force)P, AP 0">Natural Weapon</optionalpower>
+				<optionalpower>Noxious Breath</optionalpower>
+      </optionalpowers>
+      <skills>
+        <skill rating="F">Assensing</skill>
+        <skill rating="F">Astral Combat</skill>
+        <skill rating="F">Running</skill>
+        <skill rating="F">Perception</skill>
+        <skill rating="F">Unarmed Combat</skill>
+      </skills>
+      <source>SG</source>
+      <page>91</page>
+    </metatype>
     <metatype>
       <id>06c44cd2-528e-48ef-ad60-cfc943a4af9d</id>
       <name>Abomination Spirit</name>
@@ -27540,9 +27630,9 @@
       <agimin>F+1</agimin>
       <agimax>F+1</agimax>
       <agiaug>F+1</agiaug>
-      <reamin>F+2</reamin>
-      <reamax>F+2</reamax>
-      <reaaug>F+2</reaaug>
+      <reamin>F</reamin>
+      <reamax>F</reamax>
+      <reaaug>F</reaaug>
       <strmin>F+2</strmin>
       <strmax>F+2</strmax>
       <straug>F+2</straug>
@@ -27561,19 +27651,24 @@
       <inimin>(F*2)+2</inimin>
       <inimax>(F*2)+2</inimax>
       <iniaug>(F*2)+2</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -27585,52 +27680,57 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power>Animal Control</power>
+        <power select="Toxic Critters">Animal Control</power>
         <power>Astral Form</power>
-        <power>Corrosive Spit</power>
-        <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
         <power>Materialization</power>
         <power>Movement</power>
         <power>Mutagen</power>
+		<power select="DV (Force)P, AP 0">Natural Weapon</power>
+		<power>Pestilence</power>
         <power>Sapience</power>
       </powers>
       <optionalpowers>
-				<optionalpower>Concealment</optionalpower>
-				<optionalpower>Confusion</optionalpower>
-				<optionalpower>Guard</optionalpower>
-				<optionalpower>Fear</optionalpower>
-				<optionalpower select="DV ForceP, AP 0">Natural Weapon</optionalpower>
-				<optionalpower>Noxious Breath</optionalpower>
-				<optionalpower>Venom</optionalpower>
+			<optionalpower>Concealment</optionalpower>
+			<optionalpower>Corrosive Spit</optionalpower>
+			<optionalpower>Guard</optionalpower>
+			<optionalpower>Fear</optionalpower>
+			<optionalpower>Mimicry</optionalpower>
+			<optionalpower>Search</optionalpower>
+			<optionalpower>Venom</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Exotic Ranged Weapon</skill>
         <skill rating="F">Perception</skill>
+		<skill rating="F">Running</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>144</page>
+      <source>SG</source>
+      <page>87</page>
     </metatype>
     <metatype>
       <id>f870f03a-9953-468f-bc15-c1d9e13a81c5</id>
-      <name>Acid Spirit</name>
+      <name>Barren Spirit</name>
       <category>Toxic Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F</bodmin>
-      <bodmax>F</bodmax>
-      <bodaug>F</bodaug>
-      <agimin>F+2</agimin>
-      <agimax>F+2</agimax>
-      <agiaug>F+2</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
+      <bodmin>F+4</bodmin>
+      <bodmax>F+4</bodmax>
+      <bodaug>F+4</bodaug>
+      <agimin>F-2</agimin>
+      <agimax>F-2</agimax>
+      <agiaug>F-2</agiaug>
+      <reamin>F-1</reamin>
+      <reamax>F-1</reamax>
+      <reaaug>F-1</reaaug>
       <strmin>F+4</strmin>
       <strmax>F+4</strmax>
       <straug>F+4</straug>
@@ -27640,28 +27740,33 @@
       <intmin>F</intmin>
       <intmax>F</intmax>
       <intaug>F</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
+      <logmin>F-1</logmin>
+      <logmax>F-1</logmax>
+      <logaug>F-1</logaug>
       <wilmin>F</wilmin>
       <wilmax>F</wilmax>
       <wilaug>F</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -27677,31 +27782,31 @@
       </bonus>
       <powers>
         <power>Astral Form</power>
-        <power>Concealment</power>
-        <power>Confusion</power>
-        <power>Energy Aura</power>
+        <power>Binding</power>
+		<power select="Pollutant">Elemental Attack</power>
         <power>Engulf</power>
         <power>Materialization</power>
+		<power>Movement</power>
         <power>Sapience</power>
         <power>Search</power>
-        <power select="Clean Water and Fire, Severe">Allergy</power>
+        <power select="Clean Earth, Severe">Allergy</power>
       </powers>
       <optionalpowers>
 				<optionalpower>Accident</optionalpower>
-				<optionalpower>Binding</optionalpower>
-        <optionalpower select="Acid">Elemental Attack</optionalpower>
+				<optionalpower>Concealment</optionalpower>
+				<optionalpower>Confusion</optionalpower>
+				<optionalpower>Fear</optionalpower>
 				<optionalpower>Guard</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Exotic Ranged Weapon</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>144</page>
+      <source>SG</source>
+      <page>88</page>
     </metatype>
 		<!-- End Region -->
 		<!-- Region Toxic Critters -->
@@ -30012,6 +30117,95 @@
       <reamin>F+3</reamin>
       <reamax>F+3</reamax>
       <reaaug>F+3</reaaug>
+      <strmin>F-2</strmin>
+      <strmax>F-2</strmax>
+      <straug>F-2</straug>
+      <chamin>F</chamin>
+      <chamax>F</chamax>
+      <chaaug>F</chaaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
+      <logmin>F</logmin>
+      <logmax>F</logmax>
+      <logaug>F</logaug>
+      <wilmin>F</wilmin>
+      <wilmax>F</wilmax>
+      <wilaug>F</wilaug>
+      <inimin>(F*2)+3</inimin>
+      <inimax>(F*2)+3</inimax>
+      <iniaug>(F*2)+3</iniaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
+      <magmin>F</magmin>
+      <magmax>F</magmax>
+      <magaug>F</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>F</min>
+          <max>F</max>
+          <aug>F</aug>
+          <val>F</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+        <initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+        <power>Astral Form</power>
+        <power select="Radiation">Elemental Attack</power>
+        <power>Energy Aura</power>
+        <power>Engulf</power>
+        <power>Materialization</power>
+        <power>Sapience</power>
+      </powers>
+      <optionalpowers>
+		<optionalpower>Fear</optionalpower>
+		<optionalpower>Guard</optionalpower>
+		<optionalpower>Confusion</optionalpower>
+        <optionalpower>Search</optionalpower>
+      </optionalpowers>
+      <skills>
+        <skill rating="F">Assensing</skill>
+        <skill rating="F">Astral Combat</skill>
+        <skill rating="F">Exotic Ranged Weapon</skill>
+        <skill rating="F">Flight</skill>
+        <skill rating="F">Perception</skill>
+        <skill rating="F">Unarmed Combat</skill>
+      </skills>
+      <source>SG</source>
+      <page>88</page>
+    </metatype>
+    <metatype>
+      <id>ca0367a5-889a-49d1-a8a4-08155b9d737c</id>
+      <name>Sludge Spirit</name>
+      <category>Toxic Spirits</category>
+      <forcecreature />
+      <karma>0</karma>
+      <bodmin>F+1</bodmin>
+      <bodmax>F+1</bodmax>
+      <bodaug>F+1</bodaug>
+      <agimin>F+1</agimin>
+      <agimax>F+1</agimax>
+      <agiaug>F+1</agiaug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
       <strmin>F</strmin>
       <strmax>F</strmax>
       <straug>F</straug>
@@ -30027,109 +30221,27 @@
       <wilmin>F</wilmin>
       <wilmax>F</wilmax>
       <wilaug>F</wilaug>
-      <inimin>(F*2)+3</inimin>
-      <inimax>(F*2)+3</inimax>
-      <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
-      <magmin>F</magmin>
-      <magmax>F</magmax>
-      <magaug>F</magaug>
-      <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
-      <bonus>
-        <addattribute>
-          <name>MAG</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
-        <enabletab>
-          <name>critter</name>
-        </enabletab>
-        <initiativepass>1</initiativepass>
-      </bonus>
-      <powers>
-        <power>Accident</power>
-        <power>Astral Form</power>
-        <power>Confusion</power>
-        <power select="Radiation">Elemental Attack</power>
-        <power>Energy Aura</power>
-        <power>Engulf</power>
-        <power>Materialization</power>
-        <power>Sapience</power>
-      </powers>
-      <optionalpowers>
-				<optionalpower>Fear</optionalpower>
-				<optionalpower>Guard</optionalpower>
-				<optionalpower>Noxious Breath</optionalpower>
-        <optionalpower>Search</optionalpower>
-      </optionalpowers>
-      <skills>
-        <skill rating="F">Assensing</skill>
-        <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
-        <skill rating="F">Exotic Ranged Weapon</skill>
-        <skill rating="F">Flight</skill>
-        <skill rating="F">Perception</skill>
-        <skill rating="F">Unarmed Combat</skill>
-      </skills>
-      <source>SM</source>
-      <page>146</page>
-    </metatype>
-    <metatype>
-      <id>ca0367a5-889a-49d1-a8a4-08155b9d737c</id>
-      <name>Sludge Spirit</name>
-      <category>Toxic Spirits</category>
-      <forcecreature />
-      <karma>0</karma>
-      <bodmin>F+3</bodmin>
-      <bodmax>F+3</bodmax>
-      <bodaug>F+3</bodaug>
-      <agimin>F-1</agimin>
-      <agimax>F-1</agimax>
-      <agiaug>F-1</agiaug>
-      <reamin>F+2</reamin>
-      <reamax>F+2</reamax>
-      <reaaug>F+2</reaaug>
-      <strmin>F+3</strmin>
-      <strmax>F+3</strmax>
-      <straug>F+3</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
       <inimin>(F*2)+2</inimin>
       <inimax>(F*2)+2</inimax>
       <iniaug>(F*2)+2</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -30145,33 +30257,31 @@
       </bonus>
       <powers>
         <power>Astral Form</power>
-        <power>Anaphylaxis</power>
+        <power select="Pollutant">Elemental Attack</power>
         <power>Binding</power>
         <power>Engulf</power>
         <power>Materialization</power>
         <power>Movement</power>
+		<power>Mutagen</power>
         <power>Sapience</power>
-        <power>Silence</power>
+        <power>Search</power>
       </powers>
       <optionalpowers>
 				<optionalpower>Accident</optionalpower>
 				<optionalpower>Concealment</optionalpower>
 				<optionalpower>Confusion</optionalpower>
-				<optionalpower>Corrosive Spit</optionalpower>
-				<optionalpower select="Earth">Elemental Attack</optionalpower>
 				<optionalpower>Fear</optionalpower>
 				<optionalpower>Guard</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Exotic Ranged Weapon</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>146</page>
+      <source>SG</source>
+      <page>88</page>
     </metatype>
     <metatype>
       <id>b82e0b0e-e3c4-4d41-94f2-7a93f8247dbf</id>
@@ -30265,13 +30375,13 @@
     </metatype>
     <metatype>
       <id>ed2dfa45-8827-4470-8edb-f8203db47e82</id>
-      <name>Contagion Spirit</name>
+      <name>Plague Spirit</name>
       <category>Toxic Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+1</bodmin>
-      <bodmax>F+1</bodmax>
-      <bodaug>F+1</bodaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
       <agimin>F</agimin>
       <agimax>F</agimax>
       <agiaug>F</agiaug>
@@ -30284,9 +30394,9 @@
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
       <logmin>F</logmin>
       <logmax>F</logmax>
       <logaug>F</logaug>
@@ -30296,19 +30406,24 @@
       <inimin>(F*2)+2</inimin>
       <inimax>(F*2)+2</inimax>
       <iniaug>(F*2)+2</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -30325,35 +30440,37 @@
       <powers>
         <power>Accident</power>
         <power>Astral Form</power>
-        <power>Confusion</power>
-        <power select="Low-Light, Thermographic Vision">Enhanced Senses</power>
-        <power>Guard</power>
-        <power>Influence</power>
+        <power>Desire Reflection</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+        <power>Fear</power>
         <power>Materialization</power>
-        <power>Noxious Breath</power>
+        <power>Mutagen</power>
         <power>Pestilence</power>
         <power>Sapience</power>
         <power>Search</power>
       </powers>
       <optionalpowers>
-				<optionalpower>Fear</optionalpower>
+				<optionalpower>Concealment</optionalpower>
+				<optionalpower>Confusion</optionalpower>
+				<optionalpower>Guard</optionalpower>
+				<optionalpower>Innate Spell</optionalpower>
 				<optionalpower>Movement</optionalpower>
 				<optionalpower>Psychokinesis</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Spellcasting</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>88</page>
     </metatype>
     <metatype>
       <id>2e2bf724-7303-4be7-8010-1c59ff65811a</id>
-      <name>Smog Spirit</name>
+      <name>Noxious Spirit</name>
       <category>Toxic Spirits</category>
       <forcecreature />
       <karma>0</karma>
@@ -30384,19 +30501,24 @@
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>Fly 15/75</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -30413,33 +30535,31 @@
       <powers>
         <power>Accident</power>
         <power>Astral Form</power>
+		<power>Concealment</power>
+		<power>Confusion</power>
         <power>Engulf</power>
         <power>Materialization</power>
         <power>Movement</power>
-        <power>Noxious Breath</power>
         <power>Sapience</power>
         <power>Search</power>
-        <power select="Acid Rain, Pall of Smog">Weather Control</power>
       </powers>
       <optionalpowers>
-				<optionalpower select="Air">Elemental Attack</optionalpower>
-				<optionalpower>Energy Aura</optionalpower>
-				<optionalpower>Fear</optionalpower>
-				<optionalpower>Guard</optionalpower>
-        <optionalpower>Noxious Breath</optionalpower>
-				<optionalpower>Psychokinesis</optionalpower>
+		<optionalpower>Fear</optionalpower>
+		<optionalpower>Guard</optionalpower>
+		<optionalpower>Noxious Breath</optionalpower>
+		<optionalpower>Psychokinesis</optionalpower>
+		<optionalpower select="Acid Rain, Pall of Smog">Weather Control</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Exotic Ranged Weapon</skill>
-        <skill rating="F">Flight</skill>
+        <skill rating="F">Running</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>87</page>
     </metatype>
 		<!-- End Region -->
 		<!-- Region Insect Spirits -->
@@ -30449,9 +30569,9 @@
       <category>Insect Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
       <agimin>F+1</agimin>
       <agimax>F+1</agimax>
       <agiaug>F+1</agiaug>
@@ -30476,19 +30596,24 @@
       <inimin>(F*2)+1</inimin>
       <inimax>(F*2)+1</inimax>
       <iniaug>(F*2)+1</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/2</walk>
+		<run>4/4/4</run>
+		<sprint>2/2/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -30508,6 +30633,7 @@
         <power>Guard</power>
         <power>Hive Mind</power>
         <power>Inhabitation</power>
+		<power select="Physical Barrier">Innate Spell</power>
         <power>Sapience</power>
         <power select="Insecticides, Severe">Allergy</power>
         <power>Evanescence</power>
@@ -30515,7 +30641,6 @@
       <optionalpowers>
 				<optionalpower>Binding</optionalpower>
 				<optionalpower>Confusion</optionalpower>
-				<optionalpower>Movement</optionalpower>
 				<optionalpower select="Smell">Enhanced Senses</optionalpower>
 				<optionalpower select="Thermographic Vision">Enhanced Senses</optionalpower>
 				<optionalpower select="Ultrasound">Enhanced Senses</optionalpower>
@@ -30523,13 +30648,12 @@
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Leadership</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>152</page>
+      <source>SG</source>
+      <page>98</page>
       <metavariants>
         <metavariant>
           <name>Ant</name>
@@ -30551,8 +30675,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Locust</name>
@@ -30573,8 +30697,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Termite</name>
@@ -30595,8 +30719,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Wasp</name>
@@ -30617,14 +30741,17 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Beetle</name>
           <karma>0</karma>
           <powers>
-            <power>Reinforcement</power>
+            <power rating="F">Mystic Armor</power>
           </powers>
           <bonus>
             <addattribute>
@@ -30639,8 +30766,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Cicada</name>
@@ -30661,8 +30788,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Firefly</name>
@@ -30683,8 +30813,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Fly</name>
@@ -30706,8 +30839,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Mantid</name>
@@ -30728,12 +30864,41 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+          <page>97</page>
+        </metavariant>
+		<metavariant>
+          <name>Mosquito</name>
+          <karma>0</karma>
+		  <optionalpowers>
+            <optionalpower>Essence Drain</optionalpower>
+			<optionalpower>Pestilence</optionalpower>
+          </optionalpowers>
+          <bonus>
+            <addattribute>
+              <name>MAG</name>
+              <min>F</min>
+              <max>F</max>
+              <aug>F</aug>
+              <val>F</val>
+            </addattribute>
+            <enabletab>
+              <name>critter</name>
+            </enabletab>
+            <initiativepass>1</initiativepass>
+          </bonus>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>97</page>
         </metavariant>
         <metavariant>
           <name>Roach</name>
           <karma>0</karma>
+		  <powers>
+            <power select="Light, Mild">Allergy</power>
+          </powers>
           <bonus>
             <addattribute>
               <name>MAG</name>
@@ -30748,8 +30913,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>152</page>
+          <source>SG</source>
+			<page>98</page>
         </metavariant>
       </metavariants>
     </metatype>
@@ -30786,19 +30951,24 @@
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/2</walk>
+		<run>4/4/4</run>
+		<sprint>2/2/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -30815,7 +30985,9 @@
       <powers>
         <power>Animal Control</power>
         <power>Astral Form</power>
-        <power select="Smell, Thermographic Vision, or Ultrasound">Enhanced Senses</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Ultrasound">Enhanced Senses</power>
         <power>Hive Mind</power>
         <power>Inhabitation</power>
         <power>Innate Spell</power>
@@ -30829,13 +31001,13 @@
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Spellcasting</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>152</page>
+      <source>SG</source>
+      <page>98</page>
       <metavariants>
         <metavariant>
           <name>Ant</name>
@@ -30857,8 +31029,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Locust</name>
@@ -30879,8 +31051,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Termite</name>
@@ -30901,8 +31073,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Wasp</name>
@@ -30923,14 +31095,17 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Beetle</name>
           <karma>0</karma>
           <powers>
-            <power>Reinforcement</power>
+            <power rating="F">Mystic Armor</power>
           </powers>
           <bonus>
             <addattribute>
@@ -30945,8 +31120,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Cicada</name>
@@ -30967,8 +31142,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Firefly</name>
@@ -30989,8 +31167,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Fly</name>
@@ -31012,8 +31193,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Mantid</name>
@@ -31034,12 +31218,41 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+          <page>97</page>
+        </metavariant>
+		<metavariant>
+          <name>Mosquito</name>
+          <karma>0</karma>
+		  <optionalpowers>
+            <optionalpower>Essence Drain</optionalpower>
+			<optionalpower>Pestilence</optionalpower>
+          </optionalpowers>
+          <bonus>
+            <addattribute>
+              <name>MAG</name>
+              <min>F</min>
+              <max>F</max>
+              <aug>F</aug>
+              <val>F</val>
+            </addattribute>
+            <enabletab>
+              <name>critter</name>
+            </enabletab>
+            <initiativepass>1</initiativepass>
+          </bonus>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>97</page>
         </metavariant>
         <metavariant>
           <name>Roach</name>
           <karma>0</karma>
+		  <powers>
+            <power select="Light, Mild">Allergy</power>
+          </powers>
           <bonus>
             <addattribute>
               <name>MAG</name>
@@ -31054,11 +31267,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>152</page>
+          <source>SG</source>
+			<page>98</page>
         </metavariant>
       </metavariants>
-    </metatype>
+	</metatype>
     <metatype>
       <id>2d010755-0efa-439b-81ba-b39a42cb0ae5</id>
       <name>Scout Spirit</name>
@@ -31092,19 +31305,24 @@
       <inimin>(F*2)+2</inimin>
       <inimax>(F*2)+2</inimax>
       <iniaug>(F*2)+2</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/2</walk>
+		<run>4/4/4</run>
+		<sprint>2/2/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -31122,12 +31340,14 @@
         <power>Animal Control</power>
         <power>Astral Form</power>
         <power>Concealment</power>
-        <power select="Smell, Thermographic Vision, or Ultrasound">Enhanced Senses</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Ultrasound">Enhanced Senses</power>
         <power>Hive Mind</power>
         <power>Inhabitation</power>
         <power>Movement</power>
         <power>Sapience</power>
-        <power>Silence</power>
+        <power>Search</power>
         <power select="Insecticides, Severe">Allergy</power>
         <power>Evanescence</power>
       </powers>
@@ -31140,14 +31360,13 @@
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
-        <skill rating="F">Infiltration</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Perception</skill>
-        <skill rating="F">Shadowing</skill>
+        <skill rating="F">Sneaking</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>152</page>
+      <source>SG</source>
+      <page>98</page>
       <metavariants>
         <metavariant>
           <name>Ant</name>
@@ -31169,8 +31388,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Locust</name>
@@ -31191,8 +31410,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Termite</name>
@@ -31213,8 +31432,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Wasp</name>
@@ -31235,14 +31454,17 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Beetle</name>
           <karma>0</karma>
           <powers>
-            <power>Reinforcement</power>
+            <power rating="F">Mystic Armor</power>
           </powers>
           <bonus>
             <addattribute>
@@ -31257,8 +31479,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Cicada</name>
@@ -31279,8 +31501,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Firefly</name>
@@ -31301,8 +31526,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Fly</name>
@@ -31324,8 +31552,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>96</page>
         </metavariant>
         <metavariant>
           <name>Mantid</name>
@@ -31346,12 +31577,41 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+          <page>97</page>
+        </metavariant>
+		<metavariant>
+          <name>Mosquito</name>
+          <karma>0</karma>
+		  <optionalpowers>
+            <optionalpower>Essence Drain</optionalpower>
+			<optionalpower>Pestilence</optionalpower>
+          </optionalpowers>
+          <bonus>
+            <addattribute>
+              <name>MAG</name>
+              <min>F</min>
+              <max>F</max>
+              <aug>F</aug>
+              <val>F</val>
+            </addattribute>
+            <enabletab>
+              <name>critter</name>
+            </enabletab>
+            <initiativepass>1</initiativepass>
+          </bonus>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>97</page>
         </metavariant>
         <metavariant>
           <name>Roach</name>
           <karma>0</karma>
+		  <powers>
+            <power select="Light, Mild">Allergy</power>
+          </powers>
           <bonus>
             <addattribute>
               <name>MAG</name>
@@ -31366,23 +31626,23 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>152</page>
+          <source>SG</source>
+			<page>98</page>
         </metavariant>
       </metavariants>
-    </metatype>
+	</metatype>
     <metatype>
       <id>81ddedd0-1624-4e4d-94ba-f2614b875e77</id>
       <name>Soldier Spirit</name>
       <category>Insect Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
-      <agimin>F</agimin>
-      <agimax>F</agimax>
-      <agiaug>F</agiaug>
+      <bodmin>F+3</bodmin>
+      <bodmax>F+3</bodmax>
+      <bodaug>F+3</bodaug>
+      <agimin>F+1</agimin>
+      <agimax>F+1</agimax>
+      <agiaug>F+1</agiaug>
       <reamin>F+1</reamin>
       <reamax>F+1</reamax>
       <reaaug>F+1</reaaug>
@@ -31404,19 +31664,24 @@
       <inimin>(F*2)+1</inimin>
       <inimax>(F*2)+1</inimax>
       <iniaug>(F*2)+1</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/2</walk>
+		<run>4/4/4</run>
+		<sprint>2/2/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -31436,7 +31701,7 @@
         <power>Fear</power>
         <power>Hive Mind</power>
         <power>Inhabitation</power>
-        <power select="DV Force+2P, AP -1">Natural Weapon</power>
+        <power select="DV (Force+2)P, AP -1">Natural Weapon</power>
         <power>Sapience</power>
         <power select="Insecticides, Light">Allergy</power>
         <power>Evanescence</power>
@@ -31452,13 +31717,13 @@
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Counterspelling</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Exotic Ranged Weapon</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>152</page>
+      <source>SG</source>
+      <page>98</page>
       <metavariants>
         <metavariant>
           <name>Ant</name>
@@ -31480,8 +31745,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Locust</name>
@@ -31502,8 +31767,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Termite</name>
@@ -31524,8 +31789,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Wasp</name>
@@ -31546,14 +31811,17 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Beetle</name>
           <karma>0</karma>
           <powers>
-            <power>Reinforcement</power>
+            <power rating="F">Mystic Armor</power>
           </powers>
           <bonus>
             <addattribute>
@@ -31568,8 +31836,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Cicada</name>
@@ -31590,8 +31858,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Firefly</name>
@@ -31612,8 +31883,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Fly</name>
@@ -31635,8 +31909,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Mantid</name>
@@ -31660,9 +31937,38 @@
           <source>SM</source>
           <page>151</page>
         </metavariant>
+		<metavariant>
+          <name>Mosquito</name>
+          <karma>0</karma>
+		  <optionalpowers>
+            <optionalpower>Essence Drain</optionalpower>
+			<optionalpower>Pestilence</optionalpower>
+          </optionalpowers>
+          <bonus>
+            <addattribute>
+              <name>MAG</name>
+              <min>F</min>
+              <max>F</max>
+              <aug>F</aug>
+              <val>F</val>
+            </addattribute>
+            <enabletab>
+              <name>critter</name>
+            </enabletab>
+            <initiativepass>1</initiativepass>
+          </bonus>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
+        </metavariant>
         <metavariant>
           <name>Roach</name>
           <karma>0</karma>
+		  <powers>
+            <power select="Light, Mild">Allergy</power>
+          </powers>
           <bonus>
             <addattribute>
               <name>MAG</name>
@@ -31677,29 +31983,29 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>152</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
       </metavariants>
-    </metatype>
+	</metatype>
     <metatype>
       <id>ce75e8b1-10a1-43b6-b5a7-5214c360c5b8</id>
       <name>Worker Spirit</name>
       <category>Insect Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+3</bodmin>
-      <bodmax>F+3</bodmax>
-      <bodaug>F+3</bodaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
       <agimin>F</agimin>
       <agimax>F</agimax>
       <agiaug>F</agiaug>
-      <reamin>F+1</reamin>
-      <reamax>F+1</reamax>
-      <reaaug>F+1</reaaug>
-      <strmin>F+2</strmin>
-      <strmax>F+2</strmax>
-      <straug>F+2</straug>
+      <reamin>F</reamin>
+      <reamax>F</reamax>
+      <reaaug>F</reaaug>
+      <strmin>F+1</strmin>
+      <strmax>F+1</strmax>
+      <straug>F+1</straug>
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
@@ -31715,19 +32021,24 @@
       <inimin>(F*2)+1</inimin>
       <inimax>(F*2)+1</inimax>
       <iniaug>(F*2)+1</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/2</walk>
+		<run>4/4/4</run>
+		<sprint>2/2/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -31744,7 +32055,8 @@
       <powers>
         <power>Animal Control</power>
         <power>Astral Form</power>
-        <power select="Smell, Thermographic Vision">Enhanced Senses</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power>Hive Mind</power>
         <power>Inhabitation</power>
         <power>Movement</power>
@@ -31754,21 +32066,18 @@
         <power>Evanescence</power>
       </powers>
       <optionalpowers>
-				<optionalpower>Concealment</optionalpower>
-        <optionalpower select="Ultrasound">Enhanced Senses</optionalpower>
-				<optionalpower>Venom</optionalpower>
-				<optionalpower>Noxious Breath</optionalpower>
-				<optionalpower>Search</optionalpower>
+		<optionalpower>Concealment</optionalpower>
+		<optionalpower select="Ultrasound">Enhanced Senses</optionalpower>
+		<optionalpower>Venom</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>153</page>
+      <source>SG</source>
+      <page>99</page>
       <metavariants>
         <metavariant>
           <name>Ant</name>
@@ -31790,8 +32099,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Locust</name>
@@ -31812,8 +32121,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Termite</name>
@@ -31834,8 +32143,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Wasp</name>
@@ -31856,14 +32165,17 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Beetle</name>
           <karma>0</karma>
           <powers>
-            <power>Reinforcement</power>
+            <power rating="F">Mystic Armor</power>
           </powers>
           <bonus>
             <addattribute>
@@ -31878,8 +32190,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Cicada</name>
@@ -31900,8 +32212,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Firefly</name>
@@ -31922,8 +32237,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Fly</name>
@@ -31945,8 +32263,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Mantid</name>
@@ -31970,9 +32291,38 @@
           <source>SM</source>
           <page>151</page>
         </metavariant>
+		<metavariant>
+          <name>Mosquito</name>
+          <karma>0</karma>
+		  <optionalpowers>
+            <optionalpower>Essence Drain</optionalpower>
+			<optionalpower>Pestilence</optionalpower>
+          </optionalpowers>
+          <bonus>
+            <addattribute>
+              <name>MAG</name>
+              <min>F</min>
+              <max>F</max>
+              <aug>F</aug>
+              <val>F</val>
+            </addattribute>
+            <enabletab>
+              <name>critter</name>
+            </enabletab>
+            <initiativepass>1</initiativepass>
+          </bonus>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
+        </metavariant>
         <metavariant>
           <name>Roach</name>
           <karma>0</karma>
+		  <powers>
+            <power select="Light, Mild">Allergy</power>
+          </powers>
           <bonus>
             <addattribute>
               <name>MAG</name>
@@ -31987,11 +32337,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>152</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
       </metavariants>
-    </metatype>
+	</metatype>
     <metatype>
       <id>0fda263d-e9f5-475f-8312-2eb4f53480e2</id>
       <name>Queen/Mother Spirit</name>
@@ -32013,31 +32363,36 @@
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
+      <logmin>F+1</logmin>
+      <logmax>F+1</logmax>
+      <logaug>F+1</logaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+4</inimin>
       <inimax>(F*2)+4</inimax>
       <iniaug>(F*2)+4</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/45</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/2</walk>
+		<run>4/4/4</run>
+		<sprint>2/2/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -32049,43 +32404,45 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <initiativepass>2</initiativepass>
+        <initiativepass>1</initiativepass>
       </bonus>
       <powers>
         <power>Animal Control</power>
         <power>Astral Gateway</power>
         <power>Banishing Resistance</power>
         <power>Compulsion</power>
-        <power select="Smell, Thermographic Vision, or Ultrasound">Enhanced Senses</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Ultrasound">Enhanced Senses</power>
         <power>Fear</power>
         <power>Hive Mind</power>
         <power>Sapience</power>
         <power>Search</power>
         <power>Spirit Pact</power>
+		<power>Wealth</power>
         <power select="Insecticides, Severe">Allergy</power>
       </powers>
       <optionalpowers>
 				<optionalpower>Concealment</optionalpower>
 				<optionalpower>Guard</optionalpower>
-				<optionalpower select="DV Force+3P, AP -1">Natural Weapon</optionalpower>
+				<optionalpower select="DV (Force+3)P, AP -1">Natural Weapon</optionalpower>
 				<optionalpower>Noxious Breath</optionalpower>
 				<optionalpower>Venom</optionalpower>
-				<optionalpower>Wealth</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Con</skill>
         <skill rating="F">Counterspelling</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Leadership</skill>
         <skill rating="F">Negotiation</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Spellcasting</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>152</page>
+      <source>SG</source>
+      <page>99</page>
       <metavariants>
         <metavariant>
           <name>Ant</name>
@@ -32107,8 +32464,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Locust</name>
@@ -32129,8 +32486,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Termite</name>
@@ -32151,8 +32508,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Wasp</name>
@@ -32173,14 +32530,17 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>150</page>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Beetle</name>
           <karma>0</karma>
           <powers>
-            <power>Reinforcement</power>
+            <power rating="F">Mystic Armor</power>
           </powers>
           <bonus>
             <addattribute>
@@ -32195,8 +32555,8 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Cicada</name>
@@ -32217,8 +32577,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Firefly</name>
@@ -32239,8 +32602,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Fly</name>
@@ -32262,8 +32628,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>151</page>
+          <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
         <metavariant>
           <name>Mantid</name>
@@ -32287,9 +32656,38 @@
           <source>SM</source>
           <page>151</page>
         </metavariant>
+		<metavariant>
+          <name>Mosquito</name>
+          <karma>0</karma>
+		  <optionalpowers>
+            <optionalpower>Essence Drain</optionalpower>
+			<optionalpower>Pestilence</optionalpower>
+          </optionalpowers>
+          <bonus>
+            <addattribute>
+              <name>MAG</name>
+              <min>F</min>
+              <max>F</max>
+              <aug>F</aug>
+              <val>F</val>
+            </addattribute>
+            <enabletab>
+              <name>critter</name>
+            </enabletab>
+            <initiativepass>1</initiativepass>
+          </bonus>
+		  <skills>
+			<skill rating="F">Flight</skill>
+		  </skills>
+          <source>SG</source>
+			<page>95</page>
+        </metavariant>
         <metavariant>
           <name>Roach</name>
           <karma>0</karma>
+		  <powers>
+            <power select="Light, Mild">Allergy</power>
+          </powers>
           <bonus>
             <addattribute>
               <name>MAG</name>
@@ -32304,11 +32702,11 @@
             </enabletab>
             <initiativepass>1</initiativepass>
           </bonus>
-          <source>SM</source>
-          <page>152</page>
+          <source>SG</source>
+			<page>95</page>
         </metavariant>
       </metavariants>
-    </metatype>
+	</metatype>
 		<!-- End Region -->
 		<!-- Region Shedim -->
     <metatype>
@@ -32326,9 +32724,9 @@
       <reamin>F+2</reamin>
       <reamax>F+2</reamax>
       <reaaug>F+2</reaaug>
-      <strmin>F</strmin>
-      <strmax>F</strmax>
-      <straug>F</straug>
+      <strmin>F+1</strmin>
+      <strmax>F+1</strmax>
+      <straug>F+1</straug>
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
@@ -32344,19 +32742,24 @@
       <inimin>(F*2)+2</inimin>
       <inimax>(F*2)+2</inimax>
       <iniaug>(F*2)+2</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -32372,9 +32775,12 @@
       </bonus>
       <powers>
         <power>Astral Form</power>
+		<power>Deathly Aura</power>
         <power>Energy Drain</power>
         <power>Fear</power>
-        <power select="Age, Pathogens, Toxins">Immunity</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Paralyzing Touch</power>
         <power>Possession</power>
         <power>Sapience</power>
@@ -32393,12 +32799,11 @@
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
-        <skill rating="F">Dodge</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>155</page>
+      <source>SG</source>
+      <page>93</page>
     </metatype>
     <metatype>
       <id>5b122a59-408e-4634-855a-763b25fbad16</id>
@@ -32412,40 +32817,45 @@
       <agimin>F</agimin>
       <agimax>F</agimax>
       <agiaug>F</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
-      <strmin>F</strmin>
-      <strmax>F</strmax>
-      <straug>F</straug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
+      <strmin>F+1</strmin>
+      <strmax>F+1</strmax>
+      <straug>F+1</straug>
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
+      <logmin>F+1</logmin>
+      <logmax>F+1</logmax>
+      <logaug>F+1</logaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -32468,7 +32878,9 @@
         <power>Deathly Aura</power>
         <power>Energy Drain</power>
         <power>Fear</power>
-        <power select="Age, Pathogens, Toxins">Immunity</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Possession</power>
         <power>Regeneration</power>
         <power>Sapience</power>
@@ -32483,17 +32895,22 @@
         <optionalpower>Search</optionalpower>
         <optionalpower>Silence</optionalpower>
       </optionalpowers>
+	  <qualities>
+		<positive>
+			<quality>Aspected Magician</quality>
+		</positive>
+	  </qualities>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Counterspelling</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Spellcasting</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>155</page>
+      <source>SG</source>
+      <page>93</page>
     </metatype>
 		<!-- End Region -->
 		<!-- Region Harbingers -->
@@ -33086,7 +33503,7 @@
         <power>Spirit Pact</power>
       </powers>
       <optionalpowers>
-        <power>Guard</power>
+        <optionalpower>Guard</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="F">Assensing</skill>
@@ -34794,7 +35211,7 @@
         <power>Venom</power>
       </powers>
       <optionalpowers>
-        <power>Dragonspeech</power>
+        <optionalpower>Dragonspeech</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="5">Assensing</skill>
@@ -34880,9 +35297,9 @@
         <power rating="12">Mystic Armor</power>
       </powers>
       <optionalpowers>
-        <power>Influence</power>
-        <power>Innate Spell</power>
-        <power>Noxious Breath</power>
+        <optionalpower>Influence</optionalpower>
+        <optionalpower>Innate Spell</optionalpower>
+        <optionalpower>Noxious Breath</optionalpower>
       </optionalpowers>
       <skills>
         <skill rating="6">Enchanting</skill>
@@ -40729,46 +41146,51 @@
       <category>Shadow Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
-      <agimin>F</agimin>
-      <agimax>F</agimax>
-      <agiaug>F</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
+      <agimin>F+3</agimin>
+      <agimax>F+3</agimax>
+      <agiaug>F+3</agiaug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
       <strmin>F</strmin>
       <strmax>F</strmax>
       <straug>F</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
+      <chamin>F+2</chamin>
+      <chamax>F+2</chamax>
+      <chaaug>F+2</chaaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
       <logmin>F</logmin>
       <logmax>F</logmax>
       <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -40799,13 +41221,13 @@
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Con</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Intimidation</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>92</page>
     </metatype>
     <metatype>
       <id>1bb77459-4693-4bbb-9781-e09e758d564e</id>
@@ -40813,46 +41235,51 @@
       <category>Shadow Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
-      <agimin>F</agimin>
-      <agimax>F</agimax>
-      <agiaug>F</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
+      <agimin>F+3</agimin>
+      <agimax>F+3</agimax>
+      <agiaug>F+3</agiaug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
       <strmin>F</strmin>
       <strmax>F</strmax>
       <straug>F</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
+      <chamin>F+2</chamin>
+      <chamax>F+2</chamax>
+      <chaaug>F+2</chaaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
       <logmin>F</logmin>
       <logmax>F</logmax>
       <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -40875,7 +41302,6 @@
         <power>Materialization</power>
         <power>Sapience</power>
         <power>Spirit Pact</power>
-        <power>Engulf</power>
         <power>Fear</power>
         <power>Mind Link</power>
         <power>Shadow Cloak</power>
@@ -40884,13 +41310,13 @@
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Con</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Intimidation</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>92</page>
     </metatype>
     <metatype>
       <id>461c0597-5b0c-4b87-85c0-6ef06f8e49ae</id>
@@ -40898,46 +41324,51 @@
       <category>Shadow Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
-      <agimin>F</agimin>
-      <agimax>F</agimax>
-      <agiaug>F</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
+      <agimin>F+3</agimin>
+      <agimax>F+3</agimax>
+      <agiaug>F+3</agiaug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
       <strmin>F</strmin>
       <strmax>F</strmax>
       <straug>F</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
+      <chamin>F+2</chamin>
+      <chamax>F+2</chamax>
+      <chaaug>F+2</chaaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
       <logmin>F</logmin>
       <logmax>F</logmax>
       <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -40968,13 +41399,13 @@
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Con</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Intimidation</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>92</page>
     </metatype>
     <metatype>
       <id>2a111f59-102f-477c-9e94-a4d015324159</id>
@@ -40982,46 +41413,51 @@
       <category>Shadow Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
-      <agimin>F</agimin>
-      <agimax>F</agimax>
-      <agiaug>F</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
+      <agimin>F+3</agimin>
+      <agimax>F+3</agimax>
+      <agiaug>F+3</agiaug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
       <strmin>F</strmin>
       <strmax>F</strmax>
       <straug>F</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
+      <chamin>F+2</chamin>
+      <chamax>F+2</chamax>
+      <chaaug>F+2</chaaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
       <logmin>F</logmin>
       <logmax>F</logmax>
       <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -41046,20 +41482,20 @@
         <power>Spirit Pact</power>
         <power>Compulsion</power>
         <power>Desire Reflection</power>
-        <power>Mutable Form</power>
+		<power>Mutable Form</power>
         <power>Realistic Form</power>
       </powers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Con</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Intimidation</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>92</page>
     </metatype>
     <metatype>
       <id>f093c6e5-f5e1-4678-a927-97e35cd684dd</id>
@@ -41067,46 +41503,51 @@
       <category>Shadow Spirits</category>
       <forcecreature />
       <karma>0</karma>
-      <bodmin>F+2</bodmin>
-      <bodmax>F+2</bodmax>
-      <bodaug>F+2</bodaug>
-      <agimin>F</agimin>
-      <agimax>F</agimax>
-      <agiaug>F</agiaug>
-      <reamin>F+3</reamin>
-      <reamax>F+3</reamax>
-      <reaaug>F+3</reaaug>
+      <bodmin>F</bodmin>
+      <bodmax>F</bodmax>
+      <bodaug>F</bodaug>
+      <agimin>F+3</agimin>
+      <agimax>F+3</agimax>
+      <agiaug>F+3</agiaug>
+      <reamin>F+2</reamin>
+      <reamax>F+2</reamax>
+      <reaaug>F+2</reaaug>
       <strmin>F</strmin>
       <strmax>F</strmax>
       <straug>F</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
+      <chamin>F+2</chamin>
+      <chamax>F+2</chamax>
+      <chaaug>F+2</chaaug>
+      <intmin>F+1</intmin>
+      <intmax>F+1</intmax>
+      <intaug>F+1</intaug>
       <logmin>F</logmin>
       <logmax>F</logmax>
       <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
       <inimin>(F*2)+3</inimin>
       <inimax>(F*2)+3</inimax>
       <iniaug>(F*2)+3</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <edgmin>F/2</edgmin>
+      <edgmax>F/2</edgmax>
+      <edgaug>F/2</edgaug>
       <magmin>F</magmin>
       <magmax>F</magmax>
       <magaug>F</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
-      <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
+      <essmin>F</essmin>
+      <essmax>F</essmax>
+      <essaug>F</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -41131,19 +41572,19 @@
         <power>Spirit Pact</power>
         <power>Compulsion</power>
         <power>Confusion</power>
-        <power>Fear</power>
+		<power>Fear</power>
       </powers>
       <skills>
         <skill rating="F">Assensing</skill>
         <skill rating="F">Astral Combat</skill>
         <skill rating="F">Con</skill>
-        <skill rating="F">Dodge</skill>
+        <skill rating="F">Gymnastics</skill>
         <skill rating="F">Intimidation</skill>
         <skill rating="F">Perception</skill>
         <skill rating="F">Unarmed Combat</skill>
       </skills>
-      <source>SM</source>
-      <page>147</page>
+      <source>SG</source>
+      <page>92</page>
     </metatype>
 		<!-- End Region -->
   </metatypes>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -109,67 +109,74 @@
 		</metatype>
 		<metatype>
 			<id>522d14b3-9f8f-485d-9796-cd15fc94f044</id>
-			<name>Polar Bear</name>
+			<name>Bear</name>
 			<category>Mundane Critters</category>
 			<karma>0</karma>
-			<bodmin>7</bodmin>
-			<bodmax>7</bodmax>
-			<bodaug>7</bodaug>
-			<agimin>4</agimin>
-			<agimax>4</agimax>
-			<agiaug>4</agiaug>
-			<reamin>3</reamin>
-			<reamax>3</reamax>
-			<reaaug>3</reaaug>
-			<strmin>6</strmin>
-			<strmax>6</strmax>
-			<straug>6</straug>
-			<chamin>2</chamin>
-			<chamax>2</chamax>
-			<chaaug>2</chaaug>
-			<intmin>3</intmin>
-			<intmax>3</intmax>
-			<intaug>3</intaug>
-			<logmin>1</logmin>
-			<logmax>1</logmax>
-			<logaug>1</logaug>
-			<wilmin>3</wilmin>
-			<wilmax>3</wilmax>
-			<wilaug>3</wilaug>
-			<inimin>2</inimin>
-			<inimax>12</inimax>
-			<iniaug>12</iniaug>
-			<edgmin>3</edgmin>
-			<edgmax>3</edgmax>
-			<edgaug>3</edgaug>
+			<bodmin>6</bodmin>
+			<bodmax>12</bodmax>
+			<bodaug>16</bodaug>
+			<agimin>1</agimin>
+			<agimax>7</agimax>
+			<agiaug>11</agiaug>
+			<reamin>2</reamin>
+			<reamax>8</reamax>
+			<reaaug>12</reaaug>
+			<strmin>5</strmin>
+			<strmax>11</strmax>
+			<straug>15</straug>
+			<chamin>0</chamin>
+			<chamax>6</chamax>
+			<chaaug>10</chaaug>
+			<intmin>0</intmin>
+			<intmax>5</intmax>
+			<intaug>9</intaug>
+			<logmin>0</logmin>
+			<logmax>4</logmax>
+			<logaug>8</logaug>
+			<wilmin>1</wilmin>
+			<wilmax>7</wilmax>
+			<wilaug>11</wilaug>
+			<inimin>1</inimin>
+			<inimax>13</inimax>
+			<iniaug>21</iniaug>
+			<edgmin>0</edgmin>
+			<edgmax>6</edgmax>
+			<edgaug>6</edgaug>
 			<magmin>0</magmin>
-			<magmax>6</magmax>
-			<magaug>6</magaug>
+			<magmax>3</magmax>
+			<magaug>3</magaug>
 			<resmin>0</resmin>
-			<resmax>6</resmax>
-			<resaug>6</resaug>
+			<resmax>3</resmax>
+			<resaug>3</resaug>
 			<essmin>0</essmin>
 			<essmax>6</essmax>
 			<essaug>6</essaug>
-			<movement>15/40</movement>
+			<depmin>0</depmin>
+			<depmax>0</depmax>
+			<depaug>0</depaug>
+			<walk>2/1/0</walk>
+			<run>8/0/0</run>
+			<sprint>2/1/0</sprint>
 			<bonus>
 				<enabletab>
 					<name>critter</name>
 				</enabletab>
-				<initiativepass>1</initiativepass>
 			</bonus>
 			<powers>
-				<power select="Claw/Bite: DV 5P, AP 0">Natural Weapon</power>
+				<power select="Claw/Bite: DV (STR+3)P, AP -1">Natural Weapon</power>
+				<power select="Smell">Enhanced Senses</power>
+				<power rating="3">Armor</power>
 			</powers>
 			<skills>
+				<skill rating="3">Gymnastics</skill>
 				<skill rating="3">Intimidation</skill>
-				<skill rating="3">Perception</skill>
-				<skill rating="2">Swimming</skill>
-				<skill rating="1">Tracking</skill>
+				<skill rating="4">Perception</skill>
+				<skill rating="3">Running</skill>
+				<skill rating="4">Tracking</skill>
 				<skill rating="4">Unarmed Combat</skill>
 			</skills>
-			<source>HP</source>
-			<page>72</page>
+			<source>HS</source>
+			<page>39</page>
 		</metatype>
 		<metatype>
 			<id>10c99d1f-6125-43d0-95db-13ac9293459a</id>
@@ -1020,109 +1027,122 @@
       <name>Dog</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>2</strmin>
-      <strmax>2</strmax>
-      <straug>2</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <bodmin>1</bodmin>
+      <bodmax>7</bodmax>
+      <bodaug>11</bodaug>
+      <agimin>0</agimin>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>1</strmin>
+      <strmax>7</strmax>
+      <straug>11</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
       <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>18</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/45</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
+		<power>Domesticated</power>
         <power select="Smell">Enhanced Senses</power>
-        <power select="Claws/Bite: DV 2P, AP 0">Natural Weapon</power>
+		<power select="Hearing">Enhanced Senses</power>
+        <power select="Claws/Bite: DV (STR+1)P, AP 0">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="2">Intimidation</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="4">Intimidation</skill>
+        <skill rating="5" spec="Smell">Perception</skill>
+		<skill rating="5">Running</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>402</page>
     </metatype>
     <metatype>
       <id>7983859b-5c38-47b7-b127-2649f0c8c1b0</id>
       <name>Great Cat</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>6</bodmin>
-      <bodmax>6</bodmax>
-      <bodaug>6</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>5</strmin>
-      <strmax>5</strmax>
-      <straug>5</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <bodmin>3</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>13</bodaug>
+      <agimin>2</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>2</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>0</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
       <inimin>2</inimin>
-      <inimax>13</inimax>
-      <iniaug>13</iniaug>
-      <edgmin>4</edgmin>
-      <edgmax>4</edgmax>
-      <edgaug>4</edgaug>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/60</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -1130,179 +1150,203 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Claws/Bite: DV 5P, AP 0">Natural Weapon</power>
+        <power select="Claws/Bite: DV (STR+3)P, AP -1">Natural Weapon</power>
+		<power select="Low-light Vision">Enhanced Senses</power>
       </powers>
       <skills>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Perception</skill>
+		<skill rating="5">Running</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="7">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>402</page>
     </metatype>
     <metatype>
       <id>d4a66987-de45-4bd1-a1f3-c8573ba6d8cf</id>
       <name>Horse</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>8</bodmin>
-      <bodmax>8</bodmax>
-      <bodaug>8</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>5</reamin>
-      <reamax>5</reamax>
-      <reaaug>5</reaaug>
-      <strmin>8</strmin>
-      <strmax>8</strmax>
-      <straug>8</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
-      <inimin>3</inimin>
+      <bodmin>5</bodmin>
+      <bodmax>11</bodmax>
+      <bodaug>15</bodaug>
+      <agimin>2</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>2</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
+      <strmin>5</strmin>
+      <strmax>11</strmax>
+      <straug>15</straug>
+      <chamin>1</chamin>
+      <chamax>7</chamax>
+      <chaaug>11</chaaug>
+      <intmin>0</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>2</inimin>
       <inimax>14</inimax>
-      <iniaug>14</iniaug>
-      <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <iniaug>22</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>20/100</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>3/1/0</walk>
+	  <run>10/0/0</run>
+	  <sprint>6/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
+	  <powers>
+        <power select="Kick: DV (STR+1)P, AP 0, Reach 1">Natural Weapon</power>
+		<power>Domesticated</power>
+      </powers>
       <skills>
-        <skill rating="3">Running</skill>
+        <skill rating="6">Running</skill>
+		<skill rating="1">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>403</page>
     </metatype>
     <metatype>
       <id>a38329e9-cdfb-441f-9594-1ecf5fcdd787</id>
       <name>Shark</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
-      <bodmax>3</bodmax>
-      <bodaug>3</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>5</reamin>
-      <reamax>5</reamax>
-      <reaaug>5</reaaug>
-      <strmin>3</strmin>
-      <strmax>3</strmax>
-      <straug>3</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
+      <bodmin>2</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>12</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>2</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
+      <strmin>2</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>0</chamin>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
       <inimin>3</inimin>
       <inimax>15</inimax>
-      <iniaug>15</iniaug>
-      <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <iniaug>23</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>20/60</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>0/3/0</walk>
+	  <run>0/8/0</run>
+	  <sprint>0/4/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite: DV 5P, AP 0">Natural Weapon</power>
+        <power select="Bite: DV (STR+2)P, AP -2">Natural Weapon</power>
+		<power rating="2">Armor</power>
+		<power>Gills</power>
       </powers>
       <skills>
-        <skill rating="2">Perception</skill>
-        <skill rating="4">Swimming</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="6" spec="Smell">Perception</skill>
+        <skill rating="10">Swimming</skill>
+        <skill rating="8">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>403</page>
     </metatype>
     <metatype>
       <id>d6da129f-65b2-4fb4-aae3-a73e6937a2a6</id>
       <name>Wolf</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <bodmin>3</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>13</bodaug>
+      <agimin>0</agimin>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>2</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
       <strmin>2</strmin>
-      <strmax>2</strmax>
-      <straug>2</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>3</inimin>
+      <inimax>15</inimax>
+      <iniaug>23</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/50</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -1310,16 +1354,19 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Claws/Bite: DV 2P, AP 0">Natural Weapon</power>
+        <power select="Claws/Bite: DV (STR+2)P, AP -1">Natural Weapon</power>
+		<power select="Hearing">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="5">Running</skill>
+        <skill rating="5" spec="Smell">Perception</skill>
+		<skill rating="5">Sneaking</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="7">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>403</page>
     </metatype>
     <metatype>
       <id>bee84e0e-069c-4f02-bffd-11e757229506</id>
@@ -1390,64 +1437,70 @@
       <name>Squid</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
-      <strmin>3</strmin>
-      <strmax>3</strmax>
-      <straug>3</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>4</logmin>
-      <logmax>4</logmax>
-      <logaug>4</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>11</inimax>
-      <iniaug>11</iniaug>
+      <bodmin>1</bodmin>
+      <bodmax>7</bodmax>
+      <bodaug>11</bodaug>
+      <agimin>2</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>0</reamin>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
+      <strmin>2</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>1</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 15/25</movement>
+	  <depmin>0</depmin>
+      <depmax>0</depmax>
+      <depaug>0</depaug>
+      <walk>0/3/0</walk>
+	  <run>0/8/0</run>
+	  <sprint>0/2/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <reach>2</reach>
+        <reach>3</reach>
       </bonus>
       <powers>
         <power>Gills</power>
         <power select="Ink">Substance Extrusion</power>
       </powers>
       <skills>
-        <skill rating="3">Escape Artist</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Swimming</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Escape Artist</skill>
+		<skill rating="6">Gymnastics</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="5">Swimming</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>88</page>
+      <source>HS</source>
+      <page>43</page>
     </metatype>
     <metatype>
       <id>e5b5e5b4-534a-49a0-ab18-3390fdc73371</id>
@@ -1699,49 +1752,54 @@
     </metatype>
     <metatype>
       <id>1f7ea859-8fa3-42cc-8252-bab7da65f87f</id>
-      <name>Bottlenose Dolphin</name>
+      <name>Dolphin</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>8</bodmin>
-      <bodmax>8</bodmax>
-      <bodaug>8</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>5</reamin>
-      <reamax>5</reamax>
-      <reaaug>5</reaaug>
-      <strmin>8</strmin>
-      <strmax>8</strmax>
-      <straug>8</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>4</logmin>
-      <logmax>4</logmax>
-      <logaug>4</logaug>
-      <wilmin>4</wilmin>
-      <wilmax>4</wilmax>
-      <wilaug>4</wilaug>
+      <bodmin>5</bodmin>
+      <bodmax>11</bodmax>
+      <bodaug>15</bodaug>
+      <agimin>2</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>2</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
+      <strmin>4</strmin>
+      <strmax>10</strmax>
+      <straug>14</straug>
+      <chamin>1</chamin>
+      <chamax>7</chamax>
+      <chaaug>11</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>1</wilmin>
+      <wilmax>7</wilmax>
+      <wilaug>11</wilaug>
       <inimin>3</inimin>
       <inimax>15</inimax>
-      <iniaug>15</iniaug>
+      <iniaug>23</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 20/80</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>0/2/0</walk>
+	  <run>0/8/0</run>
+	  <sprint>0/4/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -1749,16 +1807,17 @@
       </bonus>
       <powers>
         <power select="Sonar">Enhanced Senses</power>
+		<power rating="2">Armor</power>
       </powers>
       <skills>
-        <skill rating="2">Diving</skill>
-        <skill rating="4">Gymnastics</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Swimming</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="3">Diving</skill>
+        <skill rating="7">Gymnastics</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="5">Swimming</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>89</page>
+      <source>HS</source>
+      <page>42</page>
     </metatype>
     <metatype>
       <id>594663d1-dc12-4a91-a619-9772162f06a5</id>
@@ -2463,63 +2522,69 @@
       <name>Sea Lion</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>7</bodmin>
-      <bodmax>7</bodmax>
-      <bodaug>7</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>6</strmin>
-      <strmax>6</strmax>
-      <straug>6</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>4</wilmin>
-      <wilmax>4</wilmax>
-      <wilaug>4</wilaug>
+      <bodmin>4</bodmin>
+      <bodmax>10</bodmax>
+      <bodaug>14</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>2</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
       <inimin>2</inimin>
       <inimax>14</inimax>
-      <iniaug>14</iniaug>
+      <iniaug>22</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 10/30</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>1/3/0</walk>
+	  <run>0/8/0</run>
+	  <sprint>1/4/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite: DV 4P, AP 0">Natural Weapon</power>
+        <power select="Bite: DV (STR+2)P, AP 0">Natural Weapon</power>
+		<power rating="2">Armor</power>
       </powers>
       <skills>
         <skill rating="2">Diving</skill>
-        <skill rating="3">Gymanstics</skill>
+        <skill rating="3">Gymnastics</skill>
         <skill rating="2">Perception</skill>
         <skill rating="4">Swimming</skill>
         <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>89</page>
+      <source>HS</source>
+      <page>43</page>
     </metatype>
     <metatype>
       <id>5206088d-c55a-4650-8ec1-74aa3497464b</id>
@@ -2576,7 +2641,7 @@
       </powers>
       <skills>
         <skill rating="2">Diving</skill>
-        <skill rating="2">Gymanstics</skill>
+        <skill rating="2">Gymnastics</skill>
         <skill rating="2">Perception</skill>
         <skill rating="4">Swimming</skill>
         <skill rating="2">Unarmed Combat</skill>
@@ -2640,7 +2705,7 @@
       </powers>
       <skills>
         <skill rating="2">Diving</skill>
-        <skill rating="3">Gymanstics</skill>
+        <skill rating="3">Gymnastics</skill>
         <skill rating="2">Perception</skill>
         <skill rating="4">Swimming</skill>
         <skill rating="1">Unarmed Combat</skill>
@@ -2781,46 +2846,51 @@
       <name>Barracuda</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
-      <strmin>2</strmin>
-      <strmax>2</strmax>
-      <straug>2</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>2</intmin>
-      <intmax>2</intmax>
-      <intaug>2</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>10</inimax>
-      <iniaug>10</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <bodmin>0</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
+      <agimin>0</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>0</reamin>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
+      <strmin>0</strmin>
+      <strmax>5</strmax>
+      <straug>9</straug>
+      <chamin>0</chamin>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>0</inimin>
+      <inimax>11</inimax>
+      <iniaug>19</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 20/60</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>0/2/0</walk>
+	  <run>0/6/0</run>
+	  <sprint>0/2/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -2829,15 +2899,16 @@
       <powers>
         <power select="Smell">Enhanced Senses</power>
         <power>Gills</power>
-        <power select="Bite: DV 3P, AP 0">Natural Weapon</power>
+        <power select="Bite: DV (STR+1)P, AP 0">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="2">Perception</skill>
-        <skill rating="4">Swimming</skill>
-        <skill rating="3">Unarmed Combat</skill>
+		<skill rating="3">Gymnastics</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="6">Swimming</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>90</page>
+      <source>HS</source>
+      <page>42</page>
     </metatype>
     <metatype>
       <id>14e32e75-f5ba-488c-a15e-400e94dff11b</id>
@@ -3217,65 +3288,72 @@
     </metatype>
     <metatype>
       <id>2cdf4a25-6866-49a2-be90-e508980ad219</id>
-      <name>Whale Shark</name>
+      <name>Killer Whale</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>10</bodmin>
-      <bodmax>10</bodmax>
-      <bodaug>10</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>6</strmin>
-      <strmax>6</strmax>
-      <straug>6</straug>
-      <chamin>2</chamin>
-      <chamax>2</chamax>
-      <chaaug>2</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>13</inimax>
-      <iniaug>13</iniaug>
-      <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <bodmin>9</bodmin>
+      <bodmax>15</bodmax>
+      <bodaug>19</bodaug>
+      <agimin>3</agimin>
+      <agimax>9</agimax>
+      <agiaug>13</agiaug>
+      <reamin>3</reamin>
+      <reamax>9</reamax>
+      <reaaug>13</reaaug>
+      <strmin>10</strmin>
+      <strmax>16</strmax>
+      <straug>20</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>2</intmin>
+      <intmax>8</intmax>
+      <intaug>12</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>5</wilmin>
+      <wilmax>11</wilmax>
+      <wilaug>15</wilaug>
+      <inimin>5</inimin>
+      <inimax>17</inimax>
+      <iniaug>25</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 15/20</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>0/3/0</walk>
+	  <run>0/8/0</run>
+	  <sprint>0/4/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power>Gills</power>
+        <power rating="4">Armor</power>
+		<power select="Sonar">Enhanced Senses</power>
+		<power select="Bite: DV (STR+2)P, AP 0">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Swimming</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="3">Diving</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="4">Swimming</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>90</page>
+      <source>HS</source>
+      <page>43</page>
     </metatype>
     <metatype>
       <id>46c8e7e9-086d-41b7-bdb2-98c2cb6df206</id>
@@ -3521,64 +3599,70 @@
       <name>Alligator</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>7</bodmin>
-      <bodmax>7</bodmax>
-      <bodaug>7</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>7</strmin>
-      <strmax>7</strmax>
-      <straug>7</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
-      <inimin>2</inimin>
-      <inimax>13</inimax>
-      <iniaug>13</iniaug>
+      <bodmin>5</bodmin>
+      <bodmax>11</bodmax>
+      <bodaug>15</bodaug>
+      <agimin>2</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>6</strmin>
+      <strmax>12</strmax>
+      <straug>16</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>8</wilaug>
+      <inimin>0</inimin>
+      <inimax>12</inimax>
+      <iniaug>20</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/35</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite: DV 6P, AP -2">Natural Weapon</power>
+        <power select="Bite: DV (STR+2)P, AP -2">Natural Weapon</power>
         <power select="Smell">Enhanced Senses</power>
+		<power rating="2">Toughness</power>
+		<power rating="6">Armor</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Shadowing</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>90</page>
+      <source>HS</source>
+      <page>39</page>
     </metatype>
     <metatype>
       <id>dc50e70e-a428-4692-ac06-e79aac93c12f</id>
@@ -3843,63 +3927,69 @@
       <name>Boar</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
-      <bodmax>5</bodmax>
-      <bodaug>5</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>5</strmin>
-      <strmax>5</strmax>
-      <straug>5</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
-      <inimin>2</inimin>
-      <inimax>13</inimax>
-      <iniaug>13</iniaug>
+      <bodmin>3</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>13</bodaug>
+      <agimin>0</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>2</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>0</inimin>
+      <inimax>12</inimax>
+      <iniaug>20</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/40</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>2/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite/Tusk: DV 3P, AP 0">Natural Weapon</power>
+        <power select="Bite/Tusk: DV (STR+2)P, AP -1">Natural Weapon</power>
         <power select="Smell">Enhanced Senses</power>
+		<power rating="4">Armor</power>
       </powers>
       <skills>
-        <skill rating="2">Perception</skill>
-        <skill rating="1">Running</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="2">Running</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>90</page>
+      <source>HS</source>
+      <page>40</page>
     </metatype>
     <metatype>
       <id>5adc42b0-97c7-495e-824b-828147fd8250</id>
@@ -5159,67 +5249,75 @@
     </metatype>
     <metatype>
       <id>be4c5fce-f717-4f96-92d1-103de839d9a2</id>
-      <name>Norwegian Rat</name>
+      <name>Rat</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
       <bodmin>0</bodmin>
-      <bodmax>0</bodmax>
-      <bodaug>0</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>0</agimin>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>0</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>1</intmin>
-      <intmax>1</intmax>
-      <intaug>1</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
+      <strmax>3</strmax>
+      <straug>7</straug>
+      <chamin>0</chamin>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
+      <intmin>0</intmin>
+      <intmax>4</intmax>
+      <intaug>8</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>8</wilaug>
+      <inimin>0</inimin>
       <inimax>9</inimax>
-      <iniaug>9</iniaug>
+      <iniaug>17</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>5/15</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
         <reach>-1</reach>
       </bonus>
       <powers>
+		<power select="Bite: DV 1P, AP 0, Reach -1">Natural Weapon</power>
         <power select="Smell">Enhanced Senses</power>
         <power>Gestalt Consciousness</power>
+		<power rating="3">Fragile</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="3">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="2">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>93</page>
+      <source>HS</source>
+      <page>46</page>
     </metatype>
     <metatype>
       <id>7d1395db-f082-499e-8224-add6a371436c</id>
@@ -6233,46 +6331,51 @@
       <name>Elephant</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>12</bodmin>
-      <bodmax>12</bodmax>
-      <bodaug>12</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>16</strmin>
-      <strmax>16</strmax>
-      <straug>16</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <bodmin>9</bodmin>
+      <bodmax>15</bodmax>
+      <bodaug>19</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>13</strmin>
+      <strmax>19</strmax>
+      <straug>23</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>0</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>1</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>24/45</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>18/0/0</run>
+	  <sprint>2/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -6280,76 +6383,86 @@
         <reach>2</reach>
       </bonus>
       <powers>
-        <power select="Tusk: DV 12P, AP -2">Natural Weapon</power>
+        <power select="Tusk: DV (STR+2)P, AP -2">Natural Weapon</power>
+		<power select="Low Frequency">Enhanced Senses</power>
+		<power rating="6">Armor</power>
       </powers>
       <skills>
-        <skill rating="3">Clubs</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Running</skill>
+        <skill rating="5">Clubs</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="4">Running</skill>
         <skill rating="2">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>94</page>
+      <source>HS</source>
+      <page>41</page>
     </metatype>
     <metatype>
       <id>3ffa4934-12e0-4ace-b314-20d1a84c4284</id>
       <name>Giraffe</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>12</bodmin>
-      <bodmax>12</bodmax>
-      <bodaug>12</bodaug>
-      <agimin>2</agimin>
-      <agimax>2</agimax>
-      <agiaug>2</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
-      <strmin>9</strmin>
-      <strmax>9</strmax>
-      <straug>9</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>1</intmin>
-      <intmax>1</intmax>
-      <intaug>1</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>8</inimax>
-      <iniaug>8</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <bodmin>7</bodmin>
+      <bodmax>13</bodmax>
+      <bodaug>17</bodaug>
+      <agimin>0</agimin>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>0</reamin>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
+      <strmin>5</strmin>
+      <strmax>11</strmax>
+      <straug>15</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>0</inimin>
+      <inimax>11</inimax>
+      <iniaug>19</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/50</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
         <reach>2</reach>
       </bonus>
-      <powers />
+      <powers>
+        <power select="Kick: DV (STR+1)P, AP 0, Reach 2">Natural Weapon</power>
+		<power rating="2">Armor</power>
+      </powers>
       <skills>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Running</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="3">Running</skill>
+        <skill rating="2">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>94</page>
+      <source>HS</source>
+      <page>41</page>
     </metatype>
     <metatype>
       <id>7ec1f78b-4887-4e01-8626-f846407f92f7</id>
@@ -7076,63 +7189,69 @@
       <name>Chimpanzee</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>4</bodmin>
-      <bodmax>4</bodmax>
-      <bodaug>4</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>5</reamin>
-      <reamax>5</reamax>
-      <reaaug>5</reaaug>
-      <strmin>4</strmin>
-      <strmax>4</strmax>
-      <straug>4</straug>
-      <chamin>2</chamin>
-      <chamax>2</chamax>
-      <chaaug>2</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>4</logmin>
-      <logmax>4</logmax>
-      <logaug>4</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>3</inimin>
+      <bodmin>1</bodmin>
+      <bodmax>7</bodmax>
+      <bodaug>11</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>1</strmin>
+      <strmax>7</strmax>
+      <straug>11</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>2</inimin>
       <inimax>14</inimax>
-      <iniaug>14</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <iniaug>22</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/30</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>2/1/0</walk>
+	  <run>4/0/0</run>
+	  <sprint>2/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite: DV 4P, AP 0">Natural Weapon</power>
+		<power>Brachiation</power>
+        <power select="Bite: DV (STR+2)P, AP 0">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="2">Clubs</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="1">Throwing Weapons</skill>
-        <skill rating="4">Unarmed Combat</skill>
-        <group rating="3">Athletics</group>
+        <skill rating="3">Clubs</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Throwing Weapons</skill>
+        <skill rating="6">Unarmed Combat</skill>
+        <group rating="4">Athletics</group>
       </skills>
-      <source>RW</source>
-      <page>94</page>
+      <source>HS</source>
+      <page>40</page>
     </metatype>
     <metatype>
       <id>5e61ede1-b0e1-41de-b8dd-6ad3be6dfcc9</id>
@@ -9361,46 +9480,51 @@
       <name>Domestic Cat</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <bodmin>0</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>0</reamin>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
+      <strmin>0</strmin>
+      <strmax>4</strmax>
+      <straug>8</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>0</inimin>
+      <inimax>11</inimax>
+      <iniaug>19</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/40</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -9408,16 +9532,18 @@
       </bonus>
       <powers>
         <power rating="2">Fragile</power>
+		<power>Domesticated</power>
+		<power select="Low-light Vision">Enhanced Senses</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="1">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="2">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="3">Tracking</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>96</page>
+      <source>HS</source>
+      <page>45</page>
     </metatype>
     <metatype>
       <id>4535aa3a-02a4-4f17-8842-511b340d4f28</id>
@@ -9487,63 +9613,70 @@
       <name>Ferret</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
-      <agimin>2</agimin>
-      <agimax>2</agimax>
-      <agiaug>2</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
+      <bodmin>0</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>0</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>0</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>2</intmin>
-      <intmax>2</intmax>
-      <intaug>2</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
+      <strmax>4</strmax>
+      <straug>8</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>0</inimin>
       <inimax>10</inimax>
-      <iniaug>10</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <iniaug>18</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/30</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<reach>-1</reach>
       </bonus>
       <powers>
-        <power select="Bite: DV 2P, AP 0, -1 Reach">Natural Weapon</power>
+        <power select="Bite: DV (STR+1)P, AP 0, -1 Reach">Natural Weapon</power>
         <power rating="1">Fragile</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="2">Unarmed Combat</skill>
+		<skill rating="3">Gymnastics</skill>
+        <skill rating="3">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>96</page>
+      <source>HS</source>
+      <page>46</page>
     </metatype>
     <metatype>
       <id>b31a9f94-4de7-4ffc-8c90-3dced66fe2d1</id>
@@ -9804,46 +9937,51 @@
       <name>Raccoon</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <bodmin>0</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>0</reamin>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
+      <strmin>0</strmin>
+      <strmax>4</strmax>
+      <straug>8</straug>
+      <chamin>0</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>1</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>8/20</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -9855,13 +9993,14 @@
         <power rating="1">Fragile</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="3">Sneaking</skill>
+		<skill rating="3">Palming</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>96</page>
+      <source>HS</source>
+      <page>46</page>
     </metatype>
     <metatype>
       <id>dbcf8f5f-8e43-43f4-84ab-ab0ed7192824</id>
@@ -10169,61 +10308,77 @@
     </metatype>
     <metatype>
       <id>7fcca21c-729f-414b-95aa-ced043d851cc</id>
-      <name>Grass Snake</name>
+      <name>Snake</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
       <bodmin>0</bodmin>
-      <bodmax>0</bodmax>
-      <bodaug>0</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
+      <agimin>1</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>0</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>2</chamin>
-      <chamax>2</chamax>
-      <chaaug>2</chaaug>
-      <intmin>1</intmin>
-      <intmax>1</intmax>
-      <intaug>1</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>8</inimax>
-      <iniaug>8</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <strmax>6</strmax>
+      <straug>10</straug>
+      <chamin>0</chamin>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>0</inimin>
+      <inimax>10</inimax>
+      <iniaug>18</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>5/8</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>2/1/0</walk>
+	  <run>3/0/0</run>
+	  <sprint>2/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
       </bonus>
-      <powers />
+      <powers>
+		<power select="Bite: DV (STR+2)P, AP 0">Natural Weapon</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power rating="3">Armor</power>
+	  </powers>
+	  <optionalpowers>
+		<optionalpower>Venom</optionalpower>
+	  </optionalpowers>
       <skills>
-        <skill rating="2">Perception</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="3">Perception</skill>
+		<skill rating="3">Gymnastics</skill>
+		<skill rating="3">Sneaking</skill>
+		<skill rating="3">Tracking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>96</page>
+      <source>HS</source>
+      <page>42</page>
     </metatype>
     <metatype>
       <id>eb903b98-e5eb-4f2e-9335-0f1d9b8fe0db</id>
@@ -10586,62 +10741,69 @@
       <category>Mundane Critters</category>
       <karma>0</karma>
       <bodmin>0</bodmin>
-      <bodmax>0</bodmax>
-      <bodaug>0</bodaug>
-      <agimin>1</agimin>
-      <agimax>1</agimax>
-      <agiaug>1</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>0</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>2</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>2</intmin>
-      <intmax>2</intmax>
-      <intaug>2</intaug>
+      <strmax>3</strmax>
+      <straug>7</straug>
+      <chamin>0</chamin>
+      <chamax>3</chamax>
+      <chaaug>7</chaaug>
+      <intmin>0</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
       <logmin>0</logmin>
-      <logmax>0</logmax>
-      <logaug>0</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>8</inimax>
-      <iniaug>8</iniaug>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>1</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>2/5</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
         <reach>-1</reach>
       </bonus>
       <powers>
         <power>Gestalt Consciousness</power>
         <power>Wall Walking</power>
+		<power>Extra Fragile</power>
       </powers>
       <skills>
-        <skill rating="3">Dodge</skill>
-        <skill rating="3">Infiltration</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="4">Sneaking</skill>
         <skill rating="2">Perception</skill>
       </skills>
-      <source>RW</source>
-      <page>96</page>
+      <source>HS</source>
+      <page>45</page>
     </metatype>
     <metatype>
       <id>168fa92d-4093-472e-980e-249e4ac79a5d</id>
@@ -11098,62 +11260,69 @@
       <category>Mundane Critters</category>
       <karma>0</karma>
       <bodmin>0</bodmin>
-      <bodmax>0</bodmax>
-      <bodaug>0</bodaug>
-      <agimin>2</agimin>
-      <agimax>2</agimax>
-      <agiaug>2</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>0</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>0</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>2</intmin>
-      <intmax>2</intmax>
-      <intaug>2</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>10</inimax>
-      <iniaug>10</iniaug>
+      <strmax>3</strmax>
+      <straug>7</straug>
+      <chamin>0</chamin>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
+      <intmin>0</intmin>
+      <intmax>4</intmax>
+      <intaug>8</intaug>
+      <logmin>0</logmin>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>8</wilaug>
+      <inimin>0</inimin>
+      <inimax>9</inimax>
+      <iniaug>17</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>3/8</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/0/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/0/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
         <reach>-1</reach>
+		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
         <power>Gestalt Consciousness</power>
         <power>Wall Walking</power>
+		<power rating="1">Fragile</power>
       </powers>
       <skills>
-        <skill rating="1">Climbing</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
+        <skill rating="4">Gymnastics</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="3">Perception</skill>
       </skills>
-      <source>RW</source>
-      <page>98</page>
+      <source>HS</source>
+      <page>47</page>
     </metatype>
     <metatype>
       <id>73b1606c-4838-4e60-95f4-851ba5c9e1c6</id>
@@ -11919,46 +12088,51 @@
       <name>Crow</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
+      <bodmin>0</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
+      <agimin>0</agimin>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>0</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
+      <strmax>4</strmax>
+      <straug>8</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>2</intmin>
+      <intmax>8</intmax>
+      <intaug>12</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>1</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
       <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 20/40</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/3</walk>
+	  <run>4/0/6</run>
+	  <sprint>4/1/5</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -11970,12 +12144,12 @@
         <power>Gestalt Consciousness</power>
       </powers>
       <skills>
-        <skill rating="4">Flight</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="6">Flight</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>98</page>
+      <source>HS</source>
+      <page>45</page>
     </metatype>
     <metatype>
       <id>553deb0a-8ee0-4fdc-9782-f6c8ebf5f96f</id>
@@ -12657,62 +12831,68 @@
       <name>Eagle</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>2</strmin>
-      <strmax>2</strmax>
-      <straug>2</straug>
-      <chamin>2</chamin>
-      <chamax>2</chamax>
-      <chaaug>2</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <bodmin>0</bodmin>
+      <bodmax>6</bodmax>
+      <bodaug>10</bodaug>
+      <agimin>2</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>1</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>0</strmin>
+      <strmax>5</strmax>
+      <straug>9</straug>
+      <chamin>0</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>1</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>0</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>0</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
       <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>1</edgmin>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>3</magmax>
+      <magaug>3</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>3</resmax>
+      <resaug>3</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 20/80</movement>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/3</walk>
+	  <run>4/0/7</run>
+	  <sprint>4/1/6</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite/Claw: DV 3P, AP 0">Natural Weapon</power>
+        <power select="Bite/Claw: DV (STR+2)P, AP 0">Natural Weapon</power>
+		<power select="Vision Magnification">Enhanced Senses</power>
       </powers>
       <skills>
         <skill rating="3">Flight</skill>
-        <skill rating="3">Perception</skill>
+        <skill rating="5">Perception</skill>
         <skill rating="2">Tracking</skill>
         <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>99</page>
+      <source>HS</source>
+      <page>41</page>
     </metatype>
     <metatype>
       <id>02c44024-04af-4242-8c20-f8b5a447c311</id>
@@ -34831,24 +35011,24 @@
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
-      <intmin>F+1</intmin>
-      <intmax>F+1</intmax>
-      <intaug>F+1</intaug>
+      <intmin>F+3</intmin>
+      <intmax>F+3</intmax>
+      <intaug>F+3</intaug>
       <logmin>F+1</logmin>
       <logmax>F+1</logmax>
       <logaug>F+1</logaug>
-      <wilmin>0</wilmin>
-      <wilmax>0</wilmax>
-      <wilaug>0</wilaug>
-      <inimin>(F*3)</inimin>
-      <inimax>(F*3)</inimax>
-      <iniaug>(F*3)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <wilmin>F+2</wilmin>
+      <wilmax>F+2</wilmax>
+      <wilaug>F+2</wilaug>
+      <inimin>(F*2)+1</inimin>
+      <inimax>(F*2)+1</inimax>
+      <iniaug>(F*2)+1</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>0</edgmax>
+      <edgaug>0</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
       <resmin>F</resmin>
       <resmax>F</resmax>
       <resaug>F</resaug>
@@ -34868,25 +35048,10 @@
       </powers>
       <skills>
         <skill rating="F">Computer</skill>
-        <skill rating="F">Data Search</skill>
         <skill rating="F">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Edit</complexform>
-        <complexform rating="F">Encrypt</complexform>
-        <complexform rating="F">Stealth</complexform>
-        <complexform rating="F">Track</complexform>
-      </complexforms>
-      <optionalcomplexforms>
-        <complexform rating="F">Browse</complexform>
-        <complexform rating="F">Command</complexform>
-        <complexform rating="F">Decrypt</complexform>
-        <complexform rating="F">Exploit</complexform>
-        <complexform rating="F">Scan</complexform>
-      </optionalcomplexforms>
-      <source>DIS</source>
-      <page>242</page>
+      <source>SR5</source>
+      <page>258</page>
     </metatype>
     <metatype>
       <id>1eabd4d6-b759-4e89-8478-1d327e2755c3</id>
@@ -34909,24 +35074,24 @@
       <chamin>F</chamin>
       <chamax>F</chamax>
       <chaaug>F</chaaug>
-      <intmin>F+1</intmin>
-      <intmax>F+1</intmax>
-      <intaug>F+1</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>0</wilmin>
-      <wilmax>0</wilmax>
-      <wilaug>0</wilaug>
-      <inimin>(F*3)</inimin>
-      <inimax>(F*3)</inimax>
-      <iniaug>(F*3)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <intmin>F+3</intmin>
+      <intmax>F+3</intmax>
+      <intaug>F+3</intaug>
+      <logmin>F+2</logmin>
+      <logmax>F+2</logmax>
+      <logaug>F+2</logaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
+      <inimin>(F*2)+2</inimin>
+      <inimax>(F*2)+2</inimax>
+      <iniaug>(F*2)+2</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>0</edgmax>
+      <edgaug>0</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
       <resmin>F</resmin>
       <resmax>F</resmax>
       <resaug>F</resaug>
@@ -34948,20 +35113,8 @@
         <skill rating="F">Electronic Warfare</skill>
         <skill rating="F">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Exploit</complexform>
-        <complexform rating="F">Stealth</complexform>
-      </complexforms>
-      <optionalcomplexforms>
-        <complexform rating="F">Decrypt</complexform>
-        <complexform rating="F">Defuse</complexform>
-        <complexform rating="F">Edit</complexform>
-        <complexform rating="F">Scan</complexform>
-        <complexform rating="F">Spoof</complexform>
-      </optionalcomplexforms>
-      <source>DIS</source>
-      <page>242</page>
+      <source>SR5</source>
+      <page>258</page>
     </metatype>
     <metatype>
       <id>4742c36a-baa9-467b-b2c1-9dc6889a46e2</id>
@@ -34981,27 +35134,27 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
+      <chamin>F-1</chamin>
+      <chamax>F-1</chamax>
+      <chaaug>F-1</chaaug>
       <intmin>F</intmin>
       <intmax>F</intmax>
       <intaug>F</intaug>
-      <logmin>F-2</logmin>
-      <logmax>F-2</logmax>
-      <logaug>F-2</logaug>
-      <wilmin>0</wilmin>
-      <wilmax>0</wilmax>
-      <wilaug>0</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <logmin>F+4</logmin>
+      <logmax>F+4</logmax>
+      <logaug>F+4</logaug>
+      <wilmin>F+1</wilmin>
+      <wilmax>F+1</wilmax>
+      <wilaug>F+1</wilaug>
+      <inimin>(F*2)+4</inimin>
+      <inimax>(F*2)+4</inimax>
+      <iniaug>(F*2)+4</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>0</edgmax>
+      <edgaug>0</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
       <resmin>F</resmin>
       <resmax>F</resmax>
       <resaug>F</resaug>
@@ -35016,29 +35169,15 @@
         </enabletab>
       </bonus>
       <powers>
-        <power>Steganography</power>
+        <power>Camouflage</power>
         <power>Watermark</power>
       </powers>
       <skills>
         <skill rating="F">Computer</skill>
-        <skill rating="F">Data Search</skill>
         <skill rating="F">Electronic Warfare</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Browse</complexform>
-        <complexform rating="F">Edit</complexform>
-        <complexform rating="F">Decrypt</complexform>
-      </complexforms>
-      <optionalcomplexforms>
-        <complexform rating="F">Defuse</complexform>
-        <complexform rating="F">Encrypt</complexform>
-        <complexform rating="F">Sniffer</complexform>
-        <complexform rating="F">Stealth</complexform>
-        <complexform rating="F">Linguasoft</complexform>
-      </optionalcomplexforms>
-      <source>DIS</source>
-      <page>242</page>
+      <source>SR5</source>
+      <page>258</page>
     </metatype>
     <metatype>
       <id>72b6f335-4351-4af7-b103-350cb15d2bca</id>
@@ -35058,27 +35197,27 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F+2</intmin>
-      <intmax>F+2</intmax>
-      <intaug>F+2</intaug>
+      <chamin>F+3</chamin>
+      <chamax>F+3</chamax>
+      <chaaug>F+3</chaaug>
+      <intmin>F</intmin>
+      <intmax>F</intmax>
+      <intaug>F</intaug>
       <logmin>F+1</logmin>
       <logmax>F+1</logmax>
       <logaug>F+1</logaug>
-      <wilmin>0</wilmin>
-      <wilmax>0</wilmax>
-      <wilaug>0</wilaug>
-      <inimin>(F*3)</inimin>
-      <inimax>(F*3)</inimax>
-      <iniaug>(F*3)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <wilmin>F+2</wilmin>
+      <wilmax>F+2</wilmax>
+      <wilaug>F+2</wilaug>
+      <inimin>(F*2)+1</inimin>
+      <inimax>(F*2)+1</inimax>
+      <iniaug>(F*2)+1</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>0</edgmax>
+      <edgaug>0</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
       <resmin>F</resmin>
       <resmax>F</resmax>
       <resaug>F</resaug>
@@ -35100,20 +35239,8 @@
         <skill rating="F">Cybercombat</skill>
         <skill rating="F">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Armor</complexform>
-        <complexform rating="F">Attack</complexform>
-        <complexform rating="F">Stealth</complexform>
-      </complexforms>
-      <optionalcomplexforms>
-        <complexform rating="F">Black Hammer</complexform>
-        <complexform rating="F">Blackout</complexform>
-        <complexform rating="F">Exploit</complexform>
-        <complexform rating="F">Medic</complexform>
-      </optionalcomplexforms>
-      <source>DIS</source>
-      <page>242</page>
+      <source>SR5</source>
+      <page>258</page>
     </metatype>
     <metatype>
       <id>1a34d4b2-2055-47e7-b750-39aa724ce19c</id>
@@ -35133,27 +35260,27 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
+      <chamin>F+1</chamin>
+      <chamax>F+1</chamax>
+      <chaaug>F+1</chaaug>
       <intmin>F</intmin>
       <intmax>F</intmax>
       <intaug>F</intaug>
-      <logmin>F+2</logmin>
-      <logmax>F+2</logmax>
-      <logaug>F+2</logaug>
-      <wilmin>0</wilmin>
-      <wilmax>0</wilmax>
-      <wilaug>0</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <logmin>F+3</logmin>
+      <logmax>F+3</logmax>
+      <logaug>F+3</logaug>
+      <wilmin>F+2</wilmin>
+      <wilmax>F+2</wilmax>
+      <wilaug>F+2</wilaug>
+      <inimin>(F*2)+3</inimin>
+      <inimax>(F*2)+3</inimax>
+      <iniaug>(F*2)+3</iniaug>
+      <edgmin>0</edgmin>
+      <edgmax>0</edgmax>
+      <edgaug>0</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
       <resmin>F</resmin>
       <resmax>F</resmax>
       <resaug>F</resaug>
@@ -35169,7 +35296,7 @@
       </bonus>
       <powers>
         <power>Diagnostics</power>
-        <power>Gremlins</power>
+        <power>Gremlins (Sprite)</power>
         <power>Stability</power>
       </powers>
       <skills>
@@ -35177,18 +35304,8 @@
         <skill rating="F">Electronic Warfare</skill>
         <skill rating="F">Hardware</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Command</complexform>
-      </complexforms>
-      <optionalcomplexforms>
-        <complexform rating="F">Decrypt</complexform>
-        <complexform rating="F">Edit</complexform>
-        <complexform rating="F">Medic</complexform>
-        <complexform rating="F" category="Autosoft" />
-      </optionalcomplexforms>
-      <source>DIS</source>
-      <page>242</page>
+      <source>SR5</source>
+      <page>258</page>
     </metatype>
     <metatype>
       <id>14c73902-04f5-4638-81b1-c7d8cbe1df7e</id>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -112,34 +112,34 @@
 			<name>Bear</name>
 			<category>Mundane Critters</category>
 			<karma>0</karma>
-			<bodmin>6</bodmin>
+			<bodmin>9</bodmin>
 			<bodmax>12</bodmax>
 			<bodaug>16</bodaug>
-			<agimin>1</agimin>
+			<agimin>4</agimin>
 			<agimax>7</agimax>
 			<agiaug>11</agiaug>
-			<reamin>2</reamin>
+			<reamin>5</reamin>
 			<reamax>8</reamax>
 			<reaaug>12</reaaug>
-			<strmin>5</strmin>
+			<strmin>8</strmin>
 			<strmax>11</strmax>
 			<straug>15</straug>
-			<chamin>0</chamin>
+			<chamin>3</chamin>
 			<chamax>6</chamax>
 			<chaaug>10</chaaug>
-			<intmin>0</intmin>
+			<intmin>2</intmin>
 			<intmax>5</intmax>
 			<intaug>9</intaug>
-			<logmin>0</logmin>
+			<logmin>1</logmin>
 			<logmax>4</logmax>
 			<logaug>8</logaug>
-			<wilmin>1</wilmin>
+			<wilmin>4</wilmin>
 			<wilmax>7</wilmax>
 			<wilaug>11</wilaug>
-			<inimin>1</inimin>
+			<inimin>7</inimin>
 			<inimax>13</inimax>
 			<iniaug>21</iniaug>
-			<edgmin>0</edgmin>
+			<edgmin>3</edgmin>
 			<edgmax>6</edgmax>
 			<edgaug>6</edgaug>
 			<magmin>0</magmin>
@@ -1027,34 +1027,34 @@
       <name>Dog</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
+      <bodmin>4</bodmin>
       <bodmax>7</bodmax>
       <bodaug>11</bodaug>
-      <agimin>0</agimin>
+      <agimin>3</agimin>
       <agimax>6</agimax>
       <agiaug>10</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>1</strmin>
+      <strmin>4</strmin>
       <strmax>7</strmax>
       <straug>11</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>2</inimin>
+      <inimin>8</inimin>
       <inimax>14</inimax>
       <iniaug>22</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -1098,34 +1098,34 @@
       <name>Great Cat</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
+      <bodmin>6</bodmin>
       <bodmax>9</bodmax>
       <bodaug>13</bodaug>
-      <agimin>2</agimin>
+      <agimin>5</agimin>
       <agimax>8</agimax>
       <agiaug>12</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>2</strmin>
+      <strmin>5</strmin>
       <strmax>8</strmax>
       <straug>12</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>0</intmin>
+      <intmin>3</intmin>
       <intmax>6</intmax>
       <intaug>10</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>2</inimin>
+      <inimin>8</inimin>
       <inimax>14</inimax>
       <iniaug>22</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -1168,34 +1168,34 @@
       <name>Horse</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
+      <bodmin>8</bodmin>
       <bodmax>11</bodmax>
       <bodaug>15</bodaug>
-      <agimin>2</agimin>
+      <agimin>5</agimin>
       <agimax>8</agimax>
       <agiaug>12</agiaug>
-      <reamin>2</reamin>
+      <reamin>5</reamin>
       <reamax>8</reamax>
       <reaaug>12</reaaug>
-      <strmin>5</strmin>
+      <strmin>8</strmin>
       <strmax>11</strmax>
       <straug>15</straug>
-      <chamin>1</chamin>
+      <chamin>4</chamin>
       <chamax>7</chamax>
       <chaaug>11</chaaug>
-      <intmin>0</intmin>
+      <intmin>3</intmin>
       <intmax>6</intmax>
       <intaug>10</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>2</inimin>
+      <inimin>8</inimin>
       <inimax>14</inimax>
       <iniaug>22</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -1234,34 +1234,34 @@
       <name>Shark</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
+      <bodmin>5</bodmin>
       <bodmax>8</bodmax>
       <bodaug>12</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>2</reamin>
+      <reamin>5</reamin>
       <reamax>8</reamax>
       <reaaug>12</reaaug>
-      <strmin>2</strmin>
+      <strmin>5</strmin>
       <strmax>8</strmax>
       <straug>12</straug>
-      <chamin>0</chamin>
+      <chamin>1</chamin>
       <chamax>4</chamax>
       <chaaug>8</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>3</inimin>
+      <inimin>9</inimin>
       <inimax>15</inimax>
       <iniaug>23</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -1302,34 +1302,34 @@
       <name>Wolf</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
+      <bodmin>6</bodmin>
       <bodmax>9</bodmax>
       <bodaug>13</bodaug>
-      <agimin>0</agimin>
+      <agimin>3</agimin>
       <agimax>6</agimax>
       <agiaug>10</agiaug>
-      <reamin>2</reamin>
+      <reamin>5</reamin>
       <reamax>8</reamax>
       <reaaug>12</reaaug>
-      <strmin>2</strmin>
+      <strmin>5</strmin>
       <strmax>8</strmax>
       <straug>12</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>3</inimin>
+      <inimin>9</inimin>
       <inimax>15</inimax>
       <iniaug>23</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -1437,34 +1437,34 @@
       <name>Squid</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
+      <bodmin>4</bodmin>
       <bodmax>7</bodmax>
       <bodaug>11</bodaug>
-      <agimin>2</agimin>
+      <agimin>5</agimin>
       <agimax>8</agimax>
       <agiaug>12</agiaug>
-      <reamin>0</reamin>
+      <reamin>3</reamin>
       <reamax>6</reamax>
       <reaaug>10</reaaug>
-      <strmin>2</strmin>
+      <strmin>5</strmin>
       <strmax>8</strmax>
       <straug>12</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>1</inimin>
+      <inimin>7</inimin>
       <inimax>13</inimax>
       <iniaug>21</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -1755,34 +1755,34 @@
       <name>Dolphin</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
+      <bodmin>8</bodmin>
       <bodmax>11</bodmax>
       <bodaug>15</bodaug>
-      <agimin>2</agimin>
+      <agimin>5</agimin>
       <agimax>8</agimax>
       <agiaug>12</agiaug>
-      <reamin>2</reamin>
+      <reamin>5</reamin>
       <reamax>8</reamax>
       <reaaug>12</reaaug>
-      <strmin>4</strmin>
+      <strmin>7</strmin>
       <strmax>10</strmax>
       <straug>14</straug>
-      <chamin>1</chamin>
+      <chamin>4</chamin>
       <chamax>7</chamax>
       <chaaug>11</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>1</wilmin>
+      <wilmin>4</wilmin>
       <wilmax>7</wilmax>
       <wilaug>11</wilaug>
-      <inimin>3</inimin>
+      <inimin>9</inimin>
       <inimax>15</inimax>
       <iniaug>23</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -2522,34 +2522,34 @@
       <name>Sea Lion</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>4</bodmin>
+      <bodmin>7</bodmin>
       <bodmax>10</bodmax>
       <bodaug>14</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>2</strmin>
+      <strmin>5</strmin>
       <strmax>8</strmax>
       <straug>12</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>2</inimin>
+      <inimin>8</inimin>
       <inimax>14</inimax>
       <iniaug>22</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -2846,34 +2846,34 @@
       <name>Barracuda</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>2</bodmin>
       <bodmax>5</bodmax>
       <bodaug>9</bodaug>
-      <agimin>0</agimin>
+      <agimin>2</agimin>
       <agimax>5</agimax>
       <agiaug>9</agiaug>
-      <reamin>0</reamin>
+      <reamin>3</reamin>
       <reamax>6</reamax>
       <reaaug>10</reaaug>
-      <strmin>0</strmin>
+      <strmin>2</strmin>
       <strmax>5</strmax>
       <straug>9</straug>
-      <chamin>0</chamin>
+      <chamin>1</chamin>
       <chamax>4</chamax>
       <chaaug>8</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
       <logmin>0</logmin>
       <logmax>3</logmax>
       <logaug>7</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>0</inimin>
+      <inimin>5</inimin>
       <inimax>11</inimax>
       <iniaug>19</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -3291,34 +3291,34 @@
       <name>Killer Whale</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>9</bodmin>
+      <bodmin>12</bodmin>
       <bodmax>15</bodmax>
       <bodaug>19</bodaug>
-      <agimin>3</agimin>
+      <agimin>6</agimin>
       <agimax>9</agimax>
       <agiaug>13</agiaug>
-      <reamin>3</reamin>
+      <reamin>6</reamin>
       <reamax>9</reamax>
       <reaaug>13</reaaug>
-      <strmin>10</strmin>
+      <strmin>13</strmin>
       <strmax>16</strmax>
       <straug>20</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>2</intmin>
+      <intmin>5</intmin>
       <intmax>8</intmax>
       <intaug>12</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>5</wilmin>
+      <wilmin>8</wilmin>
       <wilmax>11</wilmax>
       <wilaug>15</wilaug>
-      <inimin>5</inimin>
+      <inimin>11</inimin>
       <inimax>17</inimax>
       <iniaug>25</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -3599,34 +3599,34 @@
       <name>Alligator</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
+      <bodmin>8</bodmin>
       <bodmax>11</bodmax>
       <bodaug>15</bodaug>
-      <agimin>2</agimin>
+      <agimin>5</agimin>
       <agimax>8</agimax>
       <agiaug>12</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>6</strmin>
+      <strmin>9</strmin>
       <strmax>12</strmax>
       <straug>16</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>1</wilmin>
       <wilmax>4</wilmax>
       <wilaug>8</wilaug>
-      <inimin>0</inimin>
+      <inimin>6</inimin>
       <inimax>12</inimax>
       <iniaug>20</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -3927,34 +3927,34 @@
       <name>Boar</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
+      <bodmin>6</bodmin>
       <bodmax>9</bodmax>
       <bodaug>13</bodaug>
-      <agimin>0</agimin>
+      <agimin>2</agimin>
       <agimax>5</agimax>
       <agiaug>9</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>2</strmin>
+      <strmin>5</strmin>
       <strmax>8</strmax>
       <straug>12</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>0</inimin>
+      <inimin>6</inimin>
       <inimax>12</inimax>
       <iniaug>20</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -5252,34 +5252,34 @@
       <name>Rat</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>1</bodmin>
       <bodmax>4</bodmax>
       <bodaug>8</bodaug>
-      <agimin>0</agimin>
+      <agimin>3</agimin>
       <agimax>6</agimax>
       <agiaug>10</agiaug>
-      <reamin>0</reamin>
+      <reamin>2</reamin>
       <reamax>5</reamax>
       <reaaug>9</reaaug>
       <strmin>0</strmin>
       <strmax>3</strmax>
       <straug>7</straug>
-      <chamin>0</chamin>
+      <chamin>1</chamin>
       <chamax>4</chamax>
       <chaaug>8</chaaug>
-      <intmin>0</intmin>
+      <intmin>1</intmin>
       <intmax>4</intmax>
       <intaug>8</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>1</wilmin>
       <wilmax>4</wilmax>
       <wilaug>8</wilaug>
-      <inimin>0</inimin>
+      <inimin>3</inimin>
       <inimax>9</inimax>
       <iniaug>17</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -6331,34 +6331,34 @@
       <name>Elephant</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>9</bodmin>
+      <bodmin>12</bodmin>
       <bodmax>15</bodmax>
       <bodaug>19</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>13</strmin>
+      <strmin>16</strmin>
       <strmax>19</strmax>
       <straug>23</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>0</intmin>
+      <intmin>3</intmin>
       <intmax>6</intmax>
       <intaug>10</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>1</inimin>
+      <inimin>7</inimin>
       <inimax>13</inimax>
       <iniaug>21</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -6401,34 +6401,34 @@
       <name>Giraffe</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>7</bodmin>
+      <bodmin>10</bodmin>
       <bodmax>13</bodmax>
       <bodaug>17</bodaug>
-      <agimin>0</agimin>
+      <agimin>3</agimin>
       <agimax>6</agimax>
       <agiaug>10</agiaug>
-      <reamin>0</reamin>
+      <reamin>3</reamin>
       <reamax>6</reamax>
       <reaaug>10</reaaug>
-      <strmin>5</strmin>
+      <strmin>8</strmin>
       <strmax>11</strmax>
       <straug>15</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>0</inimin>
+      <inimin>5</inimin>
       <inimax>11</inimax>
       <iniaug>19</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -7189,34 +7189,34 @@
       <name>Chimpanzee</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
+      <bodmin>4</bodmin>
       <bodmax>7</bodmax>
       <bodaug>11</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>1</strmin>
+      <strmin>4</strmin>
       <strmax>7</strmax>
       <straug>11</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>2</inimin>
+      <inimin>8</inimin>
       <inimax>14</inimax>
       <iniaug>22</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -9480,34 +9480,34 @@
       <name>Domestic Cat</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>2</bodmin>
       <bodmax>5</bodmax>
       <bodaug>9</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>0</reamin>
+      <reamin>3</reamin>
       <reamax>6</reamax>
       <reaaug>10</reaaug>
-      <strmin>0</strmin>
+      <strmin>1</strmin>
       <strmax>4</strmax>
       <straug>8</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
-      <logmin>0</logmin>
+      <logmin>2</logmin>
       <logmax>5</logmax>
       <logaug>9</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>0</inimin>
+      <inimin>5</inimin>
       <inimax>11</inimax>
       <iniaug>19</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -9613,34 +9613,34 @@
       <name>Ferret</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>1</bodmin>
       <bodmax>4</bodmax>
       <bodaug>8</bodaug>
-      <agimin>0</agimin>
+      <agimin>2</agimin>
       <agimax>5</agimax>
       <agiaug>9</agiaug>
-      <reamin>0</reamin>
+      <reamin>2</reamin>
       <reamax>5</reamax>
       <reaaug>9</reaaug>
-      <strmin>0</strmin>
+      <strmin>1</strmin>
       <strmax>4</strmax>
       <straug>8</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>0</inimin>
+      <inimin>4</inimin>
       <inimax>10</inimax>
       <iniaug>18</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -9937,34 +9937,34 @@
       <name>Raccoon</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>1</bodmin>
       <bodmax>4</bodmax>
       <bodaug>8</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>0</reamin>
+      <reamin>3</reamin>
       <reamax>6</reamax>
       <reaaug>10</reaaug>
-      <strmin>0</strmin>
+      <strmin>1</strmin>
       <strmax>4</strmax>
       <straug>8</straug>
-      <chamin>0</chamin>
+      <chamin>2</chamin>
       <chamax>5</chamax>
       <chaaug>9</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>1</inimin>
+      <inimin>7</inimin>
       <inimax>13</inimax>
       <iniaug>21</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -10311,34 +10311,34 @@
       <name>Snake</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>2</bodmin>
       <bodmax>5</bodmax>
       <bodaug>9</bodaug>
-      <agimin>1</agimin>
+      <agimin>4</agimin>
       <agimax>7</agimax>
       <agiaug>11</agiaug>
-      <reamin>0</reamin>
+      <reamin>2</reamin>
       <reamax>5</reamax>
       <reaaug>9</reaaug>
-      <strmin>0</strmin>
+      <strmin>3</strmin>
       <strmax>6</strmax>
       <straug>10</straug>
-      <chamin>0</chamin>
+      <chamin>1</chamin>
       <chamax>4</chamax>
       <chaaug>8</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
       <logmin>0</logmin>
       <logmax>3</logmax>
       <logaug>7</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>0</inimin>
+      <inimin>4</inimin>
       <inimax>10</inimax>
       <iniaug>18</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -10740,13 +10740,13 @@
       <name>Cockroach</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>1</bodmin>
       <bodmax>4</bodmax>
       <bodaug>8</bodaug>
-      <agimin>0</agimin>
+      <agimin>2</agimin>
       <agimax>5</agimax>
       <agiaug>9</agiaug>
-      <reamin>2</reamin>
+      <reamin>5</reamin>
       <reamax>8</reamax>
       <reaaug>12</reaaug>
       <strmin>0</strmin>
@@ -10755,19 +10755,19 @@
       <chamin>0</chamin>
       <chamax>3</chamax>
       <chaaug>7</chaaug>
-      <intmin>0</intmin>
+      <intmin>2</intmin>
       <intmax>5</intmax>
       <intaug>9</intaug>
       <logmin>0</logmin>
       <logmax>3</logmax>
       <logaug>7</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>1</inimin>
+      <inimin>7</inimin>
       <inimax>13</inimax>
       <iniaug>21</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -11259,34 +11259,34 @@
       <name>Spider</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>1</bodmin>
       <bodmax>4</bodmax>
       <bodaug>8</bodaug>
-      <agimin>0</agimin>
+      <agimin>2</agimin>
       <agimax>5</agimax>
       <agiaug>9</agiaug>
-      <reamin>0</reamin>
+      <reamin>2</reamin>
       <reamax>5</reamax>
       <reaaug>9</reaaug>
       <strmin>0</strmin>
       <strmax>3</strmax>
       <straug>7</straug>
-      <chamin>0</chamin>
+      <chamin>1</chamin>
       <chamax>4</chamax>
       <chaaug>8</chaaug>
-      <intmin>0</intmin>
+      <intmin>1</intmin>
       <intmax>4</intmax>
       <intaug>8</intaug>
       <logmin>0</logmin>
       <logmax>3</logmax>
       <logaug>7</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>1</wilmin>
       <wilmax>4</wilmax>
       <wilaug>8</wilaug>
-      <inimin>0</inimin>
+      <inimin>3</inimin>
       <inimax>9</inimax>
       <iniaug>17</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>3</edgmin>
       <edgmax>6</edgmax>
       <edgaug>6</edgaug>
       <magmin>0</magmin>
@@ -12088,34 +12088,34 @@
       <name>Crow</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>2</bodmin>
       <bodmax>5</bodmax>
       <bodaug>9</bodaug>
-      <agimin>0</agimin>
+      <agimin>3</agimin>
       <agimax>6</agimax>
       <agiaug>10</agiaug>
-      <reamin>0</reamin>
+      <reamin>2</reamin>
       <reamax>5</reamax>
       <reaaug>9</reaaug>
-      <strmin>0</strmin>
+      <strmin>1</strmin>
       <strmax>4</strmax>
       <straug>8</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>2</intmin>
+      <intmin>5</intmin>
       <intmax>8</intmax>
       <intaug>12</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>2</wilmin>
       <wilmax>5</wilmax>
       <wilaug>9</wilaug>
-      <inimin>1</inimin>
+      <inimin>7</inimin>
       <inimax>13</inimax>
       <iniaug>21</iniaug>
-      <edgmin>0</edgmin>
+      <edgmin>2</edgmin>
       <edgmax>5</edgmax>
       <edgaug>5</edgaug>
       <magmin>0</magmin>
@@ -12831,34 +12831,34 @@
       <name>Eagle</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>0</bodmin>
+      <bodmin>3</bodmin>
       <bodmax>6</bodmax>
       <bodaug>10</bodaug>
-      <agimin>2</agimin>
+      <agimin>5</agimin>
       <agimax>8</agimax>
       <agiaug>12</agiaug>
-      <reamin>1</reamin>
+      <reamin>4</reamin>
       <reamax>7</reamax>
       <reaaug>11</reaaug>
-      <strmin>0</strmin>
+      <strmin>2</strmin>
       <strmax>5</strmax>
       <straug>9</straug>
-      <chamin>0</chamin>
+      <chamin>3</chamin>
       <chamax>6</chamax>
       <chaaug>10</chaaug>
-      <intmin>1</intmin>
+      <intmin>4</intmin>
       <intmax>7</intmax>
       <intaug>11</intaug>
-      <logmin>0</logmin>
+      <logmin>1</logmin>
       <logmax>4</logmax>
       <logaug>8</logaug>
-      <wilmin>0</wilmin>
+      <wilmin>3</wilmin>
       <wilmax>6</wilmax>
       <wilaug>10</wilaug>
-      <inimin>2</inimin>
+      <inimin>8</inimin>
       <inimax>14</inimax>
       <iniaug>22</iniaug>
-      <edgmin>1</edgmin>
+      <edgmin>4</edgmin>
       <edgmax>7</edgmax>
       <edgaug>7</edgaug>
       <magmin>0</magmin>
@@ -36924,584 +36924,918 @@
       <id>3061956f-c87e-4588-abbb-9b9968917e53</id>
       <name>Ahi</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
+      <bodmin>2</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
       <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>1</reamin>
-      <reamax>1</reamax>
-      <reaaug>1</reaaug>
-      <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>2</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
+      <strmin>3</strmin>
+      <strmax>6</strmax>
+      <straug>10</straug>
       <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
       <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
-      <inimin>2</inimin>
-      <inimax>13</inimax>
-      <iniaug>13</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>0</logmin>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>5</inimin>
+      <inimax>11</inimax>
+      <iniaug>19</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>4</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>5/10</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>2/1/0</walk>
+	  <run>3/0/0</run>
+	  <sprint>2/1/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Hardening</power>
-        <power select="Defragmentation">Technovantage [Echo]</power>
-        <power>Venomous Code</power>
-      </powers>
+		<power select="Bite: DV (STR+2)P, AP 0">Natural Weapon</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power rating="3">Armor</power>
+		<power>AR-Parallelism</power>
+		<power>Resonance Feed</power>
+		<power>Venomous Code</power>
+	  </powers>
+	  <optionalpowers>
+		<optionalpower>Venom</optionalpower>
+	  </optionalpowers>
       <skills>
-        <skill rating="2">Computer</skill>
-        <skill rating="5">Cybercombat</skill>
-        <skill rating="4">Hacking</skill>
+        <skill rating="3">Perception</skill>
+		<skill rating="3">Gymnastics</skill>
+		<skill rating="3">Sneaking</skill>
+		<skill rating="3">Tracking</skill>
+        <skill rating="5">Unarmed Combat</skill>
+		<skill rating="2">Computer</skill>
+		<skill rating="7">Cybercombat</skill>
+		<skill rating="5">Hacking</skill>
         <skill rating="1">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="2">Analyze</complexform>
-        <complexform rating="5">Armor</complexform>
-        <complexform rating="4">Attack</complexform>
-        <complexform rating="2">Corrupt</complexform>
-        <complexform rating="3">Exploit</complexform>
-        <complexform rating="3">Nuke</complexform>
-        <complexform rating="5">Stealth</complexform>
+        <complexform select="Firewall">Diffusion of [Matrix Attribute]</complexform>
+		<complexform select="Attack">Infusion of [Matrix Attribute]</complexform>
+        <complexform>Resonance Spike</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>190</page>
+      <source>HS</source>
+      <page>145</page>
     </metatype>
     <metatype>
       <id>634f4b85-5f11-4069-9479-08512772451d</id>
-      <name>Bastet</name>
+      <name>Bastet (Domestic Cat)</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
+      <bodmin>2</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
+      <agimin>4</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
       <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
       <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
+      <strmax>4</strmax>
+      <straug>8</straug>
       <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
       <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>7</inimin>
+      <inimax>13</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>5</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>10/40</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Resonant Conditioning</power>
-        <power>Resonance Bond</power>
-        <power>Suppression</power>
-        <power select="Flexible Touch">Technovantage [Echo]</power>
+        <power rating="2">Fragile</power>
+		<power>Domesticated</power>
+		<power select="Low-light Vision">Enhanced Senses</power>
+		<power>AR-Parallelism</power>
+		<power>Blend</power>
+		<power>Holographic Concealment</power>
+		<power>Spraying</power>
       </powers>
       <skills>
-        <skill rating="3">Computer</skill>
-        <skill rating="3">Cybercombat</skill>
-        <skill rating="3">Hacking</skill>
-        <skill rating="3">Software</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="2">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="3">Tracking</skill>
+        <skill rating="3">Unarmed Combat</skill>
+		<skill rating="4">Computer</skill>
+        <skill rating="4">Cybercombat</skill>
+        <skill rating="4">Hacking</skill>
+        <skill rating="4">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="4">Analyze</complexform>
-        <complexform rating="4">Blackout</complexform>
-        <complexform rating="3">Corrupt</complexform>
-        <complexform rating="5">Exploit</complexform>
-        <complexform rating="3">Spoof</complexform>
-        <complexform rating="5">Stealth</complexform>
+        <complexform>Derezz</complexform>
+		<complexform select="Attack">Diffusion of [Matrix Attribute]</complexform>
+		<complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>191</page>
+      <source>HS</source>
+      <page>145</page>
+    </metatype>
+	<metatype>
+      <id>e68c9e4b-0a58-42ae-90da-c177fc1135c1</id>
+      <name>Bastet (Great Cat)</name>
+      <category>Technocritters</category>
+      <karma>0</karma>
+      <bodmin>6</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>13</bodaug>
+      <agimin>5</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>4</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>5</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>3</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>9</inimin>
+      <inimax>15</inimax>
+      <iniaug>23</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>0</magmin>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>5</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
+      <bonus>
+        <enabletab>
+          <name>critter</name>
+		  <name>technomancer</name>
+        </enabletab>
+        <initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+        <power select="Claws/Bite: DV (STR+3)P, AP -1">Natural Weapon</power>
+		<power select="Low-light Vision">Enhanced Senses</power>
+		<power>AR-Parallelism</power>
+		<power>Blend</power>
+		<power>Holographic Concealment</power>
+		<power>Spraying</power>
+      </powers>
+      <skills>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Perception</skill>
+		<skill rating="5">Running</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="7">Unarmed Combat</skill>
+		<skill rating="4">Computer</skill>
+        <skill rating="4">Cybercombat</skill>
+        <skill rating="4">Hacking</skill>
+        <skill rating="4">Software</skill>
+      </skills>
+      <complexforms>
+        <complexform>Derezz</complexform>
+		<complexform select="Attack">Diffusion of [Matrix Attribute]</complexform>
+		<complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
+      </complexforms>
+      <source>HS</source>
+      <page>145</page>
     </metatype>
     <metatype>
       <id>9903a854-2785-4adb-bf0d-e74292d3ba05</id>
-      <name>Digit</name>
+      <name>Digit (Cockroach)</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
-      <bodmin>0</bodmin>
-      <bodmax>0</bodmax>
-      <bodaug>0</bodaug>
-      <agimin>1</agimin>
-      <agimax>1</agimax>
-      <agiaug>1</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <bodmin>1</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>2</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>5</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
+      <strmax>3</strmax>
+      <straug>7</straug>
+      <chamin>0</chamin>
+      <chamax>3</chamax>
+      <chaaug>7</chaaug>
       <intmin>2</intmin>
-      <intmax>2</intmax>
-      <intaug>2</intaug>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
       <logmin>0</logmin>
-      <logmax>0</logmax>
-      <logaug>0</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>8</inimax>
-      <iniaug>8</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>7</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>2</resmin>
+      <resmax>5</resmax>
+      <resaug>5</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>2/5</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
+        <reach>-1</reach>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>E-Hive</power>
-        <power>Gremlins</power>
-        <power select="Living ECM">Technovantage [Echo]</power>
+        <power>Gestalt Consciousness</power>
+        <power>Wall Walking</power>
+		<power>Extra Fragile</power>
+		<power>AR-Parallelism</power>
+		<power>E-Hive</power>
+		<power>Gremlins</power>
       </powers>
       <skills>
-        <skill rating="3">Computer</skill>
-        <skill rating="4">Electronic Warfare</skill>
-        <skill rating="2">Hacking</skill>
-        <skill rating="3">Software</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="2">Perception</skill>
+		<skill rating="3">Computer</skill>
+		<skill rating="3">Electronic Warfare</skill>
+		<skill rating="3">Hacking</skill>
+		<skill rating="2">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="3">Analyze</complexform>
-        <complexform rating="2">Armor</complexform>
-        <complexform rating="2">Command</complexform>
-        <complexform rating="3">Exploit</complexform>
-        <complexform rating="3">ECCM</complexform>
-        <complexform rating="2">Edit</complexform>
-        <complexform rating="3">Scan</complexform>
-        <complexform rating="3">Spoof</complexform>
-        <complexform rating="3">Stealth</complexform>
+        <complexform>Editor</complexform>
+        <complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
+		<complexform>Pulse Storm</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>191</page>
+      <source>HS</source>
+      <page>146</page>
+    </metatype>
+	<metatype>
+      <id>1da88592-fe55-46e3-b0e4-58b84dffc5f9</id>
+      <name>Digit (Spider)</name>
+      <category>Technocritters</category>
+      <karma>0</karma>
+      <bodmin>1</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>2</agimin>
+      <agimax>5</agimax>
+      <agiaug>9</agiaug>
+      <reamin>2</reamin>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
+      <strmin>0</strmin>
+      <strmax>3</strmax>
+      <straug>7</straug>
+      <chamin>2</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>2</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>0</logmin>
+      <logmax>3</logmax>
+      <logaug>7</logaug>
+      <wilmin>1</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>8</wilaug>
+      <inimin>4</inimin>
+      <inimax>10</inimax>
+      <iniaug>18</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>0</magmin>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>2</resmin>
+      <resmax>5</resmax>
+      <resaug>5</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/0/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/0/0</sprint>
+      <bonus>
+        <enabletab>
+          <name>critter</name>
+		  <name>technomancer</name>
+        </enabletab>
+        <reach>-1</reach>
+		<initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+        <power>Gestalt Consciousness</power>
+        <power>Wall Walking</power>
+		<power rating="1">Fragile</power>
+		<power>AR-Parallelism</power>
+		<power>E-Hive</power>
+		<power>Gremlins</power>
+      </powers>
+      <skills>
+        <skill rating="4">Gymnastics</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+		<skill rating="3">Computer</skill>
+		<skill rating="3">Electronic Warfare</skill>
+		<skill rating="3">Hacking</skill>
+		<skill rating="2">Software</skill>
+      </skills>
+      <complexforms>
+        <complexform>Editor</complexform>
+        <complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
+		<complexform>Pulse Storm</complexform>
+      </complexforms>
+      <source>HS</source>
+      <page>146</page>
     </metatype>
     <metatype>
       <id>c8f5522b-f482-4636-b592-f7a860a375a7</id>
       <name>Flipper</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>8</bodmin>
-      <bodmax>8</bodmax>
-      <bodaug>8</bodaug>
+      <bodmax>11</bodmax>
+      <bodaug>15</bodaug>
       <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
       <reamin>5</reamin>
-      <reamax>5</reamax>
-      <reaaug>5</reaaug>
-      <strmin>8</strmin>
-      <strmax>8</strmax>
-      <straug>8</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>4</logmin>
-      <logmax>4</logmax>
-      <logaug>4</logaug>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
+      <strmin>7</strmin>
+      <strmax>10</strmax>
+      <straug>14</straug>
+      <chamin>4</chamin>
+      <chamax>7</chamax>
+      <chaaug>11</chaaug>
+      <intmin>5</intmin>
+      <intmax>8</intmax>
+      <intaug>12</intaug>
+      <logmin>3</logmin>
+      <logmax>6</logmax>
+      <logaug>10</logaug>
       <wilmin>4</wilmin>
-      <wilmax>4</wilmax>
-      <wilaug>4</wilaug>
-      <inimin>3</inimin>
-      <inimax>15</inimax>
-      <iniaug>15</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <wilmax>7</wilmax>
+      <wilaug>11</wilaug>
+      <inimin>10</inimin>
+      <inimax>16</inimax>
+      <iniaug>24</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>5</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>Swim 20/80</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>0/2/0</walk>
+	  <run>0/8/0</run>
+	  <sprint>0/4/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Blend</power>
-        <power>Tunnel</power>
-        <power select="Overclocking">Technovantage [Echo]</power>
+        <power select="Sonar">Enhanced Senses</power>
+		<power rating="2">Armor</power>
+		<power>AR-Parallelism</power>
+		<power>Cozenge</power>
+		<power>Gremlins</power>
+		<power>Tunnel</power>
       </powers>
       <skills>
-        <skill rating="3">Computer</skill>
-        <skill rating="4">Cybercombat</skill>
-        <skill rating="3">Hacking</skill>
-        <skill rating="2">Software</skill>
+        <skill rating="3">Diving</skill>
+        <skill rating="7">Gymnastics</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="5">Swimming</skill>
+        <skill rating="3">Unarmed Combat</skill>
+		<skill rating="4">Computer</skill>
+        <skill rating="5">Cybercombat</skill>
+        <skill rating="2">Electronic Warfare</skill>
+        <skill rating="5">Hacking</skill>
+		<skill rating="3">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="3">Analyze</complexform>
-        <complexform rating="3">Armor</complexform>
-        <complexform rating="4">Attack</complexform>
-        <complexform rating="1">Browse</complexform>
-        <complexform rating="2">Command</complexform>
-        <complexform rating="3">Disarm</complexform>
-        <complexform rating="3">Shield</complexform>
-        <complexform rating="5">Stealth</complexform>
+        <complexform select="Firewall">Diffusion of [Matrix Attribute]</complexform>
+		<complexform>Editor</complexform>
+		<complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
+		<complexform>Tattletale</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>192</page>
+      <source>HS</source>
+      <page>147</page>
+    </metatype>
+	<metatype>
+      <id>0a46c8c6-f739-45bd-b327-d62f0e6f60b1</id>
+      <name>Furfur</name>
+      <category>Technocritters</category>
+      <karma>0</karma>
+      <bodmin>5</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>12</bodaug>
+      <agimin>4</agimin>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
+      <reamin>5</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
+      <strmin>4</strmin>
+      <strmax>7</strmax>
+      <straug>11</straug>
+      <chamin>3</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>3</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>8</inimin>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
+      <magmin>0</magmin>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>4</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+      <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>6/1/0</sprint>
+      <bonus>
+        <enabletab>
+          <name>critter</name>
+		  <name>technomancer</name>
+        </enabletab>
+      </bonus>
+      <powers>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Antlers: DV (STR+1)P, AP -1">Natural Weapons</power>
+		<power rating="2">Armor</power>
+		<power>AR-Parallelism</power>
+		<power>Resonance Feed</power>
+		<power>Blend</power>
+      </powers>
+      <skills>
+        <skill rating="4">Running</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Tracking</skill>
+        <skill rating="3">Unarmed Combat</skill>
+		<skill rating="4">Computer</skill>
+        <skill rating="5">Cybercombat</skill>
+        <skill rating="3">Electronic Warfare</skill>
+		<skill rating="2">Software</skill>
+      </skills>
+      <complexforms>
+		<complexform select="Attack">Infusion of [Matrix Attribute]</complexform>
+		<complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
+		<complexform>Pulse Storm</complexform>
+      </complexforms>
+      <source>HS</source>
+      <page>147</page>
     </metatype>
     <metatype>
       <id>1d8f850a-612a-4ab2-9e84-7c905dbbab47</id>
       <name>Libertine</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
       <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
+      <agimax>7</agimax>
+      <agiaug>11</agiaug>
       <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <reamax>6</reamax>
+      <reaaug>10</reaaug>
       <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
+      <strmax>4</strmax>
+      <straug>8</straug>
+      <chamin>2</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>7</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
       <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>3</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>8/20</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
+        <reach>-1</reach>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Suppression</power>
-        <power select="Skinlink">Technovantage [Echo]</power>
-        <power select="Swap, Rating 2">Technovantage [Echo]</power>
+        <power select="Touch">Enhanced Senses</power>
+        <power rating="1">Fragile</power>
+		<power>AR-Parallelism</power>
+		<power>Blend</power>
+		<power>Gremlins</power>
+		<power>Tunnel</power>
       </powers>
       <skills>
-        <skill rating="3">Computer</skill>
-        <skill rating="4">Hacking</skill>
-        <skill rating="5">Software</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="3">Sneaking</skill>
+		<skill rating="3">Palming</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Unarmed Combat</skill>
+		<skill rating="3">Computer</skill>
+		<skill rating="5">Hacking</skill>
+        <skill rating="7">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="3">Analyze</complexform>
-        <complexform rating="2">Command</complexform>
-        <complexform rating="2">Data Bomb</complexform>
-        <complexform rating="4">Exploit</complexform>
-        <complexform rating="3">Sniffer</complexform>
-        <complexform rating="5">Spoof</complexform>
-        <complexform rating="5">Stealth</complexform>
+        <complexform select="Data Processing">Diffusion of [Matrix Attribute]</complexform>
+		<complexform>Editor</complexform>
+		<complexform>Static Bomb</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>192</page>
+      <source>HS</source>
+      <page>148</page>
     </metatype>
     <metatype>
       <id>08f2a1f3-23a0-4b31-96cc-c960c8d9a6fd</id>
-      <name>Mongrel</name>
+      <name>Mongrel (Dog)</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
+      <bodmin>4</bodmin>
+      <bodmax>7</bodmax>
+      <bodaug>11</bodaug>
       <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>4</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>4</strmin>
+      <strmax>7</strmax>
+      <straug>11</straug>
       <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
       <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>8</inimin>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>3</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>10/45</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Spraying</power>
-        <power select="E-Sensing">Technovantage [Echo]</power>
-        <power select="Sift">Technovantage [Echo]</power>
-        <power>Traceroute</power>
+		<power>Domesticated</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Hearing">Enhanced Senses</power>
+        <power select="Claws/Bite: DV (STR+1)P, AP 0">Natural Weapon</power>
+		<power>Resonance Feed</power>
       </powers>
       <skills>
-        <skill rating="2">Computer</skill>
-        <skill rating="5">Data Search</skill>
-        <skill rating="4">Electronic Warfare</skill>
-        <skill rating="2">Software</skill>
+        <skill rating="4">Intimidation</skill>
+        <skill rating="5" spec="Smell">Perception</skill>
+		<skill rating="5">Running</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="5">Unarmed Combat</skill>
+		<skill rating="7">Computer</skill>
+        <skill rating="5">Electronic Warfare</skill>
+        <skill rating="3">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="4">Analyze</complexform>
-        <complexform rating="5">Browse</complexform>
-        <complexform rating="2">Edit</complexform>
-        <complexform rating="5">Scan</complexform>
-        <complexform rating="3">Sniffer</complexform>
-        <complexform rating="5">Track</complexform>
+        <complexform select="Sleaze">Diffusion of [Matrix Attribute]</complexform>
+		<complexform select="Data Processing">Infusion of [Matrix Attribute]</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>192</page>
+      <source>HS</source>
+      <page>148</page>
+    </metatype>
+	<metatype>
+      <id>d8519836-47a3-4125-aad2-72f17e47d77f</id>
+      <name>Mongrel (Wolf)</name>
+      <category>Technocritters</category>
+      <karma>0</karma>
+      <bodmin>6</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>13</bodaug>
+      <agimin>3</agimin>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
+      <reamin>5</reamin>
+      <reamax>8</reamax>
+      <reaaug>12</reaaug>
+      <strmin>5</strmin>
+      <strmax>8</strmax>
+      <straug>12</straug>
+      <chamin>3</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>9</inimin>
+      <inimax>15</inimax>
+      <iniaug>23</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>0</magmin>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>3</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>8/0/0</run>
+	  <sprint>4/1/0</sprint>
+      <bonus>
+        <enabletab>
+          <name>critter</name>
+		  <name>technomancer</name>
+        </enabletab>
+        <initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+        <power select="Claws/Bite: DV (STR+2)P, AP -1">Natural Weapon</power>
+		<power select="Hearing">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power>Resonance Feed</power>
+      </powers>
+      <skills>
+        <skill rating="5">Running</skill>
+        <skill rating="5" spec="Smell">Perception</skill>
+		<skill rating="5">Sneaking</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="7">Unarmed Combat</skill>
+		<skill rating="7">Computer</skill>
+        <skill rating="5">Electronic Warfare</skill>
+        <skill rating="3">Software</skill>
+      </skills>
+      <complexforms>
+        <complexform select="Sleaze">Diffusion of [Matrix Attribute]</complexform>
+		<complexform select="Data Processing">Infusion of [Matrix Attribute]</complexform>
+      </complexforms>
+      <source>HS</source>
+      <page>148</page>
     </metatype>
     <metatype>
       <id>71e3151b-7acf-4437-99e1-92bee71f2c2c</id>
       <name>Nezumi</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
-      <bodmin>0</bodmin>
-      <bodmax>0</bodmax>
-      <bodaug>0</bodaug>
+      <bodmin>1</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>8</bodaug>
       <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
       <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
       <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
+      <strmax>3</strmax>
+      <straug>7</straug>
       <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>1</intmin>
-      <intmax>1</intmax>
-      <intaug>1</intaug>
+      <chamax>4</chamax>
+      <chaaug>8</chaaug>
+      <intmin>2</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
       <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>1</wilmin>
-      <wilmax>1</wilmax>
-      <wilaug>1</wilaug>
-      <inimin>2</inimin>
-      <inimax>9</inimax>
-      <iniaug>9</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>4</inimin>
+      <inimax>10</inimax>
+      <iniaug>18</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>3</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>5/15</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>6/0/0</run>
+	  <sprint>4/1/0</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
+        <reach>-1</reach>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Diagnostics</power>
-        <power select="E-Sensing">Technovantage [Echo]</power>
-        <power select="Skinlink">Technovantage [Echo]</power>
+		<power select="Bite: DV 1P, AP 0, Reach -1">Natural Weapon</power>
+        <power select="Smell">Enhanced Senses</power>
+        <power>Gestalt Consciousness</power>
+		<power rating="3">Fragile</power>
+		<power>AR-Parallelism</power>
+		<power>Cozenge</power>
+		<power>Gremlins</power>
+		<power>Tunnel</power>
       </powers>
       <skills>
-        <skill rating="3">Computer</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="3">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="2">Unarmed Combat</skill>
+		<skill rating="3">Computer</skill>
+        <skill rating="2">Hardware</skill>
         <skill rating="3">Electronic Warfare</skill>
-        <skill rating="3">Hardware</skill>
-        <skill rating="3">Software</skill>
+        <skill rating="4">Hacking</skill>
+		<skill rating="2">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="3">Analyze</complexform>
-        <complexform rating="3">Command</complexform>
-        <complexform rating="3">Defuse</complexform>
-        <complexform rating="3">Decrypt</complexform>
-        <complexform rating="4">Edit</complexform>
-        <complexform rating="5">Scan</complexform>
-        <complexform rating="3">Spoof</complexform>
+        <complexform select="Firewall">Diffusion of [Matrix Attribute]</complexform>
+		<complexform>Static Bomb</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>192</page>
+      <source>HS</source>
+      <page>148</page>
     </metatype>
     <metatype>
       <id>9bd7dbd3-df42-470b-a6eb-8b152a1eda49</id>
@@ -37586,85 +37920,159 @@
     </metatype>
     <metatype>
       <id>a3adf031-3d38-4fc1-91b3-62c6a589cb68</id>
-      <name>Rook</name>
+      <name>Rook (Crow)</name>
       <category>Technocritters</category>
-      <forcecreature />
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
+      <bodmin>2</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>9</bodaug>
       <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
+      <agimax>6</agimax>
+      <agiaug>10</agiaug>
       <reamin>2</reamin>
-      <reamax>2</reamax>
-      <reaaug>2</reaaug>
-      <strmin>0</strmin>
-      <strmax>0</strmax>
-      <straug>0</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
-      <inimin>2</inimin>
-      <inimax>12</inimax>
-      <iniaug>12</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <reamax>5</reamax>
+      <reaaug>9</reaaug>
+      <strmin>1</strmin>
+      <strmax>4</strmax>
+      <straug>8</straug>
+      <chamin>0</chamin>
+      <chamax>3</chamax>
+      <chaaug>7</chaaug>
+      <intmin>3</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>5</inimin>
+      <inimax>11</inimax>
+      <iniaug>19</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>3</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
-      <movement>Fly 20/40</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/3</walk>
+	  <run>4/0/6</run>
+	  <sprint>4/1/5</sprint>
       <bonus>
-        <addattribute>
-          <name>RES</name>
-          <min>F</min>
-          <max>F</max>
-          <aug>F</aug>
-          <val>F</val>
-        </addattribute>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
+		  <name>technomancer</name>
+        </enabletab>
+        <reach>-1</reach>
+      </bonus>
+      <powers>
+        <power rating="2">Fragile</power>
+        <power>Gestalt Consciousness</power>
+		<power>AR-Parallelism</power>
+		<power>E-Hive</power>
+		<power>Gremlins</power>
+      </powers>
+      <skills>
+        <skill rating="6">Flight</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Unarmed Combat</skill>
+		<skill rating="3">Computer</skill>
+        <skill rating="4">Hacking</skill>
+        <skill rating="5">Software</skill>
+      </skills>
+      <complexforms>
+        <complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
+      </complexforms>
+      <source>HS</source>
+      <page>148</page>
+    </metatype>
+	<metatype>
+      <id>6115731c-8033-46e5-a186-cae0a820ee69</id>
+      <name>Rook (Eagle)</name>
+      <category>Technocritters</category>
+      <karma>0</karma>
+      <bodmin>3</bodmin>
+      <bodmax>6</bodmax>
+      <bodaug>10</bodaug>
+      <agimin>5</agimin>
+      <agimax>8</agimax>
+      <agiaug>12</agiaug>
+      <reamin>4</reamin>
+      <reamax>7</reamax>
+      <reaaug>11</reaaug>
+      <strmin>2</strmin>
+      <strmax>5</strmax>
+      <straug>9</straug>
+      <chamin>0</chamin>
+      <chamax>3</chamax>
+      <chaaug>7</chaaug>
+      <intmin>3</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>7</inimin>
+      <inimax>13</inimax>
+      <iniaug>21</iniaug>
+      <edgmin>4</edgmin>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
+      <magmin>0</magmin>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>3</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/3</walk>
+	  <run>4/0/7</run>
+	  <sprint>4/1/6</sprint>
+      <bonus>
+        <enabletab>
+          <name>critter</name>
+		  <name>technomancer</name>
         </enabletab>
       </bonus>
       <powers>
-        <power>AR-Parallelism</power>
-        <power>Holographic Concealment</power>
-        <power select="Immersion">Technovantage [Echo]</power>
-        <power>Virtual Mimicry</power>
+        <power select="Bite/Claw: DV (STR+2)P, AP 0">Natural Weapon</power>
+		<power select="Vision Magnification">Enhanced Senses</power>
+		<power>AR-Parallelism</power>
+		<power>E-Hive</power>
+		<power>Gremlins</power>
       </powers>
       <skills>
-        <skill rating="3">Computer</skill>
-        <skill rating="3">Hacking</skill>
-        <skill rating="4">Software</skill>
+        <skill rating="3">Flight</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="2">Tracking</skill>
+        <skill rating="3">Unarmed Combat</skill>
+		<skill rating="3">Computer</skill>
+        <skill rating="4">Hacking</skill>
+        <skill rating="5">Software</skill>
       </skills>
       <complexforms>
-        <complexform rating="4">Analyze</complexform>
-        <complexform rating="3">Command</complexform>
-        <complexform rating="3">Decrypt</complexform>
-        <complexform rating="4">Edit</complexform>
-        <complexform rating="3">Encrypt</complexform>
-        <complexform rating="4">Scan</complexform>
-        <complexform rating="3">Shield</complexform>
+        <complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
       </complexforms>
-      <source>RW</source>
-      <page>192</page>
+      <source>HS</source>
+      <page>148</page>
     </metatype>
 		<!-- End Region -->
 		<!-- Region Protosapients -->
@@ -37672,7 +38080,6 @@
       <id>67184157-820f-4738-a854-e1574527c20b</id>
       <name>Daemon</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -37686,40 +38093,41 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F+1</intmin>
-      <intmax>F+1</intmax>
-      <intaug>F+1</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>3</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>6</intmin>
+      <intmax>9</intmax>
+      <intaug>13</intaug>
+      <logmin>3</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>7</wilmax>
+      <wilaug>11</wilaug>
+      <inimin>12</inimin>
+      <inimax>18</inimax>
+      <iniaug>26</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>6</depmin>
+	  <depmax>9</depmax>
+	  <depaug>9</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality>Codivore</quality>
-          <quality select="Realigning AIs">Datavore</quality>
-          <quality>Fnord</quality>
-          <quality>Redundancy</quality>
+          <quality select="Decryption">Inherent Program</quality>
+          <quality>Munge</quality>
         </positive>
         <negative>
           <quality>Real World Naivete</quality>
@@ -37728,33 +38136,22 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F+1">Cybercombat</skill>
-        <skill rating="F">Hacking</skill>
-        <skill rating="F-1">Intimidation</skill>
+        <skill rating="3">Computer</skill>
+        <skill rating="5">Cybercombat</skill>
+		<skill rating="3">Electronic Warfare</skill>
+        <skill rating="3">Hacking</skill>
+        <skill rating="3">Intimidation</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Armor</complexform>
-        <complexform rating="F+1">Attack</complexform>
-        <complexform rating="F">Browse</complexform>
-        <complexform rating="F/2">Cascading</complexform>
-        <complexform rating="F/2">Expert Offense</complexform>
-        <complexform rating="F-1">Exploit</complexform>
-        <complexform rating="F+1">Stealth</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>198</page>
+      <source>HS</source>
+      <page>153</page>
     </metatype>
     <metatype>
       <id>313e959f-8a5d-40d5-bfbe-1eda09eea88c</id>
       <name>Frobnitz</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -37768,38 +38165,41 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F+1</intmin>
-      <intmax>F+1</intmax>
-      <intaug>F+1</intaug>
-      <logmin>F-1</logmin>
-      <logmax>F-1</logmax>
-      <logaug>F-1</logaug>
-      <wilmin>F+1</wilmin>
-      <wilmax>F+1</wilmax>
-      <wilaug>F+1</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>4</chamin>
+      <chamax>7</chamax>
+      <chaaug>11</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>6</wilmax>
+      <wilaug>10</wilaug>
+      <inimin>8</inimin>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>5</edgmin>
+      <edgmax>8</edgmax>
+      <edgaug>8</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>5</depmin>
+	  <depmax>8</depmax>
+	  <depaug>8</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality select="Sprites">Datavore</quality>
-          <quality>Sapper</quality>
+          <quality select="Stealth">Inherent Program</quality>
+          <quality>Munge</quality>
           <quality>Snooper</quality>
         </positive>
         <negative>
@@ -37809,32 +38209,20 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F+2">Cybercombat</skill>
-        <skill rating="F">Hacking</skill>
+        <skill rating="4">Computer</skill>
+        <skill rating="8">Cybercombat</skill>
+        <skill rating="4">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F+1">Armor</complexform>
-        <complexform rating="F+2">Attack</complexform>
-        <complexform rating="F/2">Cascading</complexform>
-        <complexform rating="F+1">Disarm</complexform>
-        <complexform rating="F/2">Expert Offense</complexform>
-        <complexform rating="F">Exploit</complexform>
-        <complexform rating="F">Reality Filter</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>198</page>
+      <source>HS</source>
+      <page>153</page>
     </metatype>
     <metatype>
       <id>845ab519-bd7d-498d-a9da-6890c7d9dbd0</id>
       <name>Grue</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -37848,41 +38236,41 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F+1</intmin>
-      <intmax>F+1</intmax>
-      <intaug>F+1</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F+1</wilmin>
-      <wilmax>F+1</wilmax>
-      <wilaug>F+1</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>2</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>6</intmin>
+      <intmax>9</intmax>
+      <intaug>13</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>5</wilmin>
+      <wilmax>8</wilmax>
+      <wilaug>12</wilaug>
+      <inimin>12</inimin>
+      <inimax>18</inimax>
+      <iniaug>26</iniaug>
+      <edgmin>5</edgmin>
+      <edgmax>8</edgmax>
+      <edgaug>8</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>8</depmin>
+	  <depmax>11</depmax>
+	  <depaug>11</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality>Authority</quality>
-          <quality select="Persona Programs of Dead Users">Datavore</quality>
-          <quality>Fnord</quality>
-          <quality>Rootkit</quality>
-          <quality>Teergrube</quality>
+          <quality select="Hammer">Inherent Program</quality>
+          <quality>Munge</quality>
         </positive>
         <negative>
           <quality>Real World Naivete</quality>
@@ -37891,26 +38279,15 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F+1">Cybercombat</skill>
-        <skill rating="F">Hacking</skill>
+        <skill rating="5">Computer</skill>
+        <skill rating="8">Cybercombat</skill>
+        <skill rating="4">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Armor</complexform>
-        <complexform rating="F-1">Attack</complexform>
-        <complexform rating="F">Black Hammer</complexform>
-        <complexform rating="F/2">Cascading</complexform>
-        <complexform rating="F/3">Expert Offense</complexform>
-        <complexform rating="F-2">Exploit</complexform>
-        <complexform rating="F">Stealth</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>198</page>
+      <source>HS</source>
+      <page>154</page>
     </metatype>
     <metatype>
       <id>dfe34157-e23b-436c-8e27-1b3f8a6a3517</id>
@@ -38149,7 +38526,6 @@
       <id>940822df-9130-467f-a372-d462e88904a6</id>
       <name>SINtax</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -38163,40 +38539,42 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F+1</chamin>
-      <chamax>F+1</chamax>
-      <chaaug>F+1</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F-1</logmin>
-      <logmax>F-1</logmax>
-      <logaug>F-1</logaug>
-      <wilmin>F</wilmin>
-      <wilmax>F</wilmax>
-      <wilaug>F</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>3</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>2</intmin>
+      <intmax>5</intmax>
+      <intaug>9</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>9</wilaug>
+      <inimin>4</inimin>
+      <inimax>10</inimax>
+      <iniaug>18</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>3</depmin>
+	  <depmax>6</depmax>
+	  <depaug>6</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality>Code Flux</quality>
-          <quality select="SIN Data">Datavore</quality>
-          <quality select="Spoof">Intuitive Hacking</quality>
-          <quality>Rootkit</quality>
+          <quality>Easily Exploitable</quality>
+          <quality select="Browse">Inherent Program</quality>
+          <quality>Munge</quality>
         </positive>
         <negative>
           <quality>Real World Naivete</quality>
@@ -38205,30 +38583,20 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F">Data Search</skill>
-        <skill rating="F">Hacking</skill>
+        <skill rating="2">Computer</skill>
+        <skill rating="2">Software</skill>
+        <skill rating="3">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F-1">Armor</complexform>
-        <complexform rating="F">Browse</complexform>
-        <complexform rating="F+1">Decrypt</complexform>
-        <complexform rating="F">Exploit</complexform>
-        <complexform rating="F">Stealth</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>199</page>
+      <source>HS</source>
+      <page>155</page>
     </metatype>
     <metatype>
       <id>bfb8b6c4-ef6b-4f0e-802d-a4bd2c999410</id>
       <name>Tentacle</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -38242,40 +38610,41 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F-1</chamin>
-      <chamax>F-1</chamax>
-      <chaaug>F-1</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F-2</logmin>
-      <logmax>F-2</logmax>
-      <logaug>F-2</logaug>
-      <wilmin>F+1</wilmin>
-      <wilmax>F+1</wilmax>
-      <wilaug>F+1</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>2</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>3</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>7</wilmax>
+      <wilaug>11</wilaug>
+      <inimin>6</inimin>
+      <inimax>12</inimax>
+      <iniaug>20</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>2</depmin>
+	  <depmax>5</depmax>
+	  <depaug>5</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality select="Persona Icons">Datavore</quality>
-          <quality>Nyetworking</quality>
-          <quality>Redundancy</quality>
-          <quality>Teergrube</quality>
+          <quality select="Decryption">Inherent Program</quality>
+          <quality>Munge</quality>
         </positive>
         <negative>
           <quality>Real World Naivete</quality>
@@ -38284,32 +38653,20 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F+1">Cybercombat</skill>
-        <skill rating="F-1">Hacking</skill>
+        <skill rating="3">Computer</skill>
+        <skill rating="3">Cybercombat</skill>
+        <skill rating="2">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Armor</complexform>
-        <complexform rating="F">Attack</complexform>
-        <complexform rating="F">Disarm</complexform>
-        <complexform rating="F/2">Expert Defense</complexform>
-        <complexform rating="F/2">Expert Offense</complexform>
-        <complexform rating="F-2">Exploit</complexform>
-        <complexform rating="F-1">Stealth</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>199</page>
+      <source>HS</source>
+      <page>155</page>
     </metatype>
     <metatype>
       <id>c7d14563-6c14-4c75-879e-ce6aa86a081c</id>
       <name>Cyberwerewolf</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -38323,42 +38680,41 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F</chamin>
-      <chamax>F</chamax>
-      <chaaug>F</chaaug>
-      <intmin>F+2</intmin>
-      <intmax>F+2</intmax>
-      <intaug>F+2</intaug>
-      <logmin>F-1</logmin>
-      <logmax>F-1</logmax>
-      <logaug>F-1</logaug>
-      <wilmin>F+2</wilmin>
-      <wilmax>F+2</wilmax>
-      <wilaug>F+2</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>3</chamin>
+      <chamax>6</chamax>
+      <chaaug>10</chaaug>
+      <intmin>5</intmin>
+      <intmax>8</intmax>
+      <intaug>12</intaug>
+      <logmin>2</logmin>
+      <logmax>5</logmax>
+      <logaug>9</logaug>
+      <wilmin>5</wilmin>
+      <wilmax>8</wilmax>
+      <wilaug>12</wilaug>
+      <inimin>10</inimin>
+      <inimax>16</inimax>
+      <iniaug>24</iniaug>
+      <edgmin>4</edgmin>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>4</depmin>
+	  <depmax>7</depmax>
+	  <depaug>7</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality>Authority</quality>
-          <quality>Codivore</quality>
-          <quality>Designer</quality>
-          <quality select="Exploit">Intuitive Hacking</quality>
-          <quality select="Cyberware">Persnickety Renter</quality>
-          <quality>POKEr</quality>
+          <quality select="Decryption">Inherent Program</quality>
+          <quality>Munge</quality>
         </positive>
         <negative>
           <quality>Real World Naivete</quality>
@@ -38367,24 +38723,17 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F+1">Cybercombat</skill>
-        <skill rating="F">Hacking</skill>
+        <skill rating="3">Computer</skill>
+        <skill rating="5">Cybercombat</skill>
+        <skill rating="3">Hacking</skill>
+		<skill rating="3">Electronic Warfare</skill>
+		<skill rating="3">Intimidation</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F">Armor</complexform>
-        <complexform rating="F+2">Attack</complexform>
-        <complexform rating="F/2">Cascading</complexform>
-        <complexform rating="F" select="Home">Homeground</complexform>
-        <complexform rating="F-3">Medic</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>199</page>
+      <source>HS</source>
+      <page>153</page>
     </metatype>
     <metatype>
       <id>980e18d3-cdae-4d7d-b7e6-a6ecb61db96c</id>
@@ -38463,7 +38812,6 @@
       <id>07ec2089-a37a-4743-99ef-2169e687c44b</id>
       <name>Heavyweight</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -38477,39 +38825,42 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F-1</chamin>
-      <chamax>F-1</chamax>
-      <chaaug>F-1</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F+2</wilmin>
-      <wilmax>F+2</wilmax>
-      <wilaug>F+2</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>2</chamin>
+      <chamax>5</chamax>
+      <chaaug>9</chaaug>
+      <intmin>3</intmin>
+      <intmax>6</intmax>
+      <intaug>10</intaug>
+      <logmin>1</logmin>
+      <logmax>4</logmax>
+      <logaug>8</logaug>
+      <wilmin>6</wilmin>
+      <wilmax>9</wilmax>
+      <wilaug>13</wilaug>
+      <inimin>6</inimin>
+      <inimax>12</inimax>
+      <iniaug>20</iniaug>
+      <edgmin>4</edgmin>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>7</depmin>
+	  <depmax>10</depmax>
+	  <depaug>10</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality select="Any">Datavore</quality>
-          <quality>Improved Realignment</quality>
-          <quality>Redundancy</quality>
+          <quality select="Toolbox">Inherent Program</quality>
+          <quality>Corrupter</quality>
+          <quality>Munge</quality>
         </positive>
         <negative>
           <quality>Real World Naivete</quality>
@@ -38518,24 +38869,16 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F+1">Cybercombat</skill>
-        <skill rating="F-1">Hacking</skill>
-        <skill rating="F+1">Intimidation</skill>
+        <skill rating="3">Computer</skill>
+        <skill rating="5">Cybercombat</skill>
+        <skill rating="3">Hacking</skill>
+        <skill rating="5">Intimidation</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F">Analyze</complexform>
-        <complexform rating="F+2">Armor</complexform>
-        <complexform rating="F">Attack</complexform>
-        <complexform rating="F/2">Expert Defense</complexform>
-        <complexform rating="F-2">Exploit</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>200</page>
+      <source>HS</source>
+      <page>154</page>
     </metatype>
     <metatype>
       <id>80f84b16-7826-4f5d-a2c4-4177e5cfc8f2</id>
@@ -38930,7 +39273,6 @@
       <id>da4543a8-5e08-42be-8568-e05b82a5906c</id>
       <name>Yantra</name>
       <category>Protosapients</category>
-      <forcecreature />
       <karma>0</karma>
       <bodmin>0</bodmin>
       <bodmax>0</bodmax>
@@ -38944,37 +39286,41 @@
       <strmin>0</strmin>
       <strmax>0</strmax>
       <straug>0</straug>
-      <chamin>F+1</chamin>
-      <chamax>F+1</chamax>
-      <chaaug>F+1</chaaug>
-      <intmin>F</intmin>
-      <intmax>F</intmax>
-      <intaug>F</intaug>
-      <logmin>F</logmin>
-      <logmax>F</logmax>
-      <logaug>F</logaug>
-      <wilmin>F+1</wilmin>
-      <wilmax>F+1</wilmax>
-      <wilaug>F+1</wilaug>
-      <inimin>(F*2)</inimin>
-      <inimax>(F*2)</inimax>
-      <iniaug>(F*2)</iniaug>
-      <edgmin>F</edgmin>
-      <edgmax>F</edgmax>
-      <edgaug>F</edgaug>
+      <chamin>4</chamin>
+      <chamax>7</chamax>
+      <chaaug>11</chaaug>
+      <intmin>4</intmin>
+      <intmax>7</intmax>
+      <intaug>11</intaug>
+      <logmin>3</logmin>
+      <logmax>6</logmax>
+      <logaug>10</logaug>
+      <wilmin>5</wilmin>
+      <wilmax>8</wilmax>
+      <wilaug>12</wilaug>
+      <inimin>8</inimin>
+      <inimax>14</inimax>
+      <iniaug>22</iniaug>
+      <edgmin>4</edgmin>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
       <magmin>0</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
-      <resmin>F</resmin>
-      <resmax>F</resmax>
-      <resaug>F</resaug>
+      <magmax>0</magmax>
+      <magaug>0</magaug>
+      <resmin>0</resmin>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>0</essmax>
-      <essaug>0</essaug>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+	  <depmin>5</depmin>
+	  <depmax>8</depmax>
+	  <depaug>8</depaug>
       <movement>Special</movement>
       <qualities>
         <positive>
-          <quality select="Defused Data Bombs">Datavore</quality>
+          <quality select="Demolition">Inherent Program</quality>
+		  <quality>Munge</quality>
           <quality>Redundancy</quality>
         </positive>
         <negative>
@@ -38984,28 +39330,15 @@
       <bonus>
         <enabletab>
           <name>critter</name>
-          <name>technomancer</name>
         </enabletab>
       </bonus>
       <skills>
-        <skill rating="F">Computer</skill>
-        <skill rating="F">Data Search</skill>
-        <skill rating="F-1">Hacking</skill>
+        <skill rating="4">Computer</skill>
+        <skill rating="2">Software</skill>
+        <skill rating="3">Hacking</skill>
       </skills>
-      <complexforms>
-        <complexform rating="F+1">Analyze</complexform>
-        <complexform rating="F+3">Armor</complexform>
-        <complexform rating="F">Browse</complexform>
-        <complexform rating="F/2">Cascading</complexform>
-        <complexform rating="F">Command</complexform>
-        <complexform rating="F">Corrupt</complexform>
-        <complexform rating="F-4">Data Bomb</complexform>
-        <complexform rating="F">Defuse</complexform>
-        <complexform rating="F-2">Exploit</complexform>
-        <complexform rating="F">Medic</complexform>
-      </complexforms>
-      <source>RW</source>
-      <page>200</page>
+      <source>HS</source>
+      <page>156</page>
     </metatype>
     <metatype>
       <id>8ca5747e-146d-45dc-bcbe-691b26e62278</id>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -961,18 +961,18 @@
       <name>Abrams Lobster</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
+      <bodmin>4</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>4</bodaug>
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
       <reamin>2</reamin>
       <reamax>2</reamax>
       <reaaug>2</reaaug>
-      <strmin>5</strmin>
-      <strmax>5</strmax>
-      <straug>5</straug>
+      <strmin>7</strmin>
+      <strmax>7</strmax>
+      <straug>7</straug>
       <chamin>1</chamin>
       <chamax>1</chamax>
       <chaaug>1</chaaug>
@@ -985,12 +985,12 @@
       <wilmin>3</wilmin>
       <wilmax>3</wilmax>
       <wilaug>3</wilaug>
-      <inimin>2</inimin>
+      <inimin>5</inimin>
       <inimax>11</inimax>
       <iniaug>16</iniaug>
       <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
@@ -1000,7 +1000,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 4/8</movement>
+	  <depmin>0</depmin>
+      <depmax>0</depmax>
+      <depaug>0</depaug>
+      <walk>1/1/0</walk>
+	  <run>2/2/0</run>
+	  <sprint>1/10/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -1008,19 +1013,20 @@
       </bonus>
       <powers>
         <power select="Sonar">Enhanced Senses</power>
+		<power>Fear</power>
         <power>Gestalt Consciousness</power>
         <power>Gills</power>
-        <power rating="6">Hardened Armor</power>
-        <power select="Poisons">Immunity</power>
-        <power select="Claw: DV 4P, AP 1">Natural Weapon</power>
+        <power rating="9">Hardened Armor</power>
+        <power select="Toxins">Immunity</power>
+        <power select="Claws: DV 9P, AP -4">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="3">Swimming</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Swimming</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>PZ</source>
-      <page>3</page>
+      <source>HS</source>
+      <page>53</page>
     </metatype>
     <metatype>
       <id>47428a29-890f-4b3a-9d18-d8c2e581f1b4</id>
@@ -15786,7 +15792,7 @@
 				<power select="Cold">Vulnerability</power>
 			</powers>
 			<skills>
-				<skill rating="2" select="Tongue">Exotic Ranged Weapon</skill>
+				<skill rating="2" spec="Tongue">Exotic Ranged Weapon</skill>
 				<skill rating="2">Infiltration</skill>
 				<skill rating="3">Perception</skill>
 				<skill rating="3">Shadowing</skill>
@@ -16531,53 +16537,58 @@
       <name>Barghest</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>7</bodmin>
-      <bodmax>7</bodmax>
-      <bodaug>7</bodaug>
+      <bodmin>8</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>8</bodaug>
       <agimin>5</agimin>
       <agimax>5</agimax>
       <agiaug>5</agiaug>
       <reamin>6</reamin>
       <reamax>6</reamax>
       <reaaug>6</reaaug>
-      <strmin>5</strmin>
-      <strmax>5</strmax>
-      <straug>5</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <strmin>6</strmin>
+      <strmax>6</strmax>
+      <straug>6</straug>
+      <chamin>5</chamin>
+      <chamax>5</chamax>
+      <chaaug>5</chaaug>
+      <intmin>5</intmin>
+      <intmax>5</intmax>
+      <intaug>5</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
       <inimin>4</inimin>
       <inimax>15</inimax>
       <iniaug>15</iniaug>
       <edgmin>4</edgmin>
-      <edgmax>4</edgmax>
-      <edgaug>4</edgaug>
-      <magmin>4</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
+      <magmin>5</magmin>
+      <magmax>8</magmax>
+      <magaug>8</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/50</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>4/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
           <max>6</max>
           <aug>6</aug>
-          <val>4</val>
+          <val>5</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
@@ -16585,19 +16596,25 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
+		<power rating="3">Armor</power>
+		<power>Dual Natured</power>
+		<power select="Hearing">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
         <power select="Sonar">Enhanced Senses</power>
         <power>Fear</power>
-        <power select="Bite: DV 5P, AP 0">Natural Weapon</power>
+		<power select="Barghest Howls">Immunity</power>
+        <power select="Bite: DV (STR+2)P, AP -1">Natural Weapon</power>
         <power>Paralyzing Howl</power>
       </powers>
       <skills>
-        <skill rating="4">Intimidation</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="7">Intimidation</skill>
+        <skill rating="6">Perception</skill>
+		<skill rating="5">Running</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="8">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>403</page>
     </metatype>
     <metatype>
       <id>6fb20284-a25b-4eb7-82d5-e20f79d345e3</id>
@@ -16632,9 +16649,9 @@
       <inimax>16</inimax>
       <iniaug>16</iniaug>
       <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
-      <magmin>3</magmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
+      <magmin>4</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -16643,7 +16660,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>2/10</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>2/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -16660,17 +16682,18 @@
         <power select="Ordinary Rats">Animal Control</power>
         <power>Concealment</power>
         <power select="Toxins">Immunity</power>
-        <power select="Bite: DV 1P, AP 0, -1 Reach">Natural Weapon</power>
+        <power select="Bite: DV (STR+1)P, AP 0, -1 Reach">Natural Weapon</power>
         <power select="Sunlight, Mild">Allergy</power>
       </powers>
       <skills>
-        <skill rating="3">Climbing</skill>
-        <skill rating="3">Dodge</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Gymnastics</skill>
+        <skill rating="2">Running</skill>
+        <skill rating="4">Perception</skill>
+		<skill rating="6">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>404</page>
     </metatype>
     <metatype>
       <id>d3a7e0fe-46bc-4c30-a287-b159eb53f0f8</id>
@@ -16705,18 +16728,23 @@
       <inimax>15</inimax>
       <iniaug>15</iniaug>
       <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>1</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>5</magmax>
+      <magaug>5</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>6</essmax>
-      <essaug>6</essaug>
-      <movement>10/25</movement>
+      <essmax>5</essmax>
+      <essaug>5</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -16730,37 +16758,43 @@
         </enabletab>
       </bonus>
       <powers>
+		<power rating="1">Armor</power>
         <power>Dual Natured</power>
-        <power select="Hearing, Smell">Enhanced Senses</power>
-        <power select="Claws: DV 4P, AP 0">Natural Weapon</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+        <power select="Claws: DV (STR+1)P, AP -1">Natural Weapon</power>
         <power>Sapience</power>
+		<power select="Sunlight, Moderate">Allergy</power>
+		<power select="Metahuman Flesh">Dietary Requirement</power>
+		<power select="Blind">Reduced Senses</power>
       </powers>
       <skills>
-        <skill rating="2">Assensing</skill>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="4">Assensing</skill>
+        <skill rating="6">Sneaking</skill>
+		<skill rating="3">Running</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>299</page>
+      <source>SR5</source>
+      <page>404</page>
     </metatype>
     <metatype>
       <id>2403521d-8a3b-4e73-8562-2a5978841478</id>
       <name>Hell Hound</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>4</bodmin>
-      <bodmax>4</bodmax>
-      <bodaug>4</bodaug>
+      <bodmin>6</bodmin>
+      <bodmax>6</bodmax>
+      <bodaug>6</bodaug>
       <agimin>4</agimin>
       <agimax>4</agimax>
       <agiaug>4</agiaug>
       <reamin>5</reamin>
       <reamax>5</reamax>
       <reaaug>5</reaaug>
-      <strmin>4</strmin>
-      <strmax>4</strmax>
-      <straug>4</straug>
+      <strmin>6</strmin>
+      <strmax>6</strmax>
+      <straug>6</straug>
       <chamin>3</chamin>
       <chamax>3</chamax>
       <chaaug>3</chaaug>
@@ -16770,32 +16804,37 @@
       <logmin>2</logmin>
       <logmax>2</logmax>
       <logaug>2</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
       <inimin>3</inimin>
       <inimax>15</inimax>
       <iniaug>15</iniaug>
-      <edgmin>4</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
-      <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>6</magaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>5</magmin>
+      <magmax>8</magmax>
+      <magaug>8</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/50</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>4/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
-          <max>6</max>
-          <aug>6</aug>
-          <val>3</val>
+          <max>8</max>
+          <aug>8</aug>
+          <val>5</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
@@ -16803,23 +16842,27 @@
         <initiativepass>2</initiativepass>
       </bonus>
       <powers>
+		<power rating="2">Armor</power>
         <power>Dual Natured</power>
         <power select="Fire">Elemental Attack</power>
-        <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
         <power>Fear</power>
         <power select="Fire">Immunity</power>
-        <power select="Bite: DV 4P, AP 0">Natural Weapon</power>
+        <power select="Bite: DV (STR+1)P, AP -1">Natural Weapon</power>
       </powers>
       <skills>
         <skill rating="4">Exotic Ranged Weapon</skill>
-        <skill rating="4">Infiltration</skill>
+        <skill rating="5">Sneaking</skill>
         <skill rating="3">Intimidation</skill>
+		<skill rating="4">Running</skill>
         <skill rating="3">Perception</skill>
         <skill rating="5">Tracking</skill>
         <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>300</page>
+      <source>SR5</source>
+      <page>405</page>
     </metatype>
     <metatype>
       <id>edc96d39-459c-43df-907c-1559bff5c450</id>
@@ -16832,12 +16875,12 @@
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
-      <reamin>7</reamin>
-      <reamax>7</reamax>
-      <reaaug>7</reaaug>
-      <strmin>7</strmin>
-      <strmax>7</strmax>
-      <straug>7</straug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>5</strmin>
+      <strmax>5</strmax>
+      <straug>5</straug>
       <chamin>3</chamin>
       <chamax>3</chamax>
       <chaaug>3</chaaug>
@@ -16856,7 +16899,7 @@
       <edgmin>3</edgmin>
       <edgmax>3</edgmax>
       <edgaug>3</edgaug>
-      <magmin>1</magmin>
+      <magmin>3</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -16865,33 +16908,40 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/45</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>0/2/0</walk>
+		<run>0/6/0</run>
+		<sprint>0/3/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
           <max>6</max>
           <aug>6</aug>
-          <val>1</val>
+          <val>3</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
+		<power rating="2">Armor</power>
         <power>Dual Natured</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
         <power>Sapience</power>
         <power>Uneducated</power>
       </powers>
       <skills>
-        <skill rating="3">Assensing</skill>
-        <skill rating="3">Dodge</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Swimming</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="4">Assensing</skill>
+        <skill rating="4">Gymnastics</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="7">Swimming</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>300</page>
+      <source>HS</source>
+      <page>68</page>
     </metatype>
     <metatype>
       <id>3ff9d116-3b68-4de8-8afb-962deb321525</id>
@@ -16910,18 +16960,18 @@
       <strmin>6</strmin>
       <strmax>6</strmax>
       <straug>6</straug>
-      <chamin>4</chamin>
-      <chamax>4</chamax>
-      <chaaug>4</chaaug>
+      <chamin>3</chamin>
+      <chamax>3</chamax>
+      <chaaug>3</chaaug>
       <intmin>4</intmin>
       <intmax>4</intmax>
       <intaug>4</intaug>
       <logmin>3</logmin>
       <logmax>3</logmax>
       <logaug>3</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
       <inimin>2</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
@@ -16937,7 +16987,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>5/20</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -16951,22 +17006,27 @@
         </enabletab>
       </bonus>
       <powers>
-        <power rating="2">Armor (Ballistic)</power>
-        <power rating="3">Armor (Impact)</power>
+        <power rating="8">Armor</power>
         <power>Dual Natured</power>
-        <power select="Bite: DV 5P, AP 0">Natural Weapon</power>
+		<power>Guard</power>
+        <power select="Bite: DV (STR+1)P, AP -2, -1 Reach">Natural Weapon</power>
         <power>Sapience</power>
         <power>Venom</power>
         <power>Uneducated</power>
       </powers>
+	  <qualities>
+		<negative>
+			<quality>Cold-Blooded</quality>
+		</negative>
+	  </qualities>
       <skills>
         <skill rating="4">Assensing</skill>
-        <skill rating="2">Climbing</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="7">Perception</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>300</page>
+      <source>HS</source>
+      <page>68</page>
     </metatype>
     <metatype>
       <id>6d15c952-542a-429d-9b56-51fc21ebb138</id>
@@ -16979,40 +17039,45 @@
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <reamin>4</reamin>
+      <reamax>4</reamax>
+      <reaaug>4</reaaug>
       <strmin>7</strmin>
       <strmax>7</strmax>
       <straug>7</straug>
       <chamin>3</chamin>
       <chamax>3</chamax>
       <chaaug>3</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
+      <intmin>5</intmin>
+      <intmax>5</intmax>
+      <intaug>5</intaug>
       <logmin>3</logmin>
       <logmax>3</logmax>
       <logaug>3</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
+      <wilmin>3</wilmin>
+      <wilmax>3</wilmax>
+      <wilaug>3</wilaug>
       <inimin>2</inimin>
       <inimax>12</inimax>
       <iniaug>12</iniaug>
       <edgmin>4</edgmin>
-      <edgmax>4</edgmax>
-      <edgaug>4</edgaug>
-      <magmin>3</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <edgmax>7</edgmax>
+      <edgaug>7</edgaug>
+      <magmin>4</magmin>
+      <magmax>7</magmax>
+      <magaug>7</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/35</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -17032,15 +17097,15 @@
         <power>Sapience</power>
       </powers>
       <skills>
-        <skill rating="3">Assensing</skill>
-        <skill rating="4">Artisan</skill>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="4">Perception</skill>
-        <group rating="2">Athletics</group>
-        <knowledge rating="5" category="Professional">Animal Calls</knowledge>
+        <skill rating="6">Assensing</skill>
+        <skill rating="6">Artisan</skill>
+        <skill rating="8">Sneaking</skill>
+        <skill rating="6">Perception</skill>
+        <group rating="3">Athletics</group>
+        <knowledge rating="8" category="Professional">Animal Calls</knowledge>
       </skills>
-      <source>DIS</source>
-      <page>300</page>
+      <source>SR5</source>
+      <page>406</page>
     </metatype>
     <metatype>
       <id>c216e7b6-655e-45b8-a755-09e1de66dc81</id>
@@ -17120,18 +17185,18 @@
       <name>Vampire</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
-      <bodmax>3</bodmax>
-      <bodaug>3</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
+      <bodmin>4</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>4</bodaug>
+      <agimin>3</agimin>
+      <agimax>3</agimax>
+      <agiaug>3</agiaug>
       <reamin>5</reamin>
       <reamax>5</reamax>
       <reaaug>5</reaaug>
-      <strmin>3</strmin>
-      <strmax>3</strmax>
-      <straug>3</straug>
+      <strmin>4</strmin>
+      <strmax>4</strmax>
+      <straug>4</straug>
       <chamin>5</chamin>
       <chamax>5</chamax>
       <chaaug>5</chaaug>
@@ -17148,18 +17213,23 @@
       <inimax>15</inimax>
       <iniaug>15</iniaug>
       <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
-      <magmin>3</magmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>0</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>2D6-1</essmax>
-      <essaug>2D6-1</essaug>
-      <movement>10/25</movement>
+      <essmax>2D6</essmax>
+      <essaug>2D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -17174,63 +17244,69 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Hearing, Smell, Thermographic Vision">Enhanced Senses</power>
+		<power>Dual Natured</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power>Essence Drain</power>
-        <power select="Age, Pathogens, Toxins">Immunity</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Infection</power>
         <power>Mist Form</power>
-        <power select="Bite: DV 2P, AP 0, -1 Reach">Natural Weapon</power>
+        <power select="Bite: DV (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
         <power>Regeneration</power>
         <power>Sapience</power>
-        <power select="Sunlight, Moderate">Allergy</power>
+        <power select="Sunlight, Severe">Allergy</power>
         <power select="Wood, Severe">Allergy</power>
-        <power select="Blood">Dietary Requirement</power>
+        <power select="Metahuman Blood">Dietary Requirement</power>
         <power>Essence Loss</power>
+		<power select="Lack of Air, (Essence) Minutes">Induced Dormancy</power>
       </powers>
       <skills>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="4">Running</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>DIS</source>
-      <page>301</page>
+      <source>SR5</source>
+      <page>406</page>
     </metatype>
     <metatype>
       <id>a1cfa419-e728-4a3e-ad2b-43d3ce062ef1</id>
-      <name>Wendigo</name>
+      <name>Wendigo (Magician)</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>6</bodmin>
-      <bodmax>6</bodmax>
-      <bodaug>6</bodaug>
-      <agimin>2</agimin>
-      <agimax>2</agimax>
-      <agiaug>2</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>5</strmin>
-      <strmax>5</strmax>
-      <straug>5</straug>
+      <bodmin>8</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>3</agimin>
+      <agimax>3</agimax>
+      <agiaug>3</agiaug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>6</strmin>
+      <strmax>6</strmax>
+      <straug>6</straug>
       <chamin>4</chamin>
       <chamax>4</chamax>
       <chaaug>4</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
+      <intmin>4</intmin>
+      <intmax>4</intmax>
+      <intaug>4</intaug>
       <logmin>3</logmin>
       <logmax>3</logmax>
       <logaug>3</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
       <inimin>2</inimin>
       <inimax>12</inimax>
       <iniaug>12</iniaug>
       <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
       <magmin>3</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
@@ -17238,9 +17314,14 @@
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>2D6-1</essmax>
-      <essaug>2D6-1</essaug>
-      <movement>10/25</movement>
+      <essmax>2D6</essmax>
+      <essaug>2D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>3/1/0</sprint>
       <qualities>
         <positive>
           <quality>Magician</quality>
@@ -17260,27 +17341,142 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Hearing, Low-Light Vision, Smell, Visual Acuity">Enhanced Senses</power>
+		<power>Dual Natured</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Visual Acuity">Enhanced Senses</power>
         <power>Essence Drain</power>
         <power>Fear</power>
-        <power select="Age, Pathogens, Poison">Immunity</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Poison">Immunity</power>
         <power>Infection</power>
         <power>Influence</power>
-        <power select="Bite/Claw: DV 5P, AP 0">Natural Weapon</power>
+        <power select="Bite: DV (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
+		<power select="Claw: DV (STR+2)P, AP -1">Natural Weapon</power>
         <power>Regeneration</power>
+		<power>Sapience</power>
         <power select="Ferrous Metals, Moderate">Allergy</power>
-        <power select="Sunlight, Moderate">Allergy</power>
+        <power select="Sunlight, Severe">Allergy</power>
         <power select="Metahuman Flesh">Dietary Requirement</power>
         <power>Essence Loss</power>
       </powers>
       <skills>
         <skill rating="4">Assensing</skill>
-        <skill rating="2">Climbing</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Astral Combat</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="6">Perception</skill>
+		<skill rating="7">Sneaking</skill>
+		<skill rating="7">Unarmed Combat</skill>
+		<group rating="5">Conjuring</group>
+		<group rating="6">Sorcery</group>
       </skills>
-      <source>DIS</source>
-      <page>301</page>
+      <source>HS</source>
+      <page>91</page>
+    </metatype>
+	<metatype>
+      <id>09a65ad9-18f2-40bf-88c2-b4c057e2b1c6</id>
+      <name>Wendigo (Mystic Adept)</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>8</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>3</agimin>
+      <agimax>3</agimax>
+      <agiaug>3</agiaug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>6</strmin>
+      <strmax>6</strmax>
+      <straug>6</straug>
+      <chamin>4</chamin>
+      <chamax>4</chamax>
+      <chaaug>4</chaaug>
+      <intmin>4</intmin>
+      <intmax>4</intmax>
+      <intaug>4</intaug>
+      <logmin>3</logmin>
+      <logmax>3</logmax>
+      <logaug>3</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
+      <inimin>2</inimin>
+      <inimax>12</inimax>
+      <iniaug>12</iniaug>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>3</magmin>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>2D6</essmax>
+      <essaug>2D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>3/1/0</sprint>
+      <qualities>
+        <positive>
+          <quality>Mystic Adept</quality>
+        </positive>
+      </qualities>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>6</max>
+          <aug>6</aug>
+          <val>3</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+        <initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+		<power>Dual Natured</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Visual Acuity">Enhanced Senses</power>
+        <power>Essence Drain</power>
+        <power>Fear</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Poison">Immunity</power>
+        <power>Infection</power>
+        <power>Influence</power>
+        <power select="Bite: DV (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
+		<power select="Claw: DV (STR+2)P, AP -1">Natural Weapon</power>
+        <power>Regeneration</power>
+		<power>Sapience</power>
+        <power select="Ferrous Metals, Moderate">Allergy</power>
+        <power select="Sunlight, Severe">Allergy</power>
+        <power select="Metahuman Flesh">Dietary Requirement</power>
+        <power>Essence Loss</power>
+      </powers>
+      <skills>
+        <skill rating="4">Assensing</skill>
+        <skill rating="5">Astral Combat</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="6">Perception</skill>
+		<skill rating="7">Sneaking</skill>
+		<skill rating="7">Unarmed Combat</skill>
+		<group rating="5">Conjuring</group>
+		<group rating="6">Sorcery</group>
+      </skills>
+      <source>HS</source>
+      <page>91</page>
     </metatype>
     <metatype>
       <id>83e2bba4-331f-4ef5-b078-55630c71be18</id>
@@ -17568,18 +17764,18 @@
       <name>Harpy</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>2</bodmin>
-      <bodmax>2</bodmax>
-      <bodaug>2</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
+      <bodmin>4</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>4</bodaug>
+      <agimin>5</agimin>
+      <agimax>5</agimax>
+      <agiaug>5</agiaug>
       <reamin>4</reamin>
       <reamax>4</reamax>
       <reaaug>4</reaaug>
-      <strmin>3</strmin>
-      <strmax>3</strmax>
-      <straug>3</straug>
+      <strmin>4</strmin>
+      <strmax>4</strmax>
+      <straug>4</straug>
       <chamin>1</chamin>
       <chamax>1</chamax>
       <chaaug>1</chaaug>
@@ -17607,7 +17803,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 25/120</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>2/0/4</run>
+		<sprint>1/1/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -17621,18 +17822,20 @@
         </enabletab>
       </bonus>
       <powers>
+		<power rating="2">Armor</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
         <power select="Pathogens">Immunity</power>
-        <power select="Claws: DV 3P, AP 0">Natural Weapon</power>
+        <power select="Claws: DV 6P, AP -1">Natural Weapon</power>
         <power>Pestilence</power>
         <power rating="1">Fragile</power>
       </powers>
       <skills>
-        <skill rating="3">Flight</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="4">Flight</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>103</page>
+      <source>HS</source>
+      <page>62</page>
     </metatype>
     <metatype>
       <id>1171ad5c-69bf-4572-9d89-8e808c1860fe</id>
@@ -18110,21 +18313,26 @@
       <edgmax>1</edgmax>
       <edgaug>1</edgaug>
       <magmin>6</magmin>
-      <magmax>6</magmax>
-      <magaug>6</magaug>
+      <magmax>9</magmax>
+      <magaug>9</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 10/50</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>2/0/4</run>
+		<sprint>1/1/1</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>3</min>
-          <max>6</max>
-          <aug>6</aug>
+          <max>9</max>
+          <aug>9</aug>
           <val>6</val>
         </addattribute>
         <enabletab>
@@ -18135,18 +18343,19 @@
         <power>Dual Natured</power>
         <power select="Electricity">Elemental Attack</power>
         <power select="Low-Light Vision">Enhanced Senses</power>
-        <power select="Claws/Bite: DV 6P, AP 0">Natural Weapon</power>
+        <power select="Claws: DV 10P, AP -4">Natural Weapon</power>
         <power select="Electrical Storms">Weather Control</power>
+		<power rating="1">Fragile</power>
       </powers>
       <skills>
-        <skill rating="3">Astral Combat</skill>
-        <skill rating="3">Exotic Range Weapon</skill>
-        <skill rating="3">Flight</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Astral Combat</skill>
+        <skill rating="5" spec="Lightning">Exotic Range Weapon</skill>
+        <skill rating="5">Flight</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>106</page>
+      <source>HS</source>
+      <page>73</page>
     </metatype>
     <metatype>
       <id>faf2978f-9c5c-42c1-b0b0-86352be5fd65</id>
@@ -18489,7 +18698,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 15/40</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>2/0/5</run>
+		<sprint>1/1/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -18503,16 +18717,101 @@
         </enabletab>
       </bonus>
       <powers>
-        <power select="Low-Light Vision, Vision Magnification">Enhanced Senses</power>
-        <power select="Pathogens, Toxins">Immunity</power>
+		<power>Dive Attack</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Vision Magnification">Enhanced Senses</power>
+        <power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
+		<power select="Claws: DV 4P, AP -2">Natural Weapon</power>
+		<power rating="2">Fragile</power>
       </powers>
       <skills>
-        <skill rating="5">Flight</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="7">Flight</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>109</page>
+      <source>HS</source>
+      <page>71</page>
+    </metatype>
+	<metatype>
+      <id>3eff116a-7cf6-46ed-a497-8e0222646ff3</id>
+      <name>Shadowhound</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>4</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>4</bodaug>
+      <agimin>4</agimin>
+      <agimax>4</agimax>
+      <agiaug>4</agiaug>
+      <reamin>4</reamin>
+      <reamax>4</reamax>
+      <reaaug>4</reaaug>
+      <strmin>5</strmin>
+      <strmax>5</strmax>
+      <straug>5</straug>
+      <chamin>1</chamin>
+      <chamax>1</chamax>
+      <chaaug>1</chaaug>
+      <intmin>4</intmin>
+      <intmax>4</intmax>
+      <intaug>4</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>3</wilmax>
+      <wilaug>3</wilaug>
+      <inimin>2</inimin>
+      <inimax>14</inimax>
+      <iniaug>14</iniaug>
+      <edgmin>1</edgmin>
+      <edgmax>1</edgmax>
+      <edgaug>1</edgaug>
+      <magmin>4</magmin>
+      <magmax>7</magmax>
+      <magaug>7</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>3/1/0</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>7</max>
+          <aug>7</aug>
+          <val>4</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+      </bonus>
+      <powers>
+		<power rating="2">Armor</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Claws: DV 7P, AP 0">Natural Weapon</power>
+		<power>Shadow Cloak</power>
+		<power>Silence</power>
+		<power rating="2">Fragile</power>
+		<power select="Sunlight, Severe">Allergy</power>
+      </powers>
+      <skills>
+        <skill rating="5">Perception</skill>
+        <skill rating="7">Sneaking</skill>
+		<skill rating="5">Tracking</skill>
+        <skill rating="6">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>71</page>
     </metatype>
     <metatype>
       <id>cee50594-144e-499f-b029-578d33ce9e53</id>
@@ -18847,7 +19146,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>5/10</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>2/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -18861,19 +19165,102 @@
         </enabletab>
       </bonus>
       <powers>
-        <power rating="2">Armor (Ballistic)</power>
-        <power rating="4">Armor (Impact)</power>
+        <power rating="6">Armor</power>
         <power>Concealment</power>
-        <power select="Claws/Sting: DV 2P, AP -1">Natural Weapon</power>
+        <power select="Claws: DV 6P, AP -4">Natural Weapon</power>
+		<power select="Sting: DV 2P, AP -1">Natural Weapon</power>
         <power>Venom</power>
       </powers>
       <skills>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>111</page>
+      <source>HS</source>
+      <page>69</page>
+    </metatype>
+	<metatype>
+      <id>3ac65435-45f1-4d78-ad90-42fbd36b1a85</id>
+      <name>Baboon</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>5</bodmin>
+      <bodmax>5</bodmax>
+      <bodaug>5</bodaug>
+      <agimin>5</agimin>
+      <agimax>5</agimax>
+      <agiaug>5</agiaug>
+      <reamin>4</reamin>
+      <reamax>4</reamax>
+      <reaaug>4</reaaug>
+      <strmin>4</strmin>
+      <strmax>4</strmax>
+      <straug>4</straug>
+      <chamin>4</chamin>
+      <chamax>4</chamax>
+      <chaaug>4</chaaug>
+      <intmin>5</intmin>
+      <intmax>5</intmax>
+      <intaug>5</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>2</wilmax>
+      <wilaug>2</wilaug>
+      <inimin>3</inimin>
+      <inimax>14</inimax>
+      <iniaug>14</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>2</edgmax>
+      <edgaug>2</edgaug>
+      <magmin>4</magmin>
+      <magmax>7</magmax>
+      <magaug>7</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>3/0/4</run>
+		<sprint>1/1/2</sprint>
+      <bonus>
+		<addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>7</max>
+          <aug>7</aug>
+          <val>4</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+      </bonus>
+      <powers>
+		<power rating="2">Armor</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Levitate">Innate Spell</power>
+        <power select="Claws: DV 6P, AP -2">Natural Weapon</power>
+		<power rating="2">Fragile</power>
+      </powers>
+      <skills>
+        <skill rating="5">Gymnastics</skill>
+        <skill rating="8">Flight</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="3">Sneaking</skill>
+		<skill rating="4">Spellcasting</skill>
+		<skill rating="4">Tracking</skill>
+		<skill rating="4">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>69</page>
     </metatype>
     <metatype>
       <id>46903aff-a031-4885-8217-48799ab481f3</id>
@@ -19420,7 +19807,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 20/60</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -19434,17 +19826,16 @@
         </enabletab>
       </bonus>
       <powers>
-        <power rating="4">Armor (Ballistic)</power>
-        <power rating="4">Armor (Impact)</power>
-        <power select="Bite: DV 5P, AP 0">Natural Weapon</power>
+        <power rating="10">Armor</power>
+        <power select="Bite: DV 5P, AP -2">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Swimming</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="6">Swimming</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>116</page>
+      <source>HS</source>
+      <page>59</page>
     </metatype>
     <metatype>
       <id>b2a9d10c-f34d-41b9-9a41-aa4a03b7d80a</id>
@@ -19743,18 +20134,18 @@
       <name>Centaur</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>4</bodmin>
-      <bodmax>4</bodmax>
-      <bodaug>4</bodaug>
+      <bodmin>7</bodmin>
+      <bodmax>7</bodmax>
+      <bodaug>7</bodaug>
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
       <reamin>3</reamin>
       <reamax>3</reamax>
       <reaaug>3</reaaug>
-      <strmin>4</strmin>
-      <strmax>4</strmax>
-      <straug>4</straug>
+      <strmin>7</strmin>
+      <strmax>7</strmax>
+      <straug>7</straug>
       <chamin>3</chamin>
       <chamax>3</chamax>
       <chaaug>3</chaaug>
@@ -19773,60 +20164,68 @@
       <edgmin>1</edgmin>
       <edgmax>1</edgmax>
       <edgaug>1</edgaug>
-      <magmin>1</magmin>
-      <magmax>4</magmax>
-      <magaug>4</magaug>
+      <magmin>3</magmin>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>30/80</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>6/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
-          <max>4</max>
-          <aug>4</aug>
-          <val>1</val>
+          <max>6</max>
+          <aug>6</aug>
+          <val>3</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Low-Light Vision, Thermogrpahic Vision">Enhanced Senses</power>
+		<skill rating="4">Armor</skill>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermogrpahic Vision">Enhanced Senses</power>
+		<power select="Kick: DV 9P, AP +1, +1 Reach">Natural Weapon</power>
         <power>Magic Sense</power>
         <power>Sapience</power>
         <power>Search</power>
         <power>Uneducated</power>
       </powers>
       <skills>
-        <skill rating="3" spec="Tribal">Etiquette</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Running</skill>
-        <group rating="2">Close Combat</group>
-        <group rating="3">Outdoors</group>
+        <skill rating="4" spec="Tribal">Etiquette</skill>
+        <skill rating="3">Sneaking</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="7">Running</skill>
+        <group rating="4">Close Combat</group>
+        <group rating="4">Outdoors</group>
       </skills>
-      <source>RW</source>
-      <page>118</page>
+      <source>HS</source>
+      <page>56</page>
     </metatype>
     <metatype>
       <id>f023c6db-03f3-4dba-b7ee-7e64f71f7d5b</id>
       <name>Cockatrice</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
-      <bodmax>3</bodmax>
-      <bodaug>3</bodaug>
+      <bodmin>4</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>4</bodaug>
       <agimin>5</agimin>
       <agimax>5</agimax>
       <agiaug>5</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <reamin>4</reamin>
+      <reamax>4</reamax>
+      <reaaug>4</reaaug>
       <strmin>4</strmin>
       <strmax>4</strmax>
       <straug>4</straug>
@@ -19839,60 +20238,65 @@
       <logmin>2</logmin>
       <logmax>2</logmax>
       <logaug>2</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
       <inimin>2</inimin>
       <inimax>12</inimax>
       <iniaug>12</iniaug>
       <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
-      <magmin>4</magmin>
-      <magmax>7</magmax>
-      <magaug>7</magaug>
+      <edgmax>4</edgmax>
+      <edgaug>4</edgaug>
+      <magmin>5</magmin>
+      <magmax>8</magmax>
+      <magaug>8</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/70</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>8/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
-          <max>7</max>
-          <aug>7</aug>
-          <val>4</val>
+          <max>8</max>
+          <aug>8</aug>
+          <val>5</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
+		<power rating="1">Armor</power>
         <power select="Own Touch">Immunity</power>
-        <power select="Claws: DV 2P, AP 0">Natural Weapon</power>
+        <power select="Claws: DV (STR)P, AP -1">Natural Weapon</power>
         <power>Paralyzing Touch</power>
       </powers>
       <skills>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="4">Running</skill>
-        <skill rating="2">Shadowing</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="5">Sneaking</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="7">Running</skill>
+        <skill rating="7">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>118</page>
+      <source>SR5</source>
+      <page>404</page>
     </metatype>
     <metatype>
       <id>9030debc-e820-4c9d-89f2-472703308423</id>
       <name>Juggernaut</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>17</bodmin>
-      <bodmax>17</bodmax>
-      <bodaug>17</bodaug>
+      <bodmin>20</bodmin>
+      <bodmax>20</bodmax>
+      <bodaug>20</bodaug>
       <agimin>6</agimin>
       <agimax>6</agimax>
       <agiaug>6</agiaug>
@@ -19929,7 +20333,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/45</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>4/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -19941,24 +20350,28 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <initiativepass>1</initiativepass>
         <reach>4</reach>
       </bonus>
       <powers>
-        <power>Devouring</power>
-        <power select="Hearing, Smell, Motion Detection">Enhanced Senses</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Motion Detection">Enhanced Senses</power>
         <power>Fear</power>
-        <power rating="12">Hardened Armor</power>
-        <power select="Cold, Fire, Pathogens, Toxins">Immunity</power>
-        <power select="Claws: DV 24P, AP -3">Natural Weapon</power>
+        <power rating="18">Hardened Armor</power>
+        <power select="Cold">Immunity</power>
+		<power select="Fire">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
+        <power select="Claws: DV 42P, AP -4">Natural Weapon</power>
+		<power rating="12">Toughness</power>
       </powers>
       <skills>
-        <skill rating="2">Perception</skill>
-        <skill rating="5">Running</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="7">Running</skill>
         <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>120</page>
+      <source>HS</source>
+      <page>65</page>
     </metatype>
     <metatype>
       <id>d4ec0e18-8b55-452f-99bb-ca05cac73af8</id>
@@ -20004,7 +20417,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>40/90</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>4/0/4</run>
+		<sprint>6/1/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -20016,19 +20434,103 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <initiativepass>1</initiativepass>
       </bonus>
       <powers>
+		<power rating="4">Armor</power>
+		<power select="Wing Buffet: DV 7S, AP -2, Knockdown (4)">Natural Weapon</power>
+		<power select="Kick: DV 10S, AP 0">Natural Weapon</power>
         <power select="Fruit">Dietary Requirement</power>
+		<power rating="2">Fragile</power>
       </powers>
       <skills>
-        <skill rating="4">Flight</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Running</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="6">Flight</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="5">Running</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>120</page>
+      <source>HS</source>
+      <page>70</page>
+    </metatype>
+	<metatype>
+      <id>3a07d615-c6d3-414f-83f9-98dbe8b5686e</id>
+      <name>Peryton</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>8</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>5</agimin>
+      <agimax>5</agimax>
+      <agiaug>5</agiaug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>7</strmin>
+      <strmax>7</strmax>
+      <straug>7</straug>
+      <chamin>2</chamin>
+      <chamax>2</chamax>
+      <chaaug>2</chaaug>
+      <intmin>4</intmin>
+      <intmax>4</intmax>
+      <intaug>4</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
+      <inimin>4</inimin>
+      <inimax>16</inimax>
+      <iniaug>16</iniaug>
+      <edgmin>1</edgmin>
+      <edgmax>1</edgmax>
+      <edgaug>1</edgaug>
+      <magmin>4</magmin>
+      <magmax>7</magmax>
+      <magaug>7</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>4/0/4</run>
+		<sprint>5/1/2</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>7</max>
+          <aug>7</aug>
+          <val>4</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+		<reach>1</reach>
+      </bonus>
+      <powers>
+		<power>Accident</power>
+		<power rating="4">Armor</power>
+		<power select="Vision Magnification">Enhanced Senses</power>
+		<power select="Antlers: DV 8P, AP -2">Natural Weapon</power>
+		<power select="Kick: DV 10S, AP 0">Natural Weapon</power>
+		<power>Silence</power>
+		<power rating="2">Fragile</power>
+      </powers>
+      <skills>
+        <skill rating="5">Flight</skill>
+        <skill rating="8">Perception</skill>
+        <skill rating="5">Running</skill>
+        <skill rating="6">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>71</page>
     </metatype>
     <metatype>
       <id>801c78f7-aad7-4051-b6fe-f75c3881dd2d</id>
@@ -20044,12 +20546,12 @@
       <reamin>5</reamin>
       <reamax>5</reamax>
       <reaaug>5</reaaug>
-      <strmin>7</strmin>
-      <strmax>7</strmax>
-      <straug>7</straug>
-      <chamin>4</chamin>
-      <chamax>4</chamax>
-      <chaaug>4</chaaug>
+      <strmin>9</strmin>
+      <strmax>9</strmax>
+      <straug>9</straug>
+      <chamin>6</chamin>
+      <chamax>6</chamax>
+      <chaaug>6</chaaug>
       <intmin>4</intmin>
       <intmax>4</intmax>
       <intaug>4</intaug>
@@ -20074,7 +20576,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>25/120</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>6/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -20089,18 +20596,21 @@
         <reach>1</reach>
       </bonus>
       <powers>
+		<power rating="4">Armor</power>
         <power select="Pathogens">Immunity</power>
         <power>Magical Guard</power>
-        <power select="Horn: DV 5P, AP -1">Natural Weapon</power>
+        <power select="Horn: DV 7P, AP -4">Natural Weapon</power>
+		<power select="Kick: DV 10S, AP 0">Natural Weapon</power>
         <power select="Pollutants, Severe">Allergy</power>
       </powers>
       <skills>
-        <skill rating="6">Counterspelling</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="8">Counterspelling</skill>
+        <skill rating="6">Perception</skill>
+		<skill rating="6">Running</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>121</page>
+      <source>HS</source>
+      <page>76</page>
     </metatype>
     <metatype>
       <id>0ad727a5-43ad-40e5-bcdb-a20e224e40a1</id>
@@ -20403,21 +20913,21 @@
       <reamin>4</reamin>
       <reamax>4</reamax>
       <reaaug>4</reaaug>
-      <strmin>20</strmin>
-      <strmax>20</strmax>
-      <straug>20</straug>
-      <chamin>4</chamin>
-      <chamax>4</chamax>
-      <chaaug>4</chaaug>
+      <strmin>30</strmin>
+      <strmax>30</strmax>
+      <straug>30</straug>
+      <chamin>5</chamin>
+      <chamax>5</chamax>
+      <chaaug>5</chaaug>
       <intmin>4</intmin>
       <intmax>4</intmax>
       <intaug>4</intaug>
       <logmin>3</logmin>
       <logmax>3</logmax>
       <logaug>3</logaug>
-      <wilmin>5</wilmin>
-      <wilmax>5</wilmax>
-      <wilaug>5</wilaug>
+      <wilmin>8</wilmin>
+      <wilmax>8</wilmax>
+      <wilaug>8</wilaug>
       <inimin>2</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
@@ -20433,7 +20943,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 20/40</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/2/0</walk>
+		<run>4/4/0</run>
+		<sprint>2/2/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -20448,6 +20963,7 @@
       </bonus>
       <powers>
         <power>Animal Control</power>
+		<power rating="20">Armor</power>
         <power>Compulsion</power>
         <power>Engulf</power>
         <power select="Sonar">Enhanced Senses</power>
@@ -20456,21 +20972,21 @@
         <power>Influence</power>
         <power>Magic Sense</power>
         <power>Mind Link</power>
-        <power select="Breach: DV 9P, AP 0">Natural Weapon</power>
+        <power select="Breach: DV 30P, AP +4">Natural Weapon</power>
         <power>Search</power>
         <power>Sapience</power>
         <power>Sonic Projection</power>
-        <power select="Krill">Dietary Requirement</power>
+		<power rating="10">Toughness</power>
         <power>Uneducated</power>
       </powers>
       <skills>
-        <skill rating="4">Exotic Ranged Weapon</skill>
-        <skill rating="5">Perception</skill>
-        <skill rating="4">Swimming</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="6" spec="Sonic Projection">Exotic Ranged Weapon</skill>
+        <skill rating="7">Perception</skill>
+        <skill rating="6">Swimming</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>123</page>
+      <source>HS</source>
+      <page>66</page>
     </metatype>
     <metatype>
       <id>a83d0697-da9a-4858-b15e-25c443d75507</id>
@@ -21089,7 +21605,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>3/10</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -21104,21 +21625,24 @@
       </bonus>
       <powers>
         <power>Adaptive Coloration</power>
+		<power rating="3">Armor</power>
         <power>Binding</power>
-        <power select="Touch, 360-Degree Vision">Enhanced Senses</power>
+        <power select="Touch">Enhanced Senses</power>
+		<power select="360-Degree Vision">Enhanced Senses</power>
         <power select="Toxins">Immunity</power>
-        <power select="Bite: DV 3P, AP 0">Natural Weapon</power>
-        <power select="Hearing, Smell">Reduced Senses</power>
+		<power select="Tongue: DV 3S, 0">Natural Weapon</power>
+        <power select="Bite: DV 12P, AP -2">Natural Weapon</power>
+        <power select="Hearing">Reduced Senses</power>
+		<power select="Smell">Reduced Senses</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Shadowing</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="4">Gymnastics</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="6">Shadowing</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>129</page>
+      <source>HS</source>
+      <page>62</page>
     </metatype>
     <metatype>
       <id>b3c3df86-17d8-4199-8ad6-478f0aafc39e</id>
@@ -21810,7 +22334,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/20</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -21827,17 +22356,18 @@
         <power>Concealment</power>
         <power select="Thermographic Vision">Enhanced Senses</power>
         <power>Sapience</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
         <power>Uneducated</power>
       </powers>
       <skills>
-        <skill rating="4">Climbing</skill>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="2">Throwing Weapons</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="3">Clubs</skill>
+		<skill rating="6">Gymnastics</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="4">Throwing Weapons</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>134</page>
+      <source>HS</source>
+      <page>75</page>
     </metatype>
     <metatype>
       <id>84245cb3-99e0-40e0-b6bf-d93c82662bc7</id>
@@ -21956,7 +22486,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/50</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -21971,25 +22506,189 @@
         <initiativepass>2</initiativepass>
       </bonus>
       <powers>
+		<skill rating="4">Armor</skill>
         <power>Concealment</power>
         <power>Corrosive Spit</power>
-        <power select="Hearing, Low-Light Vision, Smell, Thermographic Vision">Enhanced Senses</power>
-        <power select="Cold, Fire">Immunity</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power>Fear</power>
+        <power select="Cold">Immunity</power>
+		<power select="Fire">Immunity</power>
         <power>Movement</power>
-        <power select="Bite: DV 4P, AP 0">Natural Weapon</power>
+        <power select="Bite: DV 6P, AP 0">Natural Weapon</power>
+		<power>Search</power>
+		<skill rating="6">Toughness</skill>
       </powers>
       <skills>
-        <skill rating="2">Exotic Ranged Weapon</skill>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="3">Intimidatino</skill>
-        <skill rating="6">Perception</skill>
-        <skill rating="4">Running</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="4">Tracking</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="5">Intimidation</skill>
+        <skill rating="8">Perception</skill>
+        <skill rating="6">Running</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="8">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>135</page>
+      <source>HS</source>
+      <page>56</page>
+    </metatype>
+	<metatype>
+      <id>03895c53-e254-4ae3-bf2f-38e6a1978b69</id>
+      <name>Deathrattle</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>3</bodmin>
+      <bodmax>3</bodmax>
+      <bodaug>3</bodaug>
+      <agimin>6</agimin>
+      <agimax>6</agimax>
+      <agiaug>6</agiaug>
+      <reamin>8</reamin>
+      <reamax>8</reamax>
+      <reaaug>8</reaaug>
+      <strmin>4</strmin>
+      <strmax>4</strmax>
+      <straug>4</straug>
+      <chamin>2</chamin>
+      <chamax>2</chamax>
+      <chaaug>2</chaaug>
+      <intmin>5</intmin>
+      <intmax>5</intmax>
+      <intaug>5</intaug>
+      <logmin>1</logmin>
+      <logmax>1</logmax>
+      <logaug>1</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>2</wilmax>
+      <wilaug>2</wilaug>
+      <inimin>5</inimin>
+      <inimax>17</inimax>
+      <iniaug>17</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>2</edgmax>
+      <edgaug>2</edgaug>
+      <magmin>4</magmin>
+      <magmax>7</magmax>
+      <magaug>7</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>2/0/0</run>
+		<sprint>1/1/0</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>7</max>
+          <aug>7</aug>
+          <val>4</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+        <initiativepass>2</initiativepass>
+      </bonus>
+      <powers>
+		<skill rating="6">Armor</skill>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+        <power select="Pain">Immunity</power>
+		<power select="Toxins">Immunity</power>
+        <power select="Bite: DV 5P, AP -1">Natural Weapon</power>
+		<power>Venom</power>
+      </powers>
+      <skills>
+		<skill rating="5" spec="Venom Spit">Exotic Ranged Weapon</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="3">Swimming</skill>
+        <skill rating="3">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>57</page>
+    </metatype>
+	<metatype>
+      <id>fc743502-3f80-49d8-ab8c-1f17eb341acd</id>
+      <name>Deathspiral Butterfly</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>1</bodmin>
+      <bodmax>1</bodmax>
+      <bodaug>1</bodaug>
+      <agimin>4</agimin>
+      <agimax>4</agimax>
+      <agiaug>4</agiaug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>1</strmin>
+      <strmax>1</strmax>
+      <straug>1</straug>
+      <chamin>6</chamin>
+      <chamax>6</chamax>
+      <chaaug>6</chaaug>
+      <intmin>4</intmin>
+      <intmax>4</intmax>
+      <intaug>4</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
+      <inimin>5</inimin>
+      <inimax>17</inimax>
+      <iniaug>17</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>2</edgmax>
+      <edgaug>2</edgaug>
+      <magmin>6</magmin>
+      <magmax>9</magmax>
+      <magaug>9</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>1/0/3</run>
+		<sprint>1/1/1</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>9</max>
+          <aug>9</aug>
+          <val>6</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+      </bonus>
+      <powers>
+		<power select="Smell">Enhanced Senses</power>
+        <power select="Proboscis: DV 2P, AP -4">Natural Weapon</power>
+		<power>Venom</power>
+		<skill rating="7">Fragile</skill>
+      </powers>
+      <skills>
+        <skill rating="3">Flight</skill>
+        <skill rating="3">Perception</skill>
+        <skill rating="3">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>58</page>
     </metatype>
     <metatype>
       <id>612b5631-21d0-4bcb-8f73-78425a1950eb</id>
@@ -22149,9 +22848,9 @@
       <bodmin>13</bodmin>
       <bodmax>13</bodmax>
       <bodaug>13</bodaug>
-      <agimin>6</agimin>
-      <agimax>6</agimax>
-      <agiaug>6</agiaug>
+      <agimin>4</agimin>
+      <agimax>4</agimax>
+      <agiaug>4</agiaug>
       <reamin>4</reamin>
       <reamax>4</reamax>
       <reaaug>4</reaaug>
@@ -22185,7 +22884,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>25/45</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>8/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -22197,27 +22901,28 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <initiativepass>1</initiativepass>
         <reach>2</reach>
       </bonus>
       <powers>
-        <power rating="4">Armor (Ballistic)</power>
-        <power rating="6">Armor (Impact)</power>
+        <power rating="10">Armor</power>
         <power>Dual Natured</power>
         <power select="Smell">Enhanced Senses</power>
-        <power select="Claws/Bite: DV 7P, AP 0">Natural Weapon</power>
+		<power>Influence</power>
+        <power select="Claws/Bite: DV 13P or 13S, AP -2">Natural Weapon</power>
+		<power rating="3">Toughness</power>
+		<power select="Sight">Reduced Senses</power>
       </powers>
       <skills>
-        <skill rating="4">Astral Combat</skill>
-        <skill rating="2">Climbing</skill>
-        <skill rating="4">Intimidation</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="2">Running</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="5">Unarmed Combat</skill>
+        <skill rating="5">Astral Combat</skill>
+        <skill rating="3">Gymnastics</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="3">Running</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>136</page>
+      <source>HS</source>
+      <page>64</page>
     </metatype>
     <metatype>
       <id>93b8a9b5-efd4-40a3-8bdb-7d803dbf9fd2</id>
@@ -22439,12 +23144,12 @@
       <bodmin>2</bodmin>
       <bodmax>2</bodmax>
       <bodaug>2</bodaug>
-      <agimin>5</agimin>
-      <agimax>5</agimax>
-      <agiaug>5</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
+      <agimin>7</agimin>
+      <agimax>7</agimax>
+      <agiaug>7</agiaug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
       <strmin>2</strmin>
       <strmax>2</strmax>
       <straug>2</straug>
@@ -22475,7 +23180,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>3/10</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>2/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -22489,20 +23199,102 @@
         </enabletab>
       </bonus>
       <powers>
-        <power select="Low-Light Vision, Smell">Enhanced Senses</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power select="Cold">Immunity</power>
         <power select="Bite: DV 3P, AP +1">Natural Weapon</power>
         <power>Venom</power>
         <power select="Fire">Vulnerability</power>
       </powers>
       <skills>
-        <skill rating="4">Infiltration</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="5">Sneaking</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="5">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>71</page>
+    </metatype>
+	<metatype>
+      <id>00506308-3ec9-469b-8aee-9c0b26f99988</id>
+      <name>Spider Beast</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>2</bodmin>
+      <bodmax>2</bodmax>
+      <bodaug>2</bodaug>
+      <agimin>4</agimin>
+      <agimax>4</agimax>
+      <agiaug>4</agiaug>
+      <reamin>4</reamin>
+      <reamax>4</reamax>
+      <reaaug>4</reaaug>
+      <strmin>2</strmin>
+      <strmax>2</strmax>
+      <straug>2</straug>
+      <chamin>1</chamin>
+      <chamax>1</chamax>
+      <chaaug>1</chaaug>
+      <intmin>3</intmin>
+      <intmax>3</intmax>
+      <intaug>3</intaug>
+      <logmin>1</logmin>
+      <logmax>1</logmax>
+      <logaug>1</logaug>
+      <wilmin>3</wilmin>
+      <wilmax>3</wilmax>
+      <wilaug>3</wilaug>
+      <inimin>2</inimin>
+      <inimax>14</inimax>
+      <iniaug>14</iniaug>
+      <edgmin>1</edgmin>
+      <edgmax>1</edgmax>
+      <edgaug>1</edgaug>
+      <magmin>6</magmin>
+      <magmax>9</magmax>
+      <magaug>9</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>1/1/0</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>3</min>
+          <max>9</max>
+          <aug>9</aug>
+          <val>6</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+		<initiativepass>2</initiativepass>
+      </bonus>
+      <powers>
+		<power rating="4">Armor</power>
+        <power select="Tactile">Enhanced Senses</power>
+        <power select="Bite: DV 3P, AP 0">Natural Weapon</power>
+		<power select="Spider Silk">Secretion/Substance Extrusion</power>
+        <power>Venom</power>
+        <power>Wall Walking</power>
+      </powers>
+      <skills>
+        <skill rating="4">Gymnastics</skill>
         <skill rating="3">Perception</skill>
-        <skill rating="2">Tracking</skill>
+        <skill rating="6">Sneaking</skill>
         <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>139</page>
+      <source>HS</source>
+      <page>73</page>
     </metatype>
     <metatype>
       <id>cbb3ef3f-1857-4c6f-9383-80fe675d341f</id>
@@ -22609,9 +23401,9 @@
       <inimin>2</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
-      <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <edgmin>4</edgmin>
+      <edgmax>4</edgmax>
+      <edgaug>4</edgaug>
       <magmin>0</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
@@ -22621,36 +23413,45 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>5/20</movement>
+      <depmin>0</depmin>
+	  <depmax>0</depmax>
+	  <depaug>0</depaug>
+	  <walk>2/1/0</walk>
+	  <run>4/0/0</run>
+	  <sprint>1/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
-        <power select="Claws: DV 2P, AP 0">Natural Weapon</power>
+		<power>Brachiation</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+        <power select="Claws: DV 3P, AP 0">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="4">Climbing</skill>
-        <skill rating="3">Infiltration</skill>
+		<skill rating="2">Blades</skill>
+		<skill rating="3">Clubs</skill>
+        <skill rating="3" spec="Underground">Navigation</skill>
+        <skill rating="5">Sneaking</skill>
         <skill rating="2">Perception</skill>
-        <skill rating="2">Shadowing</skill>
+        <skill rating="2">Running</skill>
         <skill rating="3">Throwing Weapons</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>140</page>
+      <source>HS</source>
+      <page>53</page>
     </metatype>
     <metatype>
       <id>49434a88-ced1-46e3-b650-b0bd12ddd480</id>
       <name>Basilisk</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>4</bodmin>
-      <bodmax>4</bodmax>
-      <bodaug>4</bodaug>
+      <bodmin>6</bodmin>
+      <bodmax>6</bodmax>
+      <bodaug>6</bodaug>
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
@@ -22669,16 +23470,16 @@
       <logmin>1</logmin>
       <logmax>1</logmax>
       <logaug>1</logaug>
-      <wilmin>2</wilmin>
-      <wilmax>2</wilmax>
-      <wilaug>2</wilaug>
+      <wilmin>5</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>5</wilaug>
       <inimin>2</inimin>
       <inimax>12</inimax>
       <iniaug>12</iniaug>
       <edgmin>1</edgmin>
       <edgmax>1</edgmax>
       <edgaug>1</edgaug>
-      <magmin>3</magmin>
+      <magmin>4</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -22687,34 +23488,39 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>4/40, Swim 4/25</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/2/0</walk>
+		<run>5/8/0</run>
+		<sprint>1/2/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
           <max>6</max>
           <aug>6</aug>
-          <val>3</val>
+          <val>4</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power rating="3">Armor (Ballistic)</power>
-        <power rating="4">Armor (Impact)</power>
+        <power rating="7">Armor</power>
+        <power select="Bite: DV 8P, AP -2">Natural Weapon</power>
         <power>Petrification</power>
         <power select="Own Gaze">Vulnerability</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Shadowing</skill>
-        <skill rating="4">Swimming</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="3">Sneaking</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="2">Running</skill>
+        <skill rating="8">Swimming</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>140</page>
+      <source>SR5</source>
+      <page>404</page>
     </metatype>
     <metatype>
       <id>a545e6f7-1737-4561-8ec1-67c595b8b368</id>
@@ -22795,9 +23601,9 @@
       <name>Black Annis</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>7</bodmin>
-      <bodmax>7</bodmax>
-      <bodaug>7</bodaug>
+      <bodmin>8</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>8</bodaug>
       <agimin>4</agimin>
       <agimax>4</agimax>
       <agiaug>4</agiaug>
@@ -22834,7 +23640,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>20/40</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -22849,22 +23660,108 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
+		<power rating="4">Armor</power>
+		<power rating="3">Toughness</power>
         <power select="Low-Light Vision">Enhanced Senses</power>
         <power>Fear</power>
-        <power select="Claws/Bite: DV 6P, AP 0">Natural Weapon</power>
+        <power select="Claws/Bite: DV 9P, AP 0">Natural Weapon</power>
         <power select="Sunlight, Mild">Allergy</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="3">Intimidation</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Running</skill>
-        <skill rating="2">Shadowing</skill>
+        <skill rating="4">Gymnastics</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Intimidation</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="5">Running</skill>
+        <skill rating="7">Unarmed Combat</skill>
+      </skills>
+      <source>HS</source>
+      <page>55</page>
+    </metatype>
+	<metatype>
+      <id>f96a3ea0-27be-45a3-b0ed-4cc06241fe96</id>
+      <name>Blood Monkey</name>
+      <category>Paranormal Critters</category>
+      <karma>0</karma>
+      <bodmin>3</bodmin>
+      <bodmax>3</bodmax>
+      <bodaug>3</bodaug>
+      <agimin>5</agimin>
+      <agimax>5</agimax>
+      <agiaug>5</agiaug>
+      <reamin>3</reamin>
+      <reamax>3</reamax>
+      <reaaug>3</reaaug>
+      <strmin>4</strmin>
+      <strmax>4</strmax>
+      <straug>4</straug>
+      <chamin>3</chamin>
+      <chamax>3</chamax>
+      <chaaug>3</chaaug>
+      <intmin>2</intmin>
+      <intmax>2</intmax>
+      <intaug>2</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
+      <wilmin>4</wilmin>
+      <wilmax>4</wilmax>
+      <wilaug>4</wilaug>
+      <inimin>3</inimin>
+      <inimax>14</inimax>
+      <iniaug>14</iniaug>
+      <edgmin>2</edgmin>
+      <edgmax>2</edgmax>
+      <edgaug>2</edgaug>
+      <magmin>5</magmin>
+      <magmax>8</magmax>
+      <magaug>8</magaug>
+      <resmin>0</resmin>
+      <resmax>6</resmax>
+      <resaug>6</resaug>
+      <essmin>0</essmin>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>2/0/0</run>
+		<sprint>1/1/0</sprint>
+      <bonus>
+        <addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>7</max>
+          <aug>7</aug>
+          <val>5</val>
+        </addattribute>
+        <enabletab>
+          <name>critter</name>
+        </enabletab>
+        <initiativepass>1</initiativepass>
+      </bonus>
+      <powers>
+		<power rating="2">Armor</power>
+		<power>Brachiation</power>
+		<power>Confusion</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell [Blood]">Enhanced Senses</power>
+        <power select="Claw: DV 6P, AP -2">Natural Weapon</power>
+		<power>Paralyzing Touch</power>
+		<power select="Anti-coagulant">Secretion/Substance Extrusion</power>
+		<power>Wall Walking</power>
+		<power select="Blood">Dietary Requirement</power>
+		<power rating="2">Fragile</power>
+      </powers>
+      <skills>
+        <skill rating="8">Gymnastics</skill>
+        <skill rating="4" spec="Smell">Tracking</skill>
+        <skill rating="5">Perception</skill>
         <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>141</page>
+      <source>HS</source>
+      <page>55</page>
     </metatype>
     <metatype>
       <id>cfec804f-d0e2-4310-880c-c22deaae68a3</id>
@@ -23065,7 +23962,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>15/60</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -23080,22 +23982,25 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
+		<power rating="6">Armor</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
         <power>Fear</power>
         <power>Magical Guard</power>
-        <power select="Claws/Bite: DV 6P, AP +1">Natural Weapon</power>
+        <power select="Bite/Claws: DV 10P, AP 0">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="3">Counterspelling</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Intimidation</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Shadowing</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="5">Counterspelling</skill>
+        <skill rating="4">Intimidation</skill>
+        <skill rating="5">Perception</skill>
+		<skill rating="5">Running</skill>
+        <skill rating="5">Sneaking</skill>
+        <skill rating="5">Tracking</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>143</page>
+      <source>HS</source>
+      <page>61</page>
     </metatype>
     <metatype>
       <id>7693ea54-f333-47c1-bf19-88b1bd00320f</id>
@@ -23414,7 +24319,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/60</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/2</walk>
+		<run>3/0/5</run>
+		<sprint>2/1/2</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -23422,21 +24332,22 @@
         <reach>1</reach>
       </bonus>
       <powers>
+		<power rating="6">Armor</power>
         <power select="Low-Light Vision">Enhanced Senses</power>
-        <power select="Claws/Bite: DV 6P, AP 0">Natural Weapon</power>
+        <power select="Bite/Claws: DV 8P, AP -2">Natural Weapon</power>
         <power>Venom</power>
         <power select="Pollution, Mild">Allergy</power>
       </powers>
       <skills>
-        <skill rating="3">Climbing</skill>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Shadowing</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="5">Unarmed Combat</skill>
+        <skill rating="4">Flight</skill>
+        <skill rating="5">Gymnastics</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="5">Sneaking</skill>
+        <skill rating="5">Tracking</skill>
+        <skill rating="7">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>145</page>
+      <source>HS</source>
+      <page>65</page>
     </metatype>
     <metatype>
       <id>85b76ff5-a35d-47e1-a7c0-faf28d24e792</id>
@@ -23658,7 +24569,7 @@
     </metatype>
     <metatype>
       <id>32deb02a-893f-45ae-9f9e-57e1d6e816fc</id>
-      <name>Phoenix</name>
+      <name>Phoenician Birds</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
       <bodmin>3</bodmin>
@@ -23700,7 +24611,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 25/60</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/3</walk>
+		<run>2/0/6</run>
+		<sprint>1/1/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -23714,16 +24630,24 @@
         </enabletab>
       </bonus>
       <powers>
-        <power>Energy Aura</power>
+        <power select="Fire">Elemental Attack</power>
+		<power>Energy Aura</power>
+		<power>Engulf</power>
         <power select="Vision Enhancement">Enhanced Senses</power>
+		<power select="Fire">Immunity</power>
+		<power select="Claws: DV 5P, AP -2">Natural Weapon</power>
+		<power rating="2">Fragile</power>
       </powers>
+	  <optionalpowers>
+		<power select="Flammable Oils">Secretion/Substance Extrusion</power>
+	  </optionalpowers>
       <skills>
-        <skill rating="3">Flight</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="5">Flight</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>147</page>
+      <source>HS</source>
+      <page>70</page>
     </metatype>
     <metatype>
       <id>dec64aa9-d4c0-4c19-9c3c-0cb51f2e5d1e</id>
@@ -23769,31 +24693,39 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/35</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <initiativepass>2</initiativepass>
         <reach>1</reach>
       </bonus>
       <powers>
-        <power rating="3">Armor (Ballistic)</power>
-        <power rating="5">Armor (Impact)</power>
-        <power select="Thermographic Vision, Wide-Band Hearing">Enhanced Senses</power>
-        <power select="Claws/Bite: DV 10P, AP -2">Natural Weapon</power>
+        <power rating="12">Armor</power>
+        <power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Wide-Band Hearing">Enhanced Senses</power>
+        <power select="Claws/Bite: DV 12P, AP -2">Natural Weapon</power>
+		<power rating="3">Toughness</power>
         <power select="Sunlight, Mild">Allergy</power>
       </powers>
+	  <optionalpowers>
+		<power>Fear</power>
+		<power>Paralyzing Howl</power>
+	  </optionalpowers>
       <skills>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="3">Intimidation</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="2">Shadowing</skill>
-        <skill rating="4">Tracking</skill>
-        <skill rating="5">Unarmed Combat</skill>
+        <skill rating="8">Intimidation</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="5">Tracking</skill>
+        <skill rating="7">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>147</page>
+      <source>HS</source>
+      <page>71</page>
     </metatype>
     <metatype>
       <id>fccb31e0-9c58-4434-bdac-57323ce51d2f</id>
@@ -24020,18 +24952,18 @@
       <name>Volleying Porcupine</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>1</bodmin>
-      <bodmax>1</bodmax>
-      <bodaug>1</bodaug>
+      <bodmin>2</bodmin>
+      <bodmax>2</bodmax>
+      <bodaug>2</bodaug>
       <agimin>4</agimin>
       <agimax>4</agimax>
       <agiaug>4</agiaug>
       <reamin>2</reamin>
       <reamax>2</reamax>
       <reaaug>2</reaaug>
-      <strmin>1</strmin>
-      <strmax>1</strmax>
-      <straug>1</straug>
+      <strmin>2</strmin>
+      <strmax>2</strmax>
+      <straug>2</straug>
       <chamin>2</chamin>
       <chamax>2</chamax>
       <chaaug>2</chaaug>
@@ -24059,7 +24991,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/18</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -24073,20 +25010,24 @@
         </enabletab>
       </bonus>
       <powers>
+		<power rating="1">Armor</power>
         <power select="Low-Light Vision">Enhanced Senses</power>
         <power select="Quill: DV 3P, AP -2, Ranged">Natural Weapon</power>
         <power select="Bite: DV 2P, AP 0">Natural Weapon</power>
         <power>Noxious Breath</power>
         <power select="Salt">Dietary Requirement</power>
       </powers>
+	  <optionalpowers>
+		<power>Venom</power>
+	  </optionalpowers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="4" spec="Quills">Exotic Ranged Weapon</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="5">Gymnastics</skill>
+        <skill rating="5">Perception</skill>
+		<skill rating="5">Sneaking</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>150</page>
+      <source>HS</source>
+      <page>76</page>
     </metatype>
     <metatype>
       <id>2ae8f1a0-a801-4bff-91b1-be7cfda4ad75</id>
@@ -24205,7 +25146,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/50</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -24213,21 +25159,20 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power rating="1">Armor (Ballistic)</power>
-        <power rating="3">Armor (Impact)</power>
+        <power rating="6">Armor</power>
+        <power>Animal Control</power>
         <power select="Smell">Enhanced Senses</power>
-        <power select="Claws/Bite: DV 7P, AP 0">Natural Weapon</power>
+        <power select="Claws: DV 8P, AP 0">Natural Weapon</power>
         <power select="Vision">Reduced Senses</power>
       </powers>
       <skills>
-        <skill rating="1">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="2">Shadowing</skill>
-        <skill rating="5">Tracking</skill>
-        <skill rating="6">Unarmed Combat</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="6">Tracking</skill>
+        <skill rating="8">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>151</page>
+      <source>HS</source>
+      <page>77</page>
     </metatype>
     <metatype>
       <id>dcc973b7-db4f-4f48-8170-61bdb104a3f9</id>
@@ -24352,23 +25297,31 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>3/20</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power rating="1">Armor</power>
       </powers>
       <skills>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="2">Locksmith</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="1">Unarmed Combat</skill>
+        <skill rating="5">Sneaking</skill>
+        <skill rating="5">Locksmith</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>151</page>
+      <source>HS</source>
+      <page>54</page>
     </metatype>
     <metatype>
       <id>169c2d6b-32dd-47a5-bdee-070539edafb4</id>
@@ -24497,7 +25450,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>10/18</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>3/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -24509,27 +25467,35 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
         <reach>-1</reach>
       </bonus>
       <powers>
-        <power>Gestalt Consciousness</power>
         <power>Animal Control</power>
+		<power rating="2">Armor</power>
         <power>Concealment</power>
         <power>Corrosive Spit</power>
-        <power select="Pathogens, Toxins">Immunity</power>
-        <power select="Bite: DV 4P, AP +1">Natural Weapon</power>
-        <power>Noxious Breath</power>
-        <power select="Salt">Dietary Requirement</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power>Gestalt Consciousness</power>
+        <power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
+        <power select="Claws: DV 5P, AP +1">Natural Weapon</power>
+        <power select="Sunlight, Moderate">Allergy</power>
       </powers>
+	  <optionalpowers>
+		<power>Pestilence</power>
+        <power>Regeneration</power>
+		<power select="Electricity">Elemental Attack</power>
+	  </optionalpowers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="3" spec="Corrosive Spit">Exotic Ranged Weapon</skill>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Gymnastics</skill>
+        <skill rating="5" spec="Corrosive Spit">Exotic Ranged Weapon</skill>
+        <skill rating="3">Running</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>152</page>
+      <source>HS</source>
+      <page>59</page>
     </metatype>
     <metatype>
       <id>ee0f69b3-318e-4427-8f81-185266edba1f</id>
@@ -24654,7 +25620,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Fly 10/50</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/2</walk>
+		<run>3/0/4</run>
+		<sprint>2/1/2</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -24669,23 +25640,23 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
+		<power rating="15">Armor</power>
         <power>Concealment</power>
         <power select="Low-Light Vision">Enhanced Senses</power>
-        <power rating="10">Hardened Armor</power>
-        <power select="Claws/Bite: DV 9P, AP -1">Natural Weapon</power>
+        <power select="Bite/Claws: DV 10P, AP -2">Natural Weapon</power>
         <power>Noxious Breath</power>
+		<power rating="3">Toughness</power>
         <power select="Sunlight, Mild">Allergy</power>
         <power select="Iron">Vulnerability</power>
       </powers>
       <skills>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="3">Flight</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="5">Flight</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>153</page>
+      <source>HS</source>
+      <page>61</page>
     </metatype>
     <metatype>
       <id>f6d96f90-9d7d-4d56-9c5e-b943ea387192</id>
@@ -25100,7 +26071,12 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 20/45</movement>
+	  <depmin>0</depmin>
+      <depmax>0</depmax>
+      <depaug>0</depaug>
+      <walk>1/1/0</walk>
+	  <run>2/0/0</run>
+	  <sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -25115,29 +26091,30 @@
       </bonus>
       <powers>
         <power>Engulf</power>
-        <power select="Low-Light Vision, Smell">Enhanced Senses</power>
-        <power rating="7">Hardened Armor</power>
-        <power select="Bite: DV 5P, AP -2">Natural Weapon</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+        <power rating="10">Hardened Armor</power>
+        <power select="Bite: DV 8P, AP -2">Natural Weapon</power>
         <power>Search</power>
       </powers>
       <skills>
-        <skill rating="2">Intimidation</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Swimming</skill>
-        <skill rating="3">Tracking</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="4">Intimidation</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="4">Running</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="8">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>157</page>
+      <source>HS</source>
+      <page>53</page>
     </metatype>
     <metatype>
       <id>e99da2ee-d25b-4406-991d-bd66a061d101</id>
       <name>Behemoth</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>10</bodmin>
-      <bodmax>10</bodmax>
-      <bodaug>10</bodaug>
+      <bodmin>14</bodmin>
+      <bodmax>14</bodmax>
+      <bodaug>14</bodaug>
       <agimin>4</agimin>
       <agimax>4</agimax>
       <agiaug>4</agiaug>
@@ -25174,24 +26151,30 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 15/45</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power rating="10">Hardened Armor</power>
-        <power select="Bite: DV 14P, AP -2">Natural Weapon</power>
+        <power rating="15">Hardened Armor</power>
+		<power rating="4">Toughness</power>
+        <power select="Bite: DV 21P, AP -2">Natural Weapon</power>
       </powers>
       <skills>
-        <skill rating="3">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="3">Swimming</skill>
-        <skill rating="5">Unarmed Combat</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="5">Swimming</skill>
+        <skill rating="7">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>157</page>
+      <source>HS</source>
+      <page>54</page>
     </metatype>
     <metatype>
       <id>72fe10fb-83e8-413a-95b0-60fa6a00375f</id>
@@ -32562,9 +33545,9 @@
       <name>Eastern Dragon</name>
       <category>Dracoforms</category>
       <karma>0</karma>
-      <bodmin>14</bodmin>
-      <bodmax>14</bodmax>
-      <bodaug>14</bodaug>
+      <bodmin>17</bodmin>
+      <bodmax>17</bodmax>
+      <bodaug>17</bodaug>
       <agimin>8</agimin>
       <agimax>8</agimax>
       <agiaug>8</agiaug>
@@ -32583,25 +33566,30 @@
       <logmin>10</logmin>
       <logmax>10</logmax>
       <logaug>10</logaug>
-      <wilmin>8</wilmin>
-      <wilmax>8</wilmax>
-      <wilaug>8</wilaug>
+      <wilmin>9</wilmin>
+      <wilmax>9</wilmax>
+      <wilaug>9</wilaug>
       <inimin>10</inimin>
       <inimax>22</inimax>
       <iniaug>22</iniaug>
       <edgmin>6</edgmin>
-      <edgmax>6</edgmax>
-      <edgaug>6</edgaug>
-      <magmin>6+1D6</magmin>
-      <magmax>6+1D6</magmax>
-      <magaug>6+1D6</magaug>
+      <edgmax>9</edgmax>
+      <edgaug>9</edgaug>
+      <magmin>10</magmin>
+      <magmax>13</magmax>
+      <magaug>13</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>6+1D6</essmax>
-      <essaug>6+1D6</essaug>
-      <movement>15/50, Fly 30/100</movement>
+      <essmax>10</essmax>
+      <essaug>10</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/3</walk>
+		<run>4/0/7</run>
+		<sprint>4/1/6</sprint>
       <qualities>
         <positive>
           <quality>Magician</quality>
@@ -32611,9 +33599,9 @@
         <addattribute>
           <name>MAG</name>
           <min>7</min>
-          <max>12</max>
-          <aug>12</aug>
-          <val>7</val>
+          <max>13</max>
+          <aug>13</aug>
+          <val>10</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
@@ -32625,10 +33613,13 @@
         <power>Dragonspeech</power>
         <power>Dual Natured</power>
         <power select="Fire">Elemental Attack</power>
-        <power select="Smell, Low-Light Vision, Thermographic Vision, Wide-Band Hearing">Enhanced Senses</power>
-        <power rating="8">Hardened Armor</power>
-        <power rating="8">Mystic Armor</power>
-        <power select="Bite/Claws: DV 10P, AP -2">Natural Weapon</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Wide-Band Hearing">Enhanced Senses</power>
+        <power rating="17">Hardened Armor</power>
+        <power rating="9">Mystic Armor</power>
+        <power select="Bite/Claws: DV (STR+2)P, AP -4">Natural Weapon</power>
         <power>Sapience</power>
         <power>Animal Control</power>
         <power>Compulsion</power>
@@ -32639,62 +33630,68 @@
         <power>Venom</power>
       </powers>
       <skills>
-        <skill rating="8">Assensing</skill>
-        <skill rating="6">Exotic Ranged Weapon</skill>
-        <skill rating="6">Flight</skill>
-        <skill rating="6">Perception</skill>
-        <skill rating="6">Unarmed Combat</skill>
-        <group rating="6">Conjuring</group>
-        <group rating="8">Sorcery</group>
+        <skill rating="14">Assensing</skill>
+        <skill rating="12">Exotic Ranged Weapon</skill>
+        <skill rating="12">Flight</skill>
+		<skill rating="10">Running</skill>
+        <skill rating="12">Perception</skill>
+        <skill rating="12">Unarmed Combat</skill>
+        <group rating="12">Conjuring</group>
+        <group rating="14">Sorcery</group>
       </skills>
-      <source>DIS</source>
-      <page>303</page>
+      <source>SR5</source>
+      <page>407</page>
     </metatype>
     <metatype>
       <id>b6997b8d-b524-4d7d-a35c-8502e71fc9b6</id>
       <name>Feathered Serpent</name>
       <category>Dracoforms</category>
       <karma>0</karma>
-      <bodmin>12</bodmin>
-      <bodmax>12</bodmax>
-      <bodaug>12</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>8</reamin>
-      <reamax>8</reamax>
-      <reaaug>8</reaaug>
+      <bodmin>15</bodmin>
+      <bodmax>15</bodmax>
+      <bodaug>15</bodaug>
+      <agimin>9</agimin>
+      <agimax>9</agimax>
+      <agiaug>9</agiaug>
+      <reamin>10</reamin>
+      <reamax>10</reamax>
+      <reaaug>10</reaaug>
       <strmin>30</strmin>
       <strmax>30</strmax>
       <straug>30</straug>
       <chamin>8</chamin>
       <chamax>8</chamax>
       <chaaug>8</chaaug>
-      <intmin>8</intmin>
-      <intmax>8</intmax>
-      <intaug>8</intaug>
-      <logmin>8</logmin>
-      <logmax>8</logmax>
-      <logaug>8</logaug>
-      <wilmin>8</wilmin>
-      <wilmax>8</wilmax>
-      <wilaug>8</wilaug>
+      <intmin>9</intmin>
+      <intmax>9</intmax>
+      <intaug>9</intaug>
+      <logmin>9</logmin>
+      <logmax>9</logmax>
+      <logaug>9</logaug>
+      <wilmin>10</wilmin>
+      <wilmax>10</wilmax>
+      <wilaug>10</wilaug>
       <inimin>10</inimin>
       <inimax>22</inimax>
       <iniaug>22</iniaug>
       <edgmin>6</edgmin>
-      <edgmax>6</edgmax>
-      <edgaug>6</edgaug>
-      <magmin>6+1D6</magmin>
-      <magmax>6+1D6</magmax>
-      <magaug>6+1D6</magaug>
+      <edgmax>9</edgmax>
+      <edgaug>9</edgaug>
+      <magmin>10</magmin>
+      <magmax>13</magmax>
+      <magaug>13</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>6+1D6</essmax>
-      <essaug>6+1D6</essaug>
-      <movement>15/50, Fly 30/100</movement>
+      <essmax>10</essmax>
+      <essaug>10</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/4</walk>
+		<run>5/0/8</run>
+		<sprint>5/1/7</sprint>
       <qualities>
         <positive>
           <quality>Magician</quality>
@@ -32704,9 +33701,9 @@
         <addattribute>
           <name>MAG</name>
           <min>7</min>
-          <max>12</max>
-          <aug>12</aug>
-          <val>7</val>
+          <max>13</max>
+          <aug>13</aug>
+          <val>10</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
@@ -32718,10 +33715,13 @@
         <power>Dragonspeech</power>
         <power>Dual Natured</power>
         <power select="Fire">Elemental Attack</power>
-        <power select="Smell, Low-Light Vision, Thermographic Vision, Wide-Band Hearing">Enhanced Senses</power>
-        <power rating="8">Hardened Armor</power>
-        <power rating="8">Mystic Armor</power>
-        <power select="Bite/Claws: DV 10P, AP -2">Natural Weapon</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Wide-Band Hearing">Enhanced Senses</power>
+        <power rating="15">Hardened Armor</power>
+        <power rating="10">Mystic Armor</power>
+        <power select="Bite/Claws: DV (STR+2)P, AP -4">Natural Weapon</power>
         <power>Sapience</power>
         <power>Animal Control</power>
         <power>Compulsion</power>
@@ -32732,16 +33732,17 @@
         <power>Venom</power>
       </powers>
       <skills>
-        <skill rating="8">Assensing</skill>
-        <skill rating="6">Exotic Ranged Weapon</skill>
-        <skill rating="6">Flight</skill>
-        <skill rating="6">Perception</skill>
-        <skill rating="6">Unarmed Combat</skill>
-        <group rating="6">Conjuring</group>
-        <group rating="8">Sorcery</group>
+        <skill rating="14">Assensing</skill>
+        <skill rating="12">Exotic Ranged Weapon</skill>
+        <skill rating="12">Flight</skill>
+		<skill rating="10">Running</skill>
+        <skill rating="12">Perception</skill>
+        <skill rating="12">Unarmed Combat</skill>
+        <group rating="12">Conjuring</group>
+        <group rating="14">Sorcery</group>
       </skills>
-      <source>DIS</source>
-      <page>304</page>
+      <source>SR5</source>
+      <page>407</page>
     </metatype>
     <metatype>
       <id>32e18f07-76be-4832-97a1-0a03025a1bf5</id>
@@ -32841,9 +33842,9 @@
       <name>Western Dragon</name>
       <category>Dracoforms</category>
       <karma>0</karma>
-      <bodmin>15</bodmin>
-      <bodmax>15</bodmax>
-      <bodaug>15</bodaug>
+      <bodmin>18</bodmin>
+      <bodmax>18</bodmax>
+      <bodaug>18</bodaug>
       <agimin>7</agimin>
       <agimax>7</agimax>
       <agiaug>7</agiaug>
@@ -32869,18 +33870,23 @@
       <inimax>22</inimax>
       <iniaug>22</iniaug>
       <edgmin>6</edgmin>
-      <edgmax>6</edgmax>
-      <edgaug>6</edgaug>
-      <magmin>6+1D6</magmin>
-      <magmax>6+1D6</magmax>
-      <magaug>6+1D6</magaug>
+      <edgmax>9</edgmax>
+      <edgaug>9</edgaug>
+      <magmin>10</magmin>
+      <magmax>13</magmax>
+      <magaug>13</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>6+1D6</essmax>
-      <essaug>6+1D6</essaug>
-      <movement>15/40, Fly 30/60</movement>
+      <essmax>10</essmax>
+      <essaug>10</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/3</walk>
+		<run>4/0/7</run>
+		<sprint>4/1/5</sprint>
       <qualities>
         <positive>
           <quality>Magician</quality>
@@ -32890,9 +33896,9 @@
         <addattribute>
           <name>MAG</name>
           <min>7</min>
-          <max>12</max>
-          <aug>12</aug>
-          <val>7</val>
+          <max>13</max>
+          <aug>13</aug>
+          <val>10</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
@@ -32904,10 +33910,13 @@
         <power>Dragonspeech</power>
         <power>Dual Natured</power>
         <power select="Fire">Elemental Attack</power>
-        <power select="Smell, Low-Light Vision, Thermographic Vision, Wide-Band Hearing">Enhanced Senses</power>
-        <power rating="8">Hardened Armor</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Wide-Band Hearing">Enhanced Senses</power>
+        <power rating="18">Hardened Armor</power>
         <power rating="8">Mystic Armor</power>
-        <power select="Bite/Claws: DV 10P, AP -2">Natural Weapon</power>
+        <power select="Bite/Claws: DV (STR+2)P, AP -4">Natural Weapon</power>
         <power>Sapience</power>
         <power>Animal Control</power>
         <power>Compulsion</power>
@@ -32918,16 +33927,17 @@
         <power>Venom</power>
       </powers>
       <skills>
-        <skill rating="8">Assensing</skill>
-        <skill rating="6">Exotic Ranged Weapon</skill>
-        <skill rating="6">Flight</skill>
-        <skill rating="6">Perception</skill>
-        <skill rating="6">Unarmed Combat</skill>
-        <group rating="6">Conjuring</group>
-        <group rating="8">Sorcery</group>
+        <skill rating="14">Assensing</skill>
+        <skill rating="12">Exotic Ranged Weapon</skill>
+        <skill rating="12">Flight</skill>
+		<skill rating="10">Running</skill>
+        <skill rating="12">Perception</skill>
+        <skill rating="12">Unarmed Combat</skill>
+        <group rating="12">Conjuring</group>
+        <group rating="14">Sorcery</group>
       </skills>
-      <source>DIS</source>
-      <page>303</page>
+      <source>SR5</source>
+      <page>407</page>
     </metatype>
     <metatype>
       <id>ffce461b-4cbc-47d9-afa6-370d5fa56194</id>
@@ -35756,46 +36766,51 @@
       <name>Bandersnatch</name>
       <category>Infected</category>
       <karma>0</karma>
-      <bodmin>8</bodmin>
-      <bodmax>8</bodmax>
-      <bodaug>8</bodaug>
+      <bodmin>9</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>9</bodaug>
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>7</strmin>
-      <strmax>7</strmax>
-      <straug>7</straug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>9</strmin>
+      <strmax>9</strmax>
+      <straug>9</straug>
       <chamin>1</chamin>
       <chamax>1</chamax>
       <chaaug>1</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
+      <intmin>6</intmin>
+      <intmax>6</intmax>
+      <intaug>6</intaug>
       <logmin>2</logmin>
       <logmax>2</logmax>
       <logaug>2</logaug>
-      <wilmin>4</wilmin>
-      <wilmax>4</wilmax>
-      <wilaug>4</wilaug>
+      <wilmin>5</wilmin>
+      <wilmax>5</wilmax>
+      <wilaug>5</wilaug>
       <inimin>2</inimin>
       <inimax>13</inimax>
       <iniaug>13</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
-      <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>3</magaug>
+      <edgmin>2</edgmin>
+      <edgmax>2</edgmax>
+      <edgaug>5</edgaug>
+      <magmin>4</magmin>
+      <magmax>7</magmax>
+      <magaug>7</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>5</essmax>
       <essaug>5</essaug>
-      <movement>15/35</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -35811,44 +36826,45 @@
       </bonus>
       <powers>
         <power>Adaptive Coloration</power>
-        <power select="Sasquatch Flesh">Dietary Requirement</power>
+        <power select="Metahuman Flesh">Dietary Requirement</power>
+		<power select="Sunlight, Mild">Allergy</power>
         <power>Dual Natured</power>
         <power>Mimicry</power>
-        <power select="Bite/Calw: (STR/2)+1P, AP 0">Natural Weapon</power>
+        <power select="Bite: (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
+		<power select="Claw: (STR+2)P, AP -1">Natural Weapon</power>
         <power>Sapience</power>
       </powers>
       <skills>
-        <skill rating="3">Assensing</skill>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
-        <group rating="2">Athletics</group>
-        <knowledge rating="5" category="Professional">Animal Calls</knowledge>
+        <skill rating="6">Assensing</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="10">Sneaking</skill>
+        <skill rating="7">Unarmed Combat</skill>
+        <group rating="4">Athletics</group>
+        <knowledge rating="8" category="Professional">Animal Calls</knowledge>
       </skills>
-      <source>RW</source>
-      <page>64</page>
+      <source>HS</source>
+      <page>87</page>
     </metatype>
     <metatype>
       <id>2c184db2-1225-4b7b-b251-fec7271de71c</id>
       <name>Banshee</name>
       <category>Infected</category>
       <karma>0</karma>
-      <bodmin>3</bodmin>
-      <bodmax>3</bodmax>
-      <bodaug>3</bodaug>
+      <bodmin>4</bodmin>
+      <bodmax>4</bodmax>
+      <bodaug>4</bodaug>
       <agimin>4</agimin>
       <agimax>4</agimax>
       <agiaug>4</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
-      <strmin>3</strmin>
-      <strmax>3</strmax>
-      <straug>3</straug>
-      <chamin>5</chamin>
-      <chamax>5</chamax>
-      <chaaug>5</chaaug>
+      <reamin>5</reamin>
+      <reamax>5</reamax>
+      <reaaug>5</reaaug>
+      <strmin>4</strmin>
+      <strmax>4</strmax>
+      <straug>4</straug>
+      <chamin>6</chamin>
+      <chamax>6</chamax>
+      <chaaug>6</chaaug>
       <intmin>4</intmin>
       <intmax>4</intmax>
       <intaug>4</intaug>
@@ -35861,19 +36877,24 @@
       <inimin>2</inimin>
       <inimax>13</inimax>
       <iniaug>13</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>3</magaug>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>2D6-1</essmax>
-      <essaug>2D6-1</essaug>
-      <movement>10/25</movement>
+      <essmax>2D6</essmax>
+      <essaug>2D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>8/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -35888,29 +36909,34 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
+		<power>Dual Natured</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
         <power>Essence Drain</power>
         <power>Fear</power>
-        <power select="Age, Pathogens, Toxins">Immunity</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Infection</power>
         <power>Mist Form</power>
-        <power select="Bite: (STR/2)+1P, AP 0, Reach -1">Natural Weapon</power>
+        <power select="Bite: (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
+		<power>Paralyzing Howl</power>
         <power>Regeneration</power>
         <power>Sapience</power>
-        <power select="Sunlight, Moderate">Allergy</power>
-        <power select="metahuman Blood">Dietary Requirement</power>
+        <power select="Sunlight, Severe">Allergy</power>
+        <power select="Metahuman Blood">Dietary Requirement</power>
         <power>Essence Loss</power>
         <power select="Silver">Vulnerability</power>
         <power select="Wood">Vulnerability</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="9">Sneaking</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>64</page>
+      <source>HS</source>
+      <page>87</page>
     </metatype>
     <metatype>
       <id>9fd7dff2-53f3-4af7-b4d1-27329d9b7365</id>
@@ -35991,7 +37017,7 @@
     <metatype>
       <id>7a55d167-0942-4853-a63b-d2c01dbdfdf9</id>
       <name>Drop Bear</name>
-      <category>Infected</category>
+      <category>Paranormal Critters</category>
       <karma>0</karma>
       <bodmin>3</bodmin>
       <bodmax>3</bodmax>
@@ -36023,7 +37049,7 @@
       <edgmin>2</edgmin>
       <edgmax>2</edgmax>
       <edgaug>2</edgaug>
-      <magmin>0</magmin>
+      <magmin>3</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -36032,26 +37058,47 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>8/20</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/1/0</walk>
+		<run>2/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
+		<addattribute>
+          <name>MAG</name>
+          <min>1</min>
+          <max>6</max>
+          <aug>6</aug>
+          <val>3</val>
+        </addattribute>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
+		<reach>-1</reach>
       </bonus>
       <powers>
         <power>Adaptive Coloration</power>
-        <power select="Pathogens, Toxins">Immunity</power>
-        <power select="Calws/Bite: (STR/2)P, AP -1, Reach -1">Natural Weapon</power>
+		<power rating="2">Armor</power>
+        <power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
+        <power select="Claw/Bite: 5P, AP -1">Natural Weapon</power>
         <power select="Eucalyptus">Dietary Requirement</power>
       </powers>
+	  <qualities>
+		<negative>
+			<quality>Carrier (HMHVV Strain II)</quality>
+		</negative>
+	  </qualities>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="3">Shadowing</skill>
-        <skill rating="2">Unarmed Combat</skill>
+        <skill rating="4">Gymnastics</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="5">Sneaking</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>65</page>
+      <source>HS</source>
+      <page>60</page>
     </metatype>
     <metatype>
       <id>afbbdf07-5b26-4970-b968-f4f7ded991f5</id>
@@ -36067,15 +37114,15 @@
       <reamin>5</reamin>
       <reamax>5</reamax>
       <reaaug>5</reaaug>
-      <strmin>8</strmin>
-      <strmax>8</strmax>
-      <straug>8</straug>
+      <strmin>9</strmin>
+      <strmax>9</strmax>
+      <straug>9</straug>
       <chamin>1</chamin>
       <chamax>1</chamax>
       <chaaug>1</chaaug>
-      <intmin>3</intmin>
-      <intmax>3</intmax>
-      <intaug>3</intaug>
+      <intmin>4</intmin>
+      <intmax>4</intmax>
+      <intaug>4</intaug>
       <logmin>2</logmin>
       <logmax>2</logmax>
       <logaug>2</logaug>
@@ -36085,19 +37132,24 @@
       <inimin>3</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>3</magaug>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>2D6-1</essmax>
-      <essaug>2D6-1</essaug>
-      <movement>15/35</movement>
+      <essmax>2D6</essmax>
+      <essaug>2D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -36113,28 +37165,33 @@
         <reach>1</reach>
       </bonus>
       <powers>
-        <power rating="4">Armor (Ballistic)</power>
-        <power rating="4">Armor (Impact)</power>
+        <power rating="4">Armor</power>
+		<power>Dual Natured</power>
+		<power select="Hearing">Enhanced Senses</power>
         <power select="Thermographic Vision">Enhanced Senses</power>
         <power>Essence Drain</power>
+		<power select="Age">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Infection</power>
         <power>Magical Guard</power>
-        <power select="Bite/Calw: (STR/2)+2P, AP 0">Natural Weapon</power>
+        <power select="Bite: (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
+		<power select="Claw: (STR+2)P, AP -1">Natural Weapon</power>
         <power>Regeneration</power>
         <power>Sapience</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
         <power select="Metahuman Flesh">Dietary Requirement</power>
         <power>Essence Loss</power>
       </powers>
       <skills>
-        <skill rating="3">Counterspelling</skill>
-        <skill rating="3">Intimidation</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Unarmed Combat</skill>
-        <group rating="2">Athletics</group>
+		<skill rating="4">Assensing</skill>
+        <skill rating="6">Counterspelling</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="7">Perception</skill>
+        <skill rating="7">Unarmed Combat</skill>
+        <group rating="4">Athletics</group>
       </skills>
-      <source>RW</source>
-      <page>66</page>
+      <source>HS</source>
+      <page>87</page>
     </metatype>
     <metatype>
       <id>c9415a08-1766-40c4-a28b-11417a5b73a6</id>
@@ -36159,28 +37216,33 @@
       <intmin>3</intmin>
       <intmax>3</intmax>
       <intaug>3</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
+      <logmin>1</logmin>
+      <logmax>1</logmax>
+      <logaug>1</logaug>
       <wilmin>4</wilmin>
       <wilmax>4</wilmax>
       <wilaug>4</wilaug>
       <inimin>2</inimin>
       <inimax>13</inimax>
       <iniaug>13</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>3</magaug>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>5</essmax>
       <essaug>5</essaug>
-      <movement>15/35</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -36195,61 +37257,63 @@
         <reach>1</reach>
       </bonus>
       <powers>
-        <power rating="3">Armor (Ballistic)</power>
-        <power rating="3">Armor (Impact)</power>
+        <power rating="3">Armor</power>
         <power>Magical Guard</power>
-        <power select="Calws/Bite: (STR/2)+1P, AP 0">Natural Weapon</power>
+		<power select="Corrosive">Secretion/Substance Extrusion</power>
+        <power select="Bite: (STR+1)P, AP -1, -1 Reach">Natural Weapon</power>
+		<power select="Claws: (STR+2)P, AP -1">Natural Weapon</power>
         <power>Sapience</power>
-        <power select="Air Pollution, Mild">Allergy</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Air Pollution, Moderate">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
         <power select="Metahuman Flesh">Dietary Requirement</power>
       </powers>
       <skills>
-        <skill rating="3">Counterspelling</skill>
-        <skill rating="3">Intimidation</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Unarmed Combat</skill>
-        <group rating="2">Athletics</group>
+		<skill rating="3">Assensing</skill>
+        <skill rating="6">Counterspelling</skill>
+        <skill rating="6">Intimidation</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="7">Unarmed Combat</skill>
+        <group rating="4">Athletics</group>
       </skills>
-      <source>RW</source>
-      <page>66</page>
+      <source>HS</source>
+      <page>87</page>
     </metatype>
     <metatype>
       <id>73eb68ca-ff19-40fa-b6ab-c43c13ca24db</id>
       <name>Gnawer</name>
       <category>Infected</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
-      <bodmax>5</bodmax>
-      <bodaug>5</bodaug>
+      <bodmin>6</bodmin>
+      <bodmax>6</bodmax>
+      <bodaug>6</bodaug>
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
       <reamin>4</reamin>
       <reamax>4</reamax>
       <reaaug>4</reaaug>
-      <strmin>6</strmin>
-      <strmax>6</strmax>
-      <straug>6</straug>
-      <chamin>3</chamin>
-      <chamax>3</chamax>
-      <chaaug>3</chaaug>
+      <strmin>7</strmin>
+      <strmax>7</strmax>
+      <straug>7</straug>
+      <chamin>2</chamin>
+      <chamax>2</chamax>
+      <chaaug>2</chaaug>
       <intmin>5</intmin>
       <intmax>5</intmax>
       <intaug>5</intaug>
-      <logmin>3</logmin>
-      <logmax>3</logmax>
-      <logaug>3</logaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
       <wilmin>5</wilmin>
       <wilmax>5</wilmax>
       <wilaug>5</wilaug>
       <inimin>3</inimin>
       <inimax>15</inimax>
       <iniaug>15</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
-      <magmin>0</magmin>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
+      <magmin>3</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -36258,39 +37322,47 @@
       <essmin>0</essmin>
       <essmax>5</essmax>
       <essaug>5</essaug>
-      <movement>8/20</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>4/0/0</run>
+		<sprint>1/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power rating="1">Armor (Ballistic)</power>
-        <power rating="1">Armor (Impact)</power>
+		<power>Animal Control</power>
+        <power rating="2">Armor</power>
+		<power>Dual Natured</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power select="Toxins">Immunity</power>
+		<power select="Bite: DV (STR+2)P, AP 0, -1 Reach">Natural Weapon</power>
         <power>Noxious Breath</power>
         <power>Paralyzing Touch</power>
         <power>Sapience</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
         <power select="Metahuman Bone">Dietary Requirement</power>
       </powers>
       <skills>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
+		<skill rating="3">Assensing</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>66</page>
+      <source>HS</source>
+      <page>87</page>
     </metatype>
     <metatype>
       <id>3188a684-0680-44dc-adce-ec8481098f76</id>
       <name>Goblin</name>
       <category>Infected</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
-      <bodmax>5</bodmax>
-      <bodaug>5</bodaug>
+      <bodmin>6</bodmin>
+      <bodmax>6</bodmax>
+      <bodaug>6</bodaug>
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
@@ -36300,34 +37372,39 @@
       <strmin>6</strmin>
       <strmax>6</strmax>
       <straug>6</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
+      <chamin>2</chamin>
+      <chamax>2</chamax>
+      <chaaug>2</chaaug>
+      <intmin>5</intmin>
+      <intmax>5</intmax>
+      <intaug>5</intaug>
+      <logmin>2</logmin>
+      <logmax>2</logmax>
+      <logaug>2</logaug>
       <wilmin>5</wilmin>
       <wilmax>5</wilmax>
       <wilaug>5</wilaug>
       <inimin>2</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>3</magaug>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>5</essmax>
-      <essaug>5</essaug>
-      <movement>8/20</movement>
+      <essmax>2D6</essmax>
+      <essaug>2D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -36342,26 +37419,37 @@
         <initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power select="Smell, Taste">Enhanced Senses</power>
+		<power>Dual Natured</power>
+        <power select="Smell">Enhanced Senses</power>
+		<power select="Taste">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power>Essence Drain</power>
+		<power select="Age">Immunity</power>
         <power select="Fire">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Infection</power>
-        <power select="Calws: (STR/2)+1P, AP 0">Natural Weapon</power>
+		<power select="Bite: (STR+1)P, AP -1, Reach -1">Natural Weapon</power>
+        <power select="Claws: (STR+2)P, AP -1">Natural Weapon</power>
         <power>Regeneration</power>
         <power>Sapience</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
         <power select="Metahuman Flesh">Dietary Requirement</power>
         <power>Essence Loss</power>
         <power select="Iron">Vulnerability</power>
       </powers>
+	  <qualities>
+			<positive>
+				<quality>Resistance to Pathogens/Toxins</quality>
+			</positive>
+	  </qualities>
       <skills>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="3">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="4">Assensing</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="8">Sneaking</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>66</page>
+      <source>HS</source>
+      <page>88</page>
     </metatype>
     <metatype>
       <id>5c6b3c79-0997-44c3-b29c-c909ca4b8a26</id>
@@ -36371,9 +37459,9 @@
       <bodmin>8</bodmin>
       <bodmax>8</bodmax>
       <bodaug>8</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
+      <agimin>3</agimin>
+      <agimax>3</agimax>
+      <agiaug>3</agiaug>
       <reamin>4</reamin>
       <reamax>4</reamax>
       <reaaug>4</reaaug>
@@ -36396,9 +37484,9 @@
       <inimax>14</inimax>
       <iniaug>14</iniaug>
       <edgmin>1</edgmin>
-      <edgmax>1</edgmax>
-      <edgaug>1</edgaug>
-      <magmin>0</magmin>
+      <edgmax>4</edgmax>
+      <edgaug>4</edgaug>
+      <magmin>3</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -36407,7 +37495,12 @@
       <essmin>0</essmin>
       <essmax>5</essmax>
       <essaug>5</essaug>
-      <movement>10/25</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>6/0/0</run>
+		<sprint>4/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
@@ -36416,18 +37509,27 @@
       </bonus>
       <powers>
         <power>Animal Control</power>
-        <power select="Low-Light Vision, Smell, Thermographic Vision">Enhanced Senses</power>
+		<power>Concealment</power>
+		<power>Dual Natured</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Smell">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power select="Bite: (STR+1)P, AP -1, Reach -1">Natural Weapon</power>
+        <power select="Claws: (STR+1)P, AP -1">Natural Weapon</power>
+		<power>Paralyzing Touch</power>
         <power>Sapience</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
+		<power select="Metahuman Flesh">Dietary Requirement</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="3">Assensing</skill>
+		<skill rating="4">Gymnastics</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="7">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>67</page>
+      <source>HS</source>
+      <page>88</page>
     </metatype>
     <metatype>
       <id>d5940767-cdb7-44d7-a41c-733d17d60936</id>
@@ -36437,9 +37539,9 @@
       <bodmin>5</bodmin>
       <bodmax>5</bodmax>
       <bodaug>5</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
+      <agimin>4</agimin>
+      <agimax>4</agimax>
+      <agiaug>4</agiaug>
       <reamin>6</reamin>
       <reamax>6</reamax>
       <reaaug>6</reaaug>
@@ -36462,18 +37564,23 @@
       <inimax>17</inimax>
       <iniaug>17</iniaug>
       <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>3</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>2</magaug>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>5</essmax>
       <essaug>5</essaug>
-      <movement>15/35</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -36485,27 +37592,30 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
-        <reach>1</reach>
+		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
-        <power rating="1">Armor (Ballistic)</power>
-        <power rating="1">Armor (Impact)</power>
-        <power select="Low-Light Vision, Thermographic Vision">Enhanced Senses</power>
+        <power rating="2">Armor</power>
+		<power>Dual Natured</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power>Movement</power>
-        <power select="Calws: (STR/2)+1P, AP 0">Natural Weapon</power>
+        <power select="Bite: (STR+1)P, AP -1, Reach -1">Natural Weapon</power>
+        <power select="Claws: (STR+3)P, AP -3">Natural Weapon</power>
         <power>Sapience</power>
         <power select="Silver, Moderate">Allergy</power>
-        <power select="Sunlight, Mild">Allergy</power>
+        <power select="Sunlight, Moderate">Allergy</power>
       </powers>
       <skills>
-        <skill rating="2">Intimidation</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Shadowing</skill>
-        <skill rating="4">Unarmed Combat</skill>
-        <group rating="3">Athletics</group>
+        <skill rating="3">Assensing</skill>
+		<skill rating="4">Intimidation</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="7">Unarmed Combat</skill>
+        <group rating="5">Athletics</group>
       </skills>
-      <source>RW</source>
-      <page>67</page>
+      <source>HS</source>
+      <page>88</page>
     </metatype>
     <metatype>
       <id>83b6559c-1783-4589-aa1a-50ecddec131b</id>
@@ -36518,9 +37628,9 @@
       <agimin>3</agimin>
       <agimax>3</agimax>
       <agiaug>3</agiaug>
-      <reamin>3</reamin>
-      <reamax>3</reamax>
-      <reaaug>3</reaaug>
+      <reamin>4</reamin>
+      <reamax>4</reamax>
+      <reaaug>4</reaaug>
       <strmin>7</strmin>
       <strmax>7</strmax>
       <straug>7</straug>
@@ -36540,18 +37650,23 @@
       <inimax>13</inimax>
       <iniaug>13</iniaug>
       <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>3</magmin>
-      <magmax>3</magmax>
-      <magaug>3</magaug>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
       <essmax>5</essmax>
       <essaug>5</essaug>
-      <movement>10/25</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -36563,26 +37678,31 @@
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
+		<power rating="2">Armor</power>
         <power>Dual Natured</power>
+		<power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
         <power select="Thermographic Vision">Enhanced Senses</power>
-        <power select="Calws/Bite: (STR/2)+1P, AP 0">Natural Weapon</power>
+		<power select="Smell">Enhanced Senses</power>
+        <power select="Bite: (STR+2)P, AP -2, Reach -1">Natural Weapon</power>
+        <power select="Claws: (STR+3)P, AP -2">Natural Weapon</power>
         <power>Sapience</power>
         <power select="Aconite, Moderate">Allergy</power>
-        <power select="Horseradish, Moderate">Allergy</power>
-        <power select="Sunlight, Moderate">Allergy</power>
+        <power select="Sunlight, Severe">Allergy</power>
         <power select="Metahuman Flesh">Dietary Requirement</power>
       </powers>
       <skills>
-        <skill rating="3">Assensing</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
-        <group rating="2">Athletics</group>
+        <skill rating="5">Assensing</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="6">Sneaking</skill>
+        <skill rating="8">Unarmed Combat</skill>
+        <group rating="6">Athletics</group>
       </skills>
-      <source>RW</source>
-      <page>67</page>
+      <source>HS</source>
+      <page>89</page>
     </metatype>
     <metatype>
       <id>46079d32-9f76-4807-9268-d2d758513bb2</id>
@@ -36616,19 +37736,24 @@
       <inimin>3</inimin>
       <inimax>15</inimax>
       <iniaug>15</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
-      <magmin>4</magmin>
-      <magmax>4</magmax>
-      <magaug>4</magaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
+      <magmin>3</magmin>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>2D6+3</essmax>
-      <essaug>2D6+3</essaug>
-      <movement>15/35</movement>
+      <essmax>3D6</essmax>
+      <essaug>3D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>2/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
@@ -36644,34 +37769,43 @@
         <reach>1</reach>
       </bonus>
       <powers>
-        <power rating="4">Armor (Ballistic)</power>
-        <power rating="4">Armor (Impact)</power>
+        <power rating="5">Armor</power>
         <power>Dual Natured</power>
-        <power select="Hearing, Low-Light Vision, Thermographic Vision">Enhanced Senses</power>
-        <power>Essence Drain</power>
+        <power select="Hearing">Enhanced Senses</power>
+        <power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
+		<power>Essence Drain</power>
         <power>Fear</power>
+		<power select="Age">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Infection</power>
         <power>Magical Guard</power>
-        <power select="Bite/Calw: (STR/2)+2P, AP 0">Natural Weapon</power>
+        <power select="Bite: (STR+1)P, AP -1, Reach -1">Natural Weapon</power>
+        <power select="Claws: (STR+2)P, AP -1">Natural Weapon</power>
         <power>Regeneration</power>
         <power>Sapience</power>
-        <power select="Air Pollution, Mild">Allergy</power>
-        <power select="Sunlight, Severe">Allergy</power>
+        <power select="Wood, Severe">Allergy</power>
+        <power select="Sunlight, Extreme">Allergy</power>
         <power select="Metahuman Flesh">Dietary Requirement</power>
         <power>Essence Loss</power>
+		<power select="Fire">Vulnerability</power>
       </powers>
+	  <qualities>
+		<positive>
+			<quality>Adept</quality>
+		</positive>
+	  </qualities>
       <skills>
-        <skill rating="3">Assensing</skill>
-        <skill rating="4">Counterspelling</skill>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="3">Intimidation</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
-        <group rating="2">Athletics</group>
+        <skill rating="5">Assensing</skill>
+        <skill rating="6">Counterspelling</skill>
+        <skill rating="7">Intimidation</skill>
+        <skill rating="6">Perception</skill>
+        <skill rating="7">Sneaking</skill>
+        <skill rating="7">Unarmed Combat</skill>
+        <group rating="5">Athletics</group>
       </skills>
-      <source>RW</source>
-      <page>67</page>
+      <source>HS</source>
+      <page>90</page>
     </metatype>
     <metatype>
       <id>98d79172-0782-4c2d-916f-5c7c56144ee3</id>
@@ -36705,19 +37839,24 @@
       <inimin>3</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
-      <edgmin>3</edgmin>
-      <edgmax>3</edgmax>
-      <edgaug>3</edgaug>
-      <magmin>4</magmin>
-      <magmax>4</magmax>
-      <magaug>4</magaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
+      <magmin>3</magmin>
+      <magmax>6</magmax>
+      <magaug>6</magaug>
       <resmin>0</resmin>
       <resmax>6</resmax>
       <resaug>6</resaug>
       <essmin>0</essmin>
-      <essmax>2D6+5</essmax>
-      <essaug>2D6+5</essaug>
-      <movement>10/25</movement>
+      <essmax>3D6</essmax>
+      <essaug>3D6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>3/1/0</walk>
+		<run>5/0/0</run>
+		<sprint>3/1/0</sprint>
       <qualities>
         <positive>
           <quality>Magician</quality>
@@ -36738,30 +37877,37 @@
       </bonus>
       <powers>
         <power>Compulsion</power>
-        <power select="Hearing, Low-Light Vision, Thermographic Vision">Enhanced Senses</power>
+		<power>Dual Natured</power>
+        <power select="Hearing">Enhanced Senses</power>
+		<power select="Low-Light Vision">Enhanced Senses</power>
+		<power select="Thermographic Vision">Enhanced Senses</power>
         <power>Essence Drain</power>
         <power>Fear</power>
-        <power select="Age, Pathogens, Toxins">Immunity</power>
+        <power select="Age">Immunity</power>
+		<power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
         <power>Infection</power>
         <power>Influence</power>
-        <power select="Bite: (STR/2)+1P, AP 0, Reach -1">Natural Weapon</power>
+        <power select="Bite: (STR+1)P, AP -1, Reach -1">Natural Weapon</power>
         <power>Regeneration</power>
         <power>Sapience</power>
-        <power select="Sunlight, Severe">Allergy</power>
+        <power select="Sunlight, Extreme">Allergy</power>
+		<power select="Wood, Severe">Allergy</power>
         <power select="Metahuman Blood">Dietary Requirement</power>
         <power>Essence Loss</power>
+		<power select="Lack of Air, (Essence) Minutes">Induced Dormancy</power>
       </powers>
       <skills>
-        <skill rating="4">Infiltration</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="4">Shadowing</skill>
-        <skill rating="3">Unarmed Combat</skill>
-        <group rating="3">Conjuring</group>
-        <group rating="3">Influence</group>
-        <group rating="4">Sorcery</group>
+        <skill rating="6">Assensing</skill>
+        <skill rating="8">Perception</skill>
+        <skill rating="8">Sneaking</skill>
+        <skill rating="5">Unarmed Combat</skill>
+        <group rating="6">Conjuring</group>
+        <group rating="6">Influence</group>
+        <group rating="7">Sorcery</group>
       </skills>
-      <source>RW</source>
-      <page>68</page>
+      <source>HS</source>
+      <page>91</page>
     </metatype>
 		<!-- End Region -->
 		<!-- Region Mutant Critters -->

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -109,6 +109,7 @@
 		<category>Headware</category>
 		<category>Nanocybernetics</category>
 		<category>Soft Nanoware</category>
+		<category>Special Biodrone Cyberware</category>
 	</categories>
 	<cyberwares>
 		<!-- Region Shadowrun 5 -->
@@ -3519,6 +3520,87 @@
 			<cost>750</cost>
 			<source>HT</source>
 			<page>186</page>
+		</cyberware>
+		<!-- End Region -->
+		<!-- Region Howling Shadows -->
+		<cyberware>
+			<id>e36646df-68cf-4289-84e9-cd6fd4859b3c</id>
+			<name>Chameleon Pelt</name>
+			<category>Special Biodrone Cyberware</category>
+			<rating>4</rating>
+			<ess>Rating * 0.3</ess>
+			<capacity>0</capacity>
+			<avail>20F</avail>
+			<cost>Rating * 6000</cost>
+			<source>HS</source>
+			<page>181</page>
+		</cyberware>
+		<cyberware>
+			<id>8538aff0-ab67-4d7b-9310-deae1672e003</id>
+			<name>CAST</name>
+			<category>Special Biodrone Cyberware</category>
+			<ess>0.5</ess>
+			<capacity>0</capacity>
+			<avail>25</avail>
+			<cost>25000</cost>
+			<source>HS</source>
+			<page>181</page>
+		</cyberware>
+		<cyberware>
+			<id>5c5fd1d5-1c45-4fe9-ad03-df83457b33e6</id>
+			<name>CAST w/ Friend or Foe Recognition</name>
+			<category>Special Biodrone Cyberware</category>
+			<ess>0.5</ess>
+			<capacity>0</capacity>
+			<avail>26</avail>
+			<cost>30000</cost>
+			<source>HS</source>
+			<page>181</page>
+		</cyberware>
+		<cyberware>
+			<id>26cd4d9b-60dd-4f3e-b086-7a966c3ed358</id>
+			<name>Orientation Goad</name>
+			<category>Special Biodrone Cyberware</category>
+			<ess>0.1</ess>
+			<capacity>0</capacity>
+			<avail>4</avail>
+			<cost>500</cost>
+			<source>HS</source>
+			<page>181</page>
+		</cyberware>
+		<cyberware>
+			<id>e7c8dbfa-1b75-44df-9ad0-a5ba65e46cc3</id>
+			<name>Stirrup Interface</name>
+			<category>Special Biodrone Cyberware</category>
+			<rating>3</rating>
+			<ess>3.2 + Rating</ess>
+			<capacity>0</capacity>
+			<avail>FixedValues(15R,21R,28R)</avail>
+			<cost>FixedValues(45000,135000,220000)</cost>
+			<source>HS</source>
+			<page>182</page>
+		</cyberware>
+		<cyberware>
+			<id>ff56647d-300f-4b6c-9744-40eb70210cee</id>
+			<name>SEIS</name>
+			<category>Special Biodrone Cyberware</category>
+			<ess>0.7</ess>
+			<capacity>0</capacity>
+			<avail>25F</avail>
+			<cost>20000</cost>
+			<source>HS</source>
+			<page>182</page>
+		</cyberware>
+		<cyberware>
+			<id>2e510666-bc55-42d8-abcb-d79a907ac646</id>
+			<name>TRACES</name>
+			<category>Special Biodrone Cyberware</category>
+			<ess>0.7</ess>
+			<capacity>0</capacity>
+			<avail>25F</avail>
+			<cost>25000</cost>
+			<source>HS</source>
+			<page>182</page>
 		</cyberware>
 		<!-- End Region -->
 	</cyberwares>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -36,6 +36,7 @@
 		<category>Common Programs</category>
 		<category>Communications and Countermeasures</category>
 		<category>Contracts/Upkeep</category>
+		<category>Critter Gear</category>
 		<category>Custom</category>
 		<category>Cyberdeck Modules</category>
 		<category>Cyberdecks</category>
@@ -4213,38 +4214,6 @@
 			<cost>50</cost>
 			<source>SR5</source>
 			<page>443</page>
-		</gear>
-		<gear>
-			<id>bedcaf29-5b6e-4135-8589-d8b5a1291afb</id>
-			<name>Critter Earphones</name>
-			<category>Audio Devices</category>
-			<rating>6</rating>
-			<capacity>Rating</capacity>
-			<avail>3</avail>
-			<cost>Rating * 50</cost>
-			<source>HS</source>
-			<page>185</page>
-		</gear>
-		<gear>
-			<id>098beed4-c197-432e-adb9-bedba3eda18a</id>
-			<name>Critter Goggles</name>
-			<category>Vision Devices</category>
-			<rating>6</rating>
-			<capacity>Rating</capacity>
-			<avail>3</avail>
-			<cost>Rating * 50</cost>
-			<source>HS</source>
-			<page>185</page>
-		</gear>
-		<gear>
-			<id>df3e6d75-4f97-4ad3-a944-02b8f0733b78</id>
-			<name>Training Kit</name>
-			<category>Miscellany</category>
-			<rating>0</rating>
-			<avail>1</avail>
-			<cost>250</cost>
-			<source>HS</source>
-			<page>185</page>
 		</gear>
 		<!-- End Region -->
 		<!-- Region Audio Enhancements -->
@@ -10575,6 +10544,64 @@
 			<cost>250</cost>
 			<source>CF</source>
 			<page>152</page>
+		</gear>
+		<!-- End Region -->
+		<!-- Region Critter Gear -->
+		<gear>
+			<id>1f78e254-59a9-45ae-8936-cccc71484402</id>
+			<name>Sensor Collar</name>
+			<category>Critter Gear</category>
+			<rating>0</rating>
+			<avail>2</avail>
+			<cost>200</cost>
+			<gears>
+				<usegear>
+					<name>Camera</name>
+					<category>Vision Devices</category>
+					<rating>2</rating>
+					<capacity>2</capacity>
+				</usegear>
+				<usegear>
+					<name>Microphone, Omni-Directional</name>
+					<category>Audio Devices</category>
+					<rating>2</rating>
+					<capacity>2</capacity>
+				</usegear>
+			</gears>
+			<source>HS</source>
+			<page>185</page>
+		</gear>
+		<gear>
+			<id>bedcaf29-5b6e-4135-8589-d8b5a1291afb</id>
+			<name>Critter Earphones</name>
+			<category>Audio Devices</category>
+			<rating>6</rating>
+			<capacity>Rating</capacity>
+			<avail>3</avail>
+			<cost>Rating * 50</cost>
+			<source>HS</source>
+			<page>185</page>
+		</gear>
+		<gear>
+			<id>098beed4-c197-432e-adb9-bedba3eda18a</id>
+			<name>Critter Goggles</name>
+			<category>Vision Devices</category>
+			<rating>6</rating>
+			<capacity>Rating</capacity>
+			<avail>3</avail>
+			<cost>Rating * 50</cost>
+			<source>HS</source>
+			<page>185</page>
+		</gear>
+		<gear>
+			<id>df3e6d75-4f97-4ad3-a944-02b8f0733b78</id>
+			<name>Training Kit</name>
+			<category>Critter Gear</category>
+			<rating>0</rating>
+			<avail>1</avail>
+			<cost>250</cost>
+			<source>HS</source>
+			<page>185</page>
 		</gear>
 		<!-- End Region -->
 		<gear>

--- a/Chummer/data/metatypes.xml
+++ b/Chummer/data/metatypes.xml
@@ -1712,6 +1712,11 @@
 					<quality>Wanted by GOD</quality>
 				</negative>
 			</qualityrestriction>
+			<bonus>
+				<enableattribute>
+					<name>DEP</name>
+				</enableattribute>
+			</bonus>
 			<movement>Special</movement>
 			<source>DT</source>
 			<page>88</page>
@@ -1871,6 +1876,11 @@
 							<quality>Social Stress</quality>
 						</negative>
 					</qualities>
+					<bonus>
+						<enableattribute>
+							<name>DEP</name>
+						</enableattribute>
+					</bonus>
 					<source>DT</source>
 					<page>88</page>
 				</metavariant>
@@ -2029,6 +2039,11 @@
 							<quality select="Original Programming">Driven</quality>
 						</negative>
 					</qualities>
+					<bonus>
+						<enableattribute>
+							<name>DEP</name>
+						</enableattribute>
+					</bonus>
 					<source>DT</source>
 					<page>88</page>
 				</metavariant>
@@ -2194,6 +2209,11 @@
 							<quality select="Original Programming">Driven</quality>
 						</negative>
 					</qualities>
+					<bonus>
+						<enableattribute>
+							<name>DEP</name>
+						</enableattribute>
+					</bonus>
 					<source>DT</source>
 					<page>88</page>
 				</metavariant>

--- a/Chummer/data/skills.xml
+++ b/Chummer/data/skills.xml
@@ -1299,6 +1299,24 @@
       <source>SR5</source>
       <page>132</page>
     </skill>
+	<skill>
+      <id>27db6e2a-a49f-4232-b150-e676b8dacb52</id>
+      <name>Flight</name>
+      <attribute>STR</attribute>
+      <category>Physical Active</category>
+      <default>No</default>
+      <skillgroup>Athletics</skillgroup>
+      <specs>
+        <spec>Desert</spec>
+        <spec>Distance</spec>
+        <spec>Sprinting</spec>
+        <spec>Urban</spec>
+        <spec>Wilderness</spec>
+        <spec>[Terrain]</spec>
+      </specs>
+      <source>HS</source>
+      <page>164</page>
+    </skill>
   </skills>
   <knowledgeskills>
     <skill>

--- a/Chummer/data/skills.xml
+++ b/Chummer/data/skills.xml
@@ -654,7 +654,7 @@
 		<skill>
 			<id>27db6e2a-a49f-4232-b150-e676b8dacb52</id>
 			<name>Flight</name>
-			<attribute>STR</attribute>
+			<attribute>AGI</attribute>
 			<category>Physical Active</category>
 			<default>No</default>
 			<skillgroup>Athletics</skillgroup>
@@ -666,8 +666,8 @@
 				<spec>Wilderness</spec>
 				<spec>[Terrain]</spec>
 			</specs>
-			<source>HS</source>
-			<page>164</page>
+			<source>SR5</source>
+			<page>394</page>
 		</skill>
 		<skill>
 			<id>c9f52f97-a284-44a7-8af6-802dd3ed554f</id>

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -20595,6 +20595,7 @@ namespace Chummer
 				{
                     _objImprovementManager.CreateImprovement("MAG", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, "", 0, intReduction * -1, 0, 1, 1, 0);
                     _objImprovementManager.CreateImprovement("RES", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, "", 0, intReduction * -1, 0, 1, 1, 0);
+                    _objImprovementManager.CreateImprovement("DEP", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, "", 0, intReduction * -1, 0, 1, 1, 0);
 
                     if (_objCharacter.AdeptEnabled)
                     {

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -991,7 +991,7 @@ namespace Chummer
 			ToolStripManager.Merge(toolStrip, "toolStrip");
 
             // If this is a Sprite, re-label the Mental CharacterAttribute Labels.
-            if (_objCharacter.Metatype.EndsWith("Sprite"))
+            if (_objCharacter.Metatype.Contains("Sprite"))
 			{
 				lblBODLabel.Enabled = false;
 				lblAGILabel.Enabled = false;
@@ -1002,7 +1002,7 @@ namespace Chummer
 				lblLOGLabel.Text = LanguageManager.Instance.GetString("String_DataProcessing");
 				lblWILLabel.Text = LanguageManager.Instance.GetString("String_Firewall");
             }
-            else if (_objCharacter.DEP.Value > 0)
+            else if (_objCharacter.Metatype.Contains("Protosapients") || _objCharacter.Metatype.Contains("A.I."))
             {
                 lblBODLabel.Enabled = false;
                 lblAGILabel.Enabled = false;

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -997,28 +997,18 @@ namespace Chummer
 				lblAGILabel.Enabled = false;
 				lblREALabel.Enabled = false;
 				lblSTRLabel.Enabled = false;
-				lblCHALabel.Text = LanguageManager.Instance.GetString("String_AttributePilot");
-				lblINTLabel.Text = LanguageManager.Instance.GetString("String_AttributeResponse");
-				lblLOGLabel.Text = LanguageManager.Instance.GetString("String_AttributeFirewall");
-				lblWILLabel.Enabled = false;
-			}
-			else if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
-			{
-				lblRatingLabel.Visible = true;
-				lblRating.Visible = true;
-				lblSystemLabel.Visible = true;
-				lblSystem.Visible = true;
-				lblFirewallLabel.Visible = true;
-				lblFirewall.Visible = true;
-				lblResponseLabel.Visible = true;
-				nudResponse.Visible = true;
-				nudResponse.Enabled = true;
-				nudResponse.Value = _objCharacter.Response;
-				lblSignalLabel.Visible = true;
-				nudSignal.Visible = true;
-				nudSignal.Enabled = true;
-				nudSignal.Value = _objCharacter.Signal;
-			}
+				lblCHALabel.Text = LanguageManager.Instance.GetString("String_Attack");
+				lblINTLabel.Text = LanguageManager.Instance.GetString("String_Sleaze");
+				lblLOGLabel.Text = LanguageManager.Instance.GetString("String_DataProcessing");
+				lblWILLabel.Text = LanguageManager.Instance.GetString("String_Firewall");
+            }
+            else if (_objCharacter.DEP.Value > 0)
+            {
+                lblBODLabel.Enabled = false;
+                lblAGILabel.Enabled = false;
+                lblREALabel.Enabled = false;
+                lblSTRLabel.Enabled = false;
+            }
 
 			mnuSpecialConvertToFreeSprite.Visible = _objCharacter.IsSprite;
 

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -76,7 +76,8 @@ namespace Chummer
 			// Add EventHandlers for the MAG and RES enabled events and tab enabled events.
 			_objCharacter.MAGEnabledChanged += objCharacter_MAGEnabledChanged;
 			_objCharacter.RESEnabledChanged += objCharacter_RESEnabledChanged;
-			_objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
+            _objCharacter.DEPEnabledChanged += objCharacter_DEPEnabledChanged;
+            _objCharacter.AdeptTabEnabledChanged += objCharacter_AdeptTabEnabledChanged;
 			_objCharacter.MagicianTabEnabledChanged += objCharacter_MagicianTabEnabledChanged;
 			_objCharacter.TechnomancerTabEnabledChanged += objCharacter_TechnomancerTabEnabledChanged;
 			_objCharacter.CritterTabEnabledChanged += objCharacter_CritterTabEnabledChanged;
@@ -273,10 +274,10 @@ namespace Chummer
 			treFoci.Visible = _objCharacter.MAGEnabled;
 			cmdCreateStackedFocus.Visible = _objCharacter.MAGEnabled;
 
-			lblDEPLabel.Enabled = (_objCharacter.Metatype == "A.I.");
-			lblDEPAug.Enabled = (_objCharacter.Metatype == "A.I.");
-			lblDEP.Enabled = (_objCharacter.Metatype == "A.I.");
-			lblDEPMetatype.Enabled = (_objCharacter.Metatype == "A.I.");
+			lblDEPLabel.Enabled = (_objCharacter.DEPEnabled);
+			lblDEPAug.Enabled = (_objCharacter.DEPEnabled);
+			lblDEP.Enabled = (_objCharacter.DEPEnabled);
+			lblDEPMetatype.Enabled = (_objCharacter.DEPEnabled);
 
 			lblRESLabel.Enabled = _objCharacter.RESEnabled;
 			lblRESAug.Enabled = _objCharacter.RESEnabled;
@@ -1105,7 +1106,8 @@ namespace Chummer
 				// Unsubscribe from events.
 				_objCharacter.MAGEnabledChanged -= objCharacter_MAGEnabledChanged;
 				_objCharacter.RESEnabledChanged -= objCharacter_RESEnabledChanged;
-				_objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
+                _objCharacter.DEPEnabledChanged -= objCharacter_DEPEnabledChanged;
+                _objCharacter.AdeptTabEnabledChanged -= objCharacter_AdeptTabEnabledChanged;
 				_objCharacter.MagicianTabEnabledChanged -= objCharacter_MagicianTabEnabledChanged;
 				_objCharacter.TechnomancerTabEnabledChanged -= objCharacter_TechnomancerTabEnabledChanged;
 				_objCharacter.CritterTabEnabledChanged -= objCharacter_CritterTabEnabledChanged;
@@ -1370,7 +1372,19 @@ namespace Chummer
 			}
 		}
 
-		private void objCharacter_AdeptTabEnabledChanged(object sender)
+        private void objCharacter_DEPEnabledChanged(object sender)
+        {
+            if (_blnReapplyImprovements)
+                return;
+
+            // Change to the status of DEP being enabled.
+            lblDEPLabel.Enabled = _objCharacter.DEPEnabled;
+            lblDEPAug.Enabled = _objCharacter.DEPEnabled;
+            lblDEP.Enabled = _objCharacter.DEPEnabled;
+            lblDEPMetatype.Enabled = _objCharacter.DEPEnabled;
+        }
+
+        private void objCharacter_AdeptTabEnabledChanged(object sender)
 		{
 			if (_blnReapplyImprovements)
 				return;
@@ -1706,7 +1720,9 @@ namespace Chummer
 				frmPickAttribute.AddMAG();
 			if (_objCharacter.RESEnabled)
 				frmPickAttribute.AddRES();
-			frmPickAttribute.ShowMetatypeMaximum = true;
+            if (_objCharacter.DEPEnabled)
+                frmPickAttribute.AddDEP();
+            frmPickAttribute.ShowMetatypeMaximum = true;
 			frmPickAttribute.ShowDialog(this);
 
 			if (frmPickAttribute.DialogResult == DialogResult.Cancel)
@@ -1770,7 +1786,8 @@ namespace Chummer
 			// Record the status of any flags that normally trigger character events.
 			bool blnMAGEnabled = _objCharacter.MAGEnabled;
 			bool blnRESEnabled = _objCharacter.RESEnabled;
-			bool blnUneducated = _objCharacter.SkillsSection.Uneducated;
+            bool blnDEPEnabled = _objCharacter.DEPEnabled;
+            bool blnUneducated = _objCharacter.SkillsSection.Uneducated;
 			bool blnUncouth = _objCharacter.SkillsSection.Uncouth;
 
 			_blnReapplyImprovements = true;
@@ -2221,7 +2238,9 @@ namespace Chummer
 				objCharacter_MAGEnabledChanged(this);
 			if (blnRESEnabled != _objCharacter.RESEnabled)
 				objCharacter_RESEnabledChanged(this);
-			if (blnUneducated != _objCharacter.SkillsSection.Uneducated)
+            if (blnDEPEnabled != _objCharacter.DEPEnabled)
+                objCharacter_DEPEnabledChanged(this);
+            if (blnUneducated != _objCharacter.SkillsSection.Uneducated)
 				objCharacter_UneducatedChanged(this);
 			if (blnUncouth != _objCharacter.SkillsSection.Uncouth)
 				objCharacter_UncouthChanged(this);
@@ -20409,7 +20428,12 @@ namespace Chummer
 					if (_objCharacter.RES.Value > _objCharacter.RES.TotalMaximum)
 						intEssenceLoss = _objCharacter.RES.Value - _objCharacter.RES.TotalMaximum;
 				}
-			}
+                else if (_objCharacter.DEPEnabled)
+                {
+                    if (_objCharacter.DEP.Value > _objCharacter.DEP.TotalMaximum)
+                        intEssenceLoss = _objCharacter.DEP.Value - _objCharacter.DEP.TotalMaximum;
+                }
+            }
 
 			lblBOD.Text = _objCharacter.BOD.Value.ToString();
 			lblAGI.Text = _objCharacter.AGI.Value.ToString();
@@ -20593,7 +20617,12 @@ namespace Chummer
 						if (_objCharacter.RES.Value > _objCharacter.RES.TotalMaximum)
 							intEssenceLoss = _objCharacter.RES.Value - _objCharacter.RES.TotalMaximum;
 					}
-				}
+                    else if (_objCharacter.DEPEnabled)
+                    {
+                        if (_objCharacter.DEP.Value > _objCharacter.DEP.TotalMaximum)
+                            intEssenceLoss = _objCharacter.DEP.Value - _objCharacter.DEP.TotalMaximum;
+                    }
+                }
 
 				// Update the CharacterAttribute information.
 				lblBOD.Text = _objCharacter.BOD.Value.ToString();
@@ -20727,7 +20756,7 @@ namespace Chummer
                     _objCharacter.MAGAdept = _objCharacter.MAG.TotalValue;
 
 				// If the character is an A.I., set the Edge MetatypeMaximum to their Rating.
-				if (_objCharacter.Metatype == "A.I.")
+				if (_objCharacter.DEPEnabled)
 					_objCharacter.EDG.MetatypeMaximum = _objCharacter.DEP.Value;
 
 				// If the character is Cyberzombie, adjust their Attributes based on their Essence.
@@ -20780,14 +20809,18 @@ namespace Chummer
 						tipTooltip.SetToolTip(cmdImproveMAG, strTooltip);
 						strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.RES.Value + _objCharacter.RES.AttributeValueModifiers + 1).ToString()).Replace("{1}", ((_objCharacter.RES.Value + _objCharacter.RES.AttributeValueModifiers + 1) * _objOptions.KarmaAttribute).ToString());
 						tipTooltip.SetToolTip(cmdImproveRES, strTooltip);
-					}
+                        strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.DEP.Value + _objCharacter.DEP.AttributeValueModifiers + 1).ToString()).Replace("{1}", ((_objCharacter.DEP.Value + _objCharacter.DEP.AttributeValueModifiers + 1) * _objOptions.KarmaAttribute).ToString());
+                        tipTooltip.SetToolTip(cmdImproveDEP, strTooltip);
+                    }
 					else
 					{
 						strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.MAG.Value - _objCharacter.EssencePenalty + 1).ToString()).Replace("{1}", ((_objCharacter.MAG.Value + _objCharacter.EssencePenalty + 1) * _objOptions.KarmaAttribute).ToString());
 						tipTooltip.SetToolTip(cmdImproveMAG, strTooltip);
 						strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.RES.Value - _objCharacter.EssencePenalty + 1).ToString()).Replace("{1}", ((_objCharacter.RES.Value + _objCharacter.EssencePenalty + 1) * _objOptions.KarmaAttribute).ToString());
 						tipTooltip.SetToolTip(cmdImproveRES, strTooltip);
-					}
+                        strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.DEP.Value - _objCharacter.EssencePenalty + 1).ToString()).Replace("{1}", ((_objCharacter.DEP.Value + _objCharacter.EssencePenalty + 1) * _objOptions.KarmaAttribute).ToString());
+                        tipTooltip.SetToolTip(cmdImproveDEP, strTooltip);
+                    }
 				}
 				else
 				{
@@ -20815,14 +20848,18 @@ namespace Chummer
 						tipTooltip.SetToolTip(cmdImproveMAG, strTooltip);
 						strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.RES.Value + _objCharacter.RES.AttributeValueModifiers + 1).ToString()).Replace("{1}", ((_objCharacter.RES.Value + _objCharacter.RES.AttributeValueModifiers + 1) * _objOptions.KarmaAttribute).ToString());
 						tipTooltip.SetToolTip(cmdImproveRES, strTooltip);
-					}
+                        strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.DEP.Value + _objCharacter.DEP.AttributeValueModifiers + 1).ToString()).Replace("{1}", ((_objCharacter.DEP.Value + _objCharacter.DEP.AttributeValueModifiers + 1) * _objOptions.KarmaAttribute).ToString());
+                        tipTooltip.SetToolTip(cmdImproveDEP, strTooltip);
+                    }
 					else
 					{
 						strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.MAG.Value - _objCharacter.EssencePenalty + 1).ToString()).Replace("{1}", ((_objCharacter.MAG.Value - _objCharacter.EssencePenalty + 1) * _objOptions.KarmaAttribute).ToString());
 						tipTooltip.SetToolTip(cmdImproveMAG, strTooltip);
 						strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.RES.Value - _objCharacter.EssencePenalty + 1).ToString()).Replace("{1}", ((_objCharacter.RES.Value - _objCharacter.EssencePenalty + 1) * _objOptions.KarmaAttribute).ToString());
 						tipTooltip.SetToolTip(cmdImproveRES, strTooltip);
-					}
+                        strTooltip = LanguageManager.Instance.GetString("Tip_ImproveItem").Replace("{0}", (_objCharacter.DEP.Value - _objCharacter.EssencePenalty + 1).ToString()).Replace("{1}", ((_objCharacter.DEP.Value - _objCharacter.EssencePenalty + 1) * _objOptions.KarmaAttribute).ToString());
+                        tipTooltip.SetToolTip(cmdImproveDEP, strTooltip);
+                    }
 				}
 
 				// Disable any CharacterAttribute Karma buttons that have reached their Total Metatype Maximum.
@@ -20834,7 +20871,6 @@ namespace Chummer
 				cmdImproveINT.Enabled = !(_objCharacter.INT.Value == _objCharacter.INT.TotalMaximum);
 				cmdImproveLOG.Enabled = !(_objCharacter.LOG.Value == _objCharacter.LOG.TotalMaximum);
 				cmdImproveWIL.Enabled = !(_objCharacter.WIL.Value == _objCharacter.WIL.TotalMaximum);
-				cmdImproveDEP.Enabled = !(_objCharacter.DEP.Value == _objCharacter.DEP.TotalMaximum);
 				cmdImproveEDG.Enabled = !(_objCharacter.EDG.Value == _objCharacter.EDG.TotalMaximum);
 
 				// Disable the Magic or Resonance Karma buttons if they have reached their current limits.
@@ -20848,8 +20884,13 @@ namespace Chummer
 				else
 					cmdImproveRES.Enabled = false;
 
-				// Condition Monitor.
-				UpdateConditionMonitor(lblCMPhysical, lblCMStun, tipTooltip, _objImprovementManager);
+                if (_objCharacter.DEPEnabled)
+                    cmdImproveDEP.Enabled = !(_objCharacter.DEP.Value - intEssenceLoss >= _objCharacter.DEP.TotalMaximum);
+                else
+                    cmdImproveDEP.Enabled = false;
+
+                // Condition Monitor.
+                UpdateConditionMonitor(lblCMPhysical, lblCMStun, tipTooltip, _objImprovementManager);
 				int intCMPhysical = _objCharacter.PhysicalCM;
 				int intCMStun = _objCharacter.StunCM;
 				int intCMOverflow = _objCharacter.CMOverflow;
@@ -21092,33 +21133,22 @@ namespace Chummer
 				}
 
                 // Update Living Persona values.
-                if (_objCharacter.RESEnabled)
+                if (_objCharacter.RESEnabled || _objCharacter.DEPEnabled)
                 {
+                    int intMainAttribute = _objCharacter.RES.TotalValue;
+                    if (_objCharacter.DEPEnabled)
+                        intMainAttribute = _objCharacter.DEP.TotalValue;
                     string strPersonaTip = "";
                     int intFirewall = _objCharacter.WIL.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaFirewall);
                     int intResponse = _objCharacter.INT.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaResponse);
-                    int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(_objCharacter.RES.TotalValue, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
+                    int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(intMainAttribute, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
                     int intSystem = _objCharacter.LOG.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSystem);
                     int intBiofeedback = _objCharacter.CHA.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaBiofeedback);
 
-                    // If this is a Technocritter, their Matrix Attributes always equal their RES.
-                    if (_objCharacter.MetatypeCategory == "Technocritters")
-                    {
-                        intFirewall = _objCharacter.RES.TotalValue;
-                        intSystem = _objCharacter.RES.TotalValue;
-                        intResponse = _objCharacter.RES.TotalValue;
-                        intSignal = _objCharacter.RES.TotalValue;
-                        intBiofeedback = _objCharacter.RES.TotalValue;
-                    }
-
-                    // Make sure none of the Attributes exceed the Technomancer's RES.
-                    intFirewall = Math.Min(intFirewall, _objCharacter.RES.TotalValue);
-                    intResponse = Math.Min(intResponse, _objCharacter.RES.TotalValue);
-                    intSignal = Math.Min(intSignal, _objCharacter.RES.TotalValue);
-                    intSystem = Math.Min(intSystem, _objCharacter.RES.TotalValue);
-
-                    lblLivingPersonaDeviceRating.Text = _objCharacter.RES.TotalValue.ToString();
-                    strPersonaTip = "RES (" + _objCharacter.RES.TotalValue.ToString() + ")";
+                    lblLivingPersonaDeviceRating.Text = intMainAttribute.ToString();
+                    strPersonaTip = "RES (" + intMainAttribute.ToString() + ")";
+                    if (_objCharacter.DEPEnabled)
+                        strPersonaTip = "DEP (" + intMainAttribute.ToString() + ")";
                     tipTooltip.SetToolTip(lblLivingPersonaDeviceRating, strPersonaTip);
 
                     lblLivingPersonaAttack.Text = _objCharacter.CHA.TotalValue.ToString();
@@ -21247,14 +21277,6 @@ namespace Chummer
 
 				// Career Nuyen.
 				lblCareerNuyen.Text = String.Format("{0:###,###,##0¥}", _objCharacter.CareerNuyen);
-
-				// Update A.I. Attributes.
-				if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
-				{
-					lblRating.Text = _objCharacter.Rating.ToString();
-					lblSystem.Text = _objCharacter.System.ToString();
-					lblFirewall.Text = _objCharacter.Firewall.ToString();
-				}
 
 				// Update Damage Resistance Pool.
 				lblCMDamageResistancePool.Text = (_objCharacter.BOD.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.DamageResistance) + _objCharacter.TotalArmorRating).ToString();
@@ -23883,7 +23905,7 @@ namespace Chummer
 				chkVehicleWeaponAccessoryInstalled.Enabled = false;
 				chkVehicleIncludedInWeapon.Checked = false;
 
-				if (_objCharacter.Metatype.EndsWith("A.I.") || _objCharacter.MetatypeCategory == "Technocritters" || _objCharacter.MetatypeCategory == "Protosapients")
+				if (_objCharacter.Metatype.Contains("A.I.") || _objCharacter.MetatypeCategory == "Protosapients")
 				{
 					chkVehicleHomeNode.Visible = true;
 					chkVehicleHomeNode.Checked = objVehicle.HomeNode;

--- a/Chummer/frmCreateImprovement.cs
+++ b/Chummer/frmCreateImprovement.cs
@@ -173,7 +173,9 @@ namespace Chummer
 					frmPickAttribute.AddMAG();
 				if (_objCharacter.RESEnabled)
 					frmPickAttribute.AddRES();
-				frmPickAttribute.ShowDialog(this);
+                if (_objCharacter.DEPEnabled)
+                    frmPickAttribute.AddDEP();
+                frmPickAttribute.ShowDialog(this);
 
 				if (frmPickAttribute.DialogResult == DialogResult.OK)
 					txtSelect.Text = frmPickAttribute.SelectedAttribute;

--- a/Chummer/frmCreatePACKSKit.cs
+++ b/Chummer/frmCreatePACKSKit.cs
@@ -124,7 +124,8 @@ namespace Chummer
 				int intWIL = _objCharacter.WIL.Value - (_objCharacter.WIL.MetatypeMinimum - 1);
 				int intEDG = _objCharacter.EDG.Value - (_objCharacter.EDG.MetatypeMinimum - 1);
 				int intMAG = _objCharacter.MAG.Value - (_objCharacter.MAG.MetatypeMinimum - 1);
-				int intRES = _objCharacter.RES.Value - (_objCharacter.RES.MetatypeMinimum - 1);
+                int intDEP = _objCharacter.DEP.Value - (_objCharacter.DEP.MetatypeMinimum - 1);
+                int intRES = _objCharacter.RES.Value - (_objCharacter.RES.MetatypeMinimum - 1);
 				// <attributes>
 				objWriter.WriteStartElement("attributes");
 				objWriter.WriteElementString("bod", intBOD.ToString());
@@ -140,8 +141,10 @@ namespace Chummer
 					objWriter.WriteElementString("mag", intMAG.ToString());
 				if (_objCharacter.RESEnabled)
 					objWriter.WriteElementString("res", intRES.ToString());
-				// </attributes>
-				objWriter.WriteEndElement();
+                if (_objCharacter.DEPEnabled)
+                    objWriter.WriteElementString("dep", intDEP.ToString());
+                // </attributes>
+                objWriter.WriteEndElement();
 			}
 
 			// Export Qualities.

--- a/Chummer/frmTest.cs
+++ b/Chummer/frmTest.cs
@@ -652,7 +652,8 @@ namespace Chummer
 						_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["resmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["resaug"].InnerText, intForce, 0));
 						_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["edgmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["edgaug"].InnerText, intForce, 0));
 						_objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
-					}
+                        _objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["depaug"].InnerText, intForce, 0));
+                    }
 					else
 					{
 						int intMinModifier = -3;
@@ -671,7 +672,8 @@ namespace Chummer
 						_objCharacter.RES.AssignLimits(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 3));
 						_objCharacter.EDG.AssignLimits(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 3));
 						_objCharacter.ESS.AssignLimits(ExpressionToString(objXmlMetatype["essmin"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0), ExpressionToString(objXmlMetatype["essaug"].InnerText, intForce, 0));
-					}
+                        _objCharacter.DEP.AssignLimits(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, intMinModifier), ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 3), ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 3));
+                    }
 
 					// If we're working with a Critter, set the Attributes to their default values.
 					if (strFile == "critters.xml")
@@ -688,7 +690,8 @@ namespace Chummer
 						_objCharacter.RES.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["resmin"].InnerText, intForce, 0));
 						_objCharacter.EDG.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["edgmin"].InnerText, intForce, 0));
 						_objCharacter.ESS.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["essmax"].InnerText, intForce, 0));
-					}
+                        _objCharacter.DEP.Value = Convert.ToInt32(ExpressionToString(objXmlMetatype["depmin"].InnerText, intForce, 0));
+                    }
 
 					// Sprites can never have Physical Attributes or WIL.
 					if (objXmlMetatype["name"].InnerText.EndsWith("Sprite"))
@@ -697,7 +700,6 @@ namespace Chummer
 						_objCharacter.AGI.AssignLimits("0", "0", "0");
 						_objCharacter.REA.AssignLimits("0", "0", "0");
 						_objCharacter.STR.AssignLimits("0", "0", "0");
-						_objCharacter.WIL.AssignLimits("0", "0", "0");
 						_objCharacter.INI.MetatypeMinimum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
 						_objCharacter.INI.MetatypeMaximum = Convert.ToInt32(ExpressionToString(objXmlMetatype["inimax"].InnerText, intForce, 0));
 					}


### PR DESCRIPTION
Application Changes:

- Fixed the bug where Matrix entities would have SR4 stats in career mode.
- Depth is now properly handled in ways similar to Resonance and Magic. While this currently only affects critters, it should be a precursor to proper AI chargen.
- Fixed a bug where setting the metatype maximum of an attribute to a value lower than the current value would lower the current value, even if the current value was not higher than the total maximum.
- Removed SR4 labels from Matrix entities in Create mode.
- Added the ability for priorities to add to Depth.

Data Changes:

- Added and/or updated all critter powers to SR5, complete with proper references.
- Added the Flight skill as described by the core rulebook. It will only show up for characters with a non-zero Fly speed.
- Added and/or updated the following critter types from SR5: mundane critters from both CRB and HS, paracritters from both CRB and HS, technocritters from HS, insect spirits from SG, sprites from CRB, protosapients from HS, infected critters from HS, toxic spirits from SG, shadow spirits from SG, shedim from SG, and blood spirits from SG. Currently, the following entries are missing: toxic critters from HS, otherworldly beings from HS, and the Manananggal and Engkanto from SG.
- Added all missing Critter Gear from HS.
- Added Specialized Biodrone Cyberware from HS.