### PR TITLE
Updated german character sheets

### DIFF
--- a/Chummer/sheets/de/Shadowrun 5 (Grouped Skills by Name).xsl
+++ b/Chummer/sheets/de/Shadowrun 5 (Grouped Skills by Name).xsl
@@ -32,25 +32,22 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:value-of select="total" />
-													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="total + 2" />)</xsl:if>
+													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
-													<strong><xsl:value-of select="rating" /></strong>
+													<xsl:value-of select="rating" />
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="attributemod" />
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
 													<xsl:value-of select="ratingmod" />
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="poolmod" />
 												</td>
 											</tr>
 		</xsl:for-each>
@@ -84,25 +81,22 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:value-of select="total" />
-													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="total + 2" />)</xsl:if>
+													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
-													<strong><xsl:value-of select="rating" /></strong>
+													<xsl:value-of select="rating" />
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="attributemod" />
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
 													<xsl:value-of select="ratingmod" />
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="poolmod" />
 												</td>
 											</tr>
 		</xsl:for-each>
@@ -116,29 +110,19 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:if test="islanguage = 'True'">Sprache: </xsl:if>
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:choose>
 														<xsl:when test="islanguage = 'True' and rating = 0">
 															M
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="total" />
-															<xsl:if test="spec != ''"> (<xsl:value-of select="total + 2" />)</xsl:if>
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															<strong>M</strong>
-														</xsl:when>
-														<xsl:otherwise>
-															<strong><xsl:value-of select="rating" /></strong>
+															<xsl:if test="spec != ''"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -148,7 +132,17 @@
 															M
 														</xsl:when>
 														<xsl:otherwise>
-															<xsl:value-of select="attributemod" />
+															<xsl:value-of select="rating" />
+														</xsl:otherwise>
+													</xsl:choose>
+												</td>
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:choose>
+														<xsl:when test="islanguage = 'True' and rating = 0">
+															M
+														</xsl:when>
+														<xsl:otherwise>
+															<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -159,16 +153,6 @@
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="ratingmod" />
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															M
-														</xsl:when>
-														<xsl:otherwise>
-															<xsl:value-of select="poolmod" />
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -180,29 +164,19 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
-													<xsl:if test="islanguage = 'True'">Sprache: </xsl:if>
+												<td width="45%" valign="top">
+													<xsl:if test="islanguage = 'islanguage'">Sprache: </xsl:if>
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:choose>
 														<xsl:when test="islanguage = 'True' and rating = 0">
 															M
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="total" />
-															<xsl:if test="spec != ''"> (<xsl:value-of select="total + 2" />)</xsl:if>
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															<strong>M</strong>
-														</xsl:when>
-														<xsl:otherwise>
-															<strong><xsl:value-of select="rating" /></strong>
+															<xsl:if test="spec != ''"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -212,7 +186,17 @@
 															M
 														</xsl:when>
 														<xsl:otherwise>
-															<xsl:value-of select="attributemod" />
+															<xsl:value-of select="rating" />
+														</xsl:otherwise>
+													</xsl:choose>
+												</td>
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:choose>
+														<xsl:when test="islanguage = 'True' and rating = 0">
+															M
+														</xsl:when>
+														<xsl:otherwise>
+															<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -223,16 +207,6 @@
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="ratingmod" />
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															M
-														</xsl:when>
-														<xsl:otherwise>
-															<xsl:value-of select="poolmod" />
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>

--- a/Chummer/sheets/de/Shadowrun 5 (Grouped Skills by Rating).xsl
+++ b/Chummer/sheets/de/Shadowrun 5 (Grouped Skills by Rating).xsl
@@ -32,25 +32,22 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:value-of select="total" />
-													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="total + 2" />)</xsl:if>
+													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
-													<strong><xsl:value-of select="rating" /></strong>
+													<xsl:value-of select="rating" />
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="attributemod" />
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
 													<xsl:value-of select="ratingmod" />
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="poolmod" />
 												</td>
 											</tr>
 		</xsl:for-each>
@@ -84,25 +81,22 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:value-of select="total" />
-													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="total + 2" />)</xsl:if>
+													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
-													<strong><xsl:value-of select="rating" /></strong>
+													<xsl:value-of select="rating" />
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="attributemod" />
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 												</td>
 												<td width="10%" style="text-align:center;" valign="top">
 													<xsl:value-of select="ratingmod" />
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:value-of select="poolmod" />
 												</td>
 											</tr>
 		</xsl:for-each>
