### PR TITLE
Qualities List Hotfix

### DIFF
--- a/Chummer/Selection Forms/frmSelectQuality.cs
+++ b/Chummer/Selection Forms/frmSelectQuality.cs
@@ -409,12 +409,12 @@ namespace Chummer
 
                 bool blnNeedQualityWhitelist = false;
                 XmlNode objXmlMetatype = objXmlMetatypeDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + _objCharacter.Metatype + "\"]");
-                if (objXmlMetatype?.SelectNodes("qualityrestriction") != null)
+                if (objXmlMetatype?.SelectNodes("qualityrestriction")?.Count > 0)
                     blnNeedQualityWhitelist = true;
                 else
                 {
                     objXmlMetatype = objXmlCrittersDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + _objCharacter.Metatype + "\"]");
-                    if (objXmlMetatype?.SelectNodes("qualityrestriction") != null)
+                    if (objXmlMetatype?.SelectNodes("qualityrestriction")?.Count > 0)
                         blnNeedQualityWhitelist = true;
                 }
                 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -41,6 +41,7 @@ Data Changes:
 - Added entries for the AI programs and advanced programs that protosapient critters come with by default.
 - Removed the duplicate entry for the Chatty quality.
 - Updated Inherent Program quality so that it allows the player to choose a program from a list rather than type one in.
+- Updated Fragmentation quality so that it allows the player to specify the negative psychological quality that it exhibits.
 
 Build 188
 

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -10407,6 +10407,7 @@
 					<name>ESS</name>
 					<val>-1</val>
 				</specificattribute>
+				<selecttext />
 			</bonus>
 			<required>
 				<oneof>


### PR DESCRIPTION
Fixed the bug that was causing the quality list to appear empty.

Added a text field to the Fragmentation quality so that players can specify its psychological effect.