@@ -116,29 +110,19 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:if test="islanguage = 'True'">Sprache: </xsl:if>
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:choose>
 														<xsl:when test="islanguage = 'True' and rating = 0">
 															M
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="total" />
-															<xsl:if test="spec != ''"> (<xsl:value-of select="total + 2" />)</xsl:if>
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															<strong>M</strong>
-														</xsl:when>
-														<xsl:otherwise>
-															<strong><xsl:value-of select="rating" /></strong>
+															<xsl:if test="spec != ''"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -148,7 +132,17 @@
 															M
 														</xsl:when>
 														<xsl:otherwise>
-															<xsl:value-of select="attributemod" />
+															<xsl:value-of select="rating" />
+														</xsl:otherwise>
+													</xsl:choose>
+												</td>
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:choose>
+														<xsl:when test="islanguage = 'True' and rating = 0">
+															M
+														</xsl:when>
+														<xsl:otherwise>
+															<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -159,16 +153,6 @@
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="ratingmod" />
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															M
-														</xsl:when>
-														<xsl:otherwise>
-															<xsl:value-of select="poolmod" />
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -180,29 +164,19 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
-													<xsl:if test="islanguage = 'True'">Sprache: </xsl:if>
+												<td width="45%" valign="top">
+													<xsl:if test="islanguage = 'islanguage'">Sprache: </xsl:if>
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:choose>
 														<xsl:when test="islanguage = 'True' and rating = 0">
 															M
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="total" />
-															<xsl:if test="spec != ''"> (<xsl:value-of select="total + 2" />)</xsl:if>
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															<strong>M</strong>
-														</xsl:when>
-														<xsl:otherwise>
-															<strong><xsl:value-of select="rating" /></strong>
+															<xsl:if test="spec != ''"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -212,7 +186,17 @@
 															M
 														</xsl:when>
 														<xsl:otherwise>
-															<xsl:value-of select="attributemod" />
+															<xsl:value-of select="rating" />
+														</xsl:otherwise>
+													</xsl:choose>
+												</td>
+												<td width="20%" style="text-align:center;" valign="top">
+													<xsl:choose>
+														<xsl:when test="islanguage = 'True' and rating = 0">
+															M
+														</xsl:when>
+														<xsl:otherwise>
+															<xsl:value-of select="attributemod" /> (<xsl:value-of select="displayattribute" />)
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>
@@ -223,16 +207,6 @@
 														</xsl:when>
 														<xsl:otherwise>
 															<xsl:value-of select="ratingmod" />
-														</xsl:otherwise>
-													</xsl:choose>
-												</td>
-												<td width="10%" style="text-align:center;" valign="top">
-													<xsl:choose>
-														<xsl:when test="islanguage = 'True' and rating = 0">
-															M
-														</xsl:when>
-														<xsl:otherwise>
-															<xsl:value-of select="poolmod" />
 														</xsl:otherwise>
 													</xsl:choose>
 												</td>

--- a/Chummer/sheets/de/Shadowrun 5 Base.xslt
+++ b/Chummer/sheets/de/Shadowrun 5 Base.xslt
@@ -464,10 +464,10 @@
 										<strong>Aktionsfertigkeiten</strong>
 										<table width="100%" cellspacing="0" cellpadding="0" border="0">
 											<tr>
-												<td width="50%">
+												<td width="45%">
 													<strong>Fertigkeit</strong>
 												</td>
-												<td width="10%" style="text-align:center;">
+												<td width="15%" style="text-align:center;">
 													<strong>Pool</strong>
 												</td>
 												<td width="10%" style="text-align:center;">
@@ -487,10 +487,10 @@
 										<strong>Aktionsfertigkeiten</strong>
 										<table width="100%" cellspacing="0" cellpadding="0" border="0">
 											<tr>
-												<td width="50%">
+												<td width="45%">
 													<strong>Fertigkeit</strong>
 												</td>
-												<td width="10%" style="text-align:center;">
+												<td width="15%" style="text-align:center;">
 													<strong>Pool</strong>
 												</td>
 												<td width="10%" style="text-align:center;">
@@ -510,10 +510,10 @@
 										<strong>Wissensfertigkeiten</strong>
 										<table width="100%" cellspacing="0" cellpadding="0" border="0">
 											<tr>
-												<td width="50%">
+												<td width="45%">
 													<strong>Fertigkeit</strong>
 												</td>
-												<td width="10%" style="text-align:center;">
+												<td width="15%" style="text-align:center;">
 													<strong>Pool</strong>
 												</td>
 												<td width="10%" style="text-align:center;">
@@ -547,10 +547,10 @@
 				</div>
 				
 				<div class="block" id="LimitsBlock">
-					<table width="100%" cellspacing="0" cellpadding="0" class="tableborder">
+					<table width="100%" cellspacing="0" cellpadding="0" border="0">
 						<tr>
 							<td width="100%">
-								<table width="100%" cellspacing="0" cellpadding="0" border="0">
+								<table width="100%" cellspacing="0" cellpadding="0" border="0" class="tableborder">
 									<tr>
 										<td width="25%" style="text-align:center;" valign="top">
 											<strong>Körperliches Limit: <xsl:value-of
@@ -1760,7 +1760,7 @@
 																<xsl:if test="position() mod 2 != 1">
 																	<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 																</xsl:if>
-																<td colspan="4" class="notesrow">
+																<td colspan="6" class="notesrow">
 																	<xsl:call-template name="PreserveLineBreaks">
 																		<xsl:with-param name="text" select="notes" />
 																	</xsl:call-template>
@@ -1974,7 +1974,7 @@
 										<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 									</xsl:if>
 									<td></td>
-									<td style="text-align:center;" valign="top">S: <xsl:value-of select="ranges/short" /></td>
+									<td style="text-align:center;" valign="top">K: <xsl:value-of select="ranges/short" /></td>
 									<td style="text-align:center;" valign="top">M: <xsl:value-of select="ranges/medium" /></td>
 									<td style="text-align:center;" valign="top">L: <xsl:value-of select="ranges/long" /></td>
 									<td style="text-align:center;" valign="top">E: <xsl:value-of select="ranges/extreme" /></td>
@@ -2042,7 +2042,7 @@
 										<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 									</xsl:if>
 									<td></td>
-									<td style="text-align:center;" valign="top">S: <xsl:value-of select="ranges/short" /></td>
+									<td style="text-align:center;" valign="top">K: <xsl:value-of select="ranges/short" /></td>
 									<td style="text-align:center;" valign="top">M: <xsl:value-of select="ranges/medium" /></td>
 									<td style="text-align:center;" valign="top">L: <xsl:value-of select="ranges/long" /></td>
 									<td style="text-align:center;" valign="top">E: <xsl:value-of select="ranges/extreme" /></td>
@@ -3079,7 +3079,7 @@
 										<strong>SM</strong>
 									</td>
 									<td width="7%" style="text-align:center;">
-										<strong>Seats</strong>
+										<strong>Sitze</strong>
 									</td>
 									<td width="6%" style="text-align:center;">
 										<strong>G-Stuf.</strong>

--- a/Chummer/sheets/de/Shadowrun 5.xsl
+++ b/Chummer/sheets/de/Shadowrun 5.xsl
@@ -13,11 +13,11 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:value-of select="total" />
 													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 												</td>
@@ -43,11 +43,11 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:value-of select="total" />
 													<xsl:if test="spec != '' and exotic = 'False'"> (<xsl:value-of select="specializedrating" />)</xsl:if>
 												</td>
@@ -71,12 +71,12 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:if test="islanguage = 'True'">Sprache: </xsl:if>
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:choose>
 														<xsl:when test="islanguage = 'True' and rating = 0">
 															M
@@ -125,12 +125,12 @@
 												<xsl:if test="position() mod 2 != 1">
 													<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
 												</xsl:if>
-												<td width="50%" valign="top">
+												<td width="45%" valign="top">
 													<xsl:if test="islanguage = 'islanguage'">Sprache: </xsl:if>
 													<xsl:value-of select="name" />
 													<xsl:if test="spec != ''"> (<xsl:value-of select="spec" />)</xsl:if>
 												</td>
-												<td width="10%" style="text-align:center;" valign="top">
+												<td width="15%" style="text-align:center;" valign="top">
 													<xsl:choose>
 														<xsl:when test="islanguage = 'True' and rating = 0">
 															M


### PR DESCRIPTION
Updated the german character sheets to reflect some of the layout changes done in the english version. Also did a few missing translations.

List of changes:
- Updated skills table to match the english layout (display attribute name, column widths).
- Moved "class=tableborder" of LimitsBlock to inner table. Before this, the "hseparator" after that block is inside of the table border. Now the layout matches other blocks.
- Increased contact notes column span to entire table. Before this, it only covered 4 of the 6 columns.
- Translated ranged weapon range table abbreviation from "S" for "Short" to "K" for "Kurz", which is the term already used in the UI weapon pane.
- Translated vehicle table header for "Seats" to "Sitze".