### PR TITLE
XML Node Filtering, Weapon Fixes

### DIFF
--- a/Chummer/Backend/Extensions/XmlNodeExtensions.cs
+++ b/Chummer/Backend/Extensions/XmlNodeExtensions.cs
@@ -37,72 +37,80 @@ namespace Chummer.Backend
                 else
                 {
                     XmlNodeList objXmlTargetNodeList = objXmlParentNode.SelectNodes(objXmlOperationChildNode.Name);
-                    // default is "any", replace with switch() if more check modes are necessary
-                    boolOperationChildNodeResult = false;
-                    if (objXmlOperationChildNode?.Attributes?["checktype"]?.InnerText == "all")
-                        boolOperationChildNodeResult = true;
-
-                    boolOperationChildNodeResult = boolSubNodeResult = boolInvert;
-                    foreach (XmlNode objXmlTargetNode in objXmlTargetNodeList)
+                    // If we're just checking for existance of a node, no need for more processing
+                    if (objXmlOperationChildNode.Attributes?["operation"]?.InnerText == "exists")
                     {
-                        boolSubNodeResult = boolInvert;
-                        if (objXmlTargetNode.SelectNodes("*").Count > 0)
-                        {
-                            if (objXmlOperationChildNode.SelectNodes("*").Count > 0)
-                                boolSubNodeResult = processFilterOperationNode(objXmlTargetNode, objXmlOperationChildNode, objXmlOperationChildNode.Attributes?["OR"] != null) != boolInvert;
-                        }
-                        else
-                        {
-                            strOperationType = "==";
-                            if (objXmlOperationChildNode.Attributes["operation"] != null)
-                                strOperationType = objXmlOperationChildNode.Attributes["operation"].InnerText;
-                            // Note when adding more operation cases: XML does not like the "<" symbol as part of an attribute value
-                            switch (strOperationType)
-                            {
-                                case "doesnotequal":
-                                case "notequals":
-                                case "!=":
-                                    boolInvert = !boolInvert;
-                                    goto case "==";
-                                case "lessthan":
-                                    boolInvert = !boolInvert;
-                                    goto case ">=";
-                                case "lessthanequals":
-                                    boolInvert = !boolInvert;
-                                    goto case ">";
-
-                                case "like":
-                                case "contains":
-                                    boolSubNodeResult = objXmlTargetNode.InnerText.Contains(objXmlOperationChildNode.InnerText) != boolInvert;
-                                    break;
-                                case "greaterthan":
-                                case ">":
-                                    boolSubNodeResult = (System.Convert.ToInt32(objXmlTargetNode.InnerText) > Convert.ToInt32(objXmlOperationChildNode.InnerText)) != boolInvert;
-                                    break;
-                                case "greaterthanequals":
-                                case ">=":
-                                    boolSubNodeResult = (Convert.ToInt32(objXmlTargetNode.InnerText) >= Convert.ToInt32(objXmlOperationChildNode.InnerText)) != boolInvert;
-                                    break;
-                                case "equals":
-                                case "==":
-                                default:
-                                    boolSubNodeResult = (objXmlTargetNode.InnerText == objXmlOperationChildNode.InnerText) != boolInvert;
-                                    break;
-                            }
-                        }
+                        boolOperationChildNodeResult = (objXmlTargetNodeList.Count > 0) != boolInvert;
+                    }
+                    else
+                    {
+                        // default is "any", replace with switch() if more check modes are necessary
+                        boolOperationChildNodeResult = false;
                         if (objXmlOperationChildNode.Attributes?["checktype"]?.InnerText == "all")
+                            boolOperationChildNodeResult = true;
+
+                        boolSubNodeResult = boolInvert;
+                        foreach (XmlNode objXmlTargetNode in objXmlTargetNodeList)
                         {
-                            if (!boolSubNodeResult)
+                            boolSubNodeResult = boolInvert;
+                            if (objXmlTargetNode.SelectNodes("*").Count > 0)
                             {
-                                boolOperationChildNodeResult = false;
+                                if (objXmlOperationChildNode.SelectNodes("*").Count > 0)
+                                    boolSubNodeResult = processFilterOperationNode(objXmlTargetNode, objXmlOperationChildNode, objXmlOperationChildNode.Attributes?["OR"] != null) != boolInvert;
+                            }
+                            else
+                            {
+                                strOperationType = "==";
+                                if (objXmlOperationChildNode.Attributes?["operation"] != null)
+                                    strOperationType = objXmlOperationChildNode.Attributes["operation"].InnerText;
+                                // Note when adding more operation cases: XML does not like the "<" symbol as part of an attribute value
+                                switch (strOperationType)
+                                {
+                                    case "doesnotequal":
+                                    case "notequals":
+                                    case "!=":
+                                        boolInvert = !boolInvert;
+                                        goto case "==";
+                                    case "lessthan":
+                                        boolInvert = !boolInvert;
+                                        goto case ">=";
+                                    case "lessthanequals":
+                                        boolInvert = !boolInvert;
+                                        goto case ">";
+
+                                    case "like":
+                                    case "contains":
+                                        boolSubNodeResult = objXmlTargetNode.InnerText.Contains(objXmlOperationChildNode.InnerText) != boolInvert;
+                                        break;
+                                    case "greaterthan":
+                                    case ">":
+                                        boolSubNodeResult = (System.Convert.ToInt32(objXmlTargetNode.InnerText) > Convert.ToInt32(objXmlOperationChildNode.InnerText)) != boolInvert;
+                                        break;
+                                    case "greaterthanequals":
+                                    case ">=":
+                                        boolSubNodeResult = (Convert.ToInt32(objXmlTargetNode.InnerText) >= Convert.ToInt32(objXmlOperationChildNode.InnerText)) != boolInvert;
+                                        break;
+                                    case "equals":
+                                    case "==":
+                                    default:
+                                        boolSubNodeResult = (objXmlTargetNode.InnerText == objXmlOperationChildNode.InnerText) != boolInvert;
+                                        break;
+                                }
+                            }
+                            if (objXmlOperationChildNode.Attributes?["checktype"]?.InnerText == "all")
+                            {
+                                if (!boolSubNodeResult)
+                                {
+                                    boolOperationChildNodeResult = false;
+                                    break;
+                                }
+                            }
+                            // default is "any", replace above with a switch() should more than two checktypes be required
+                            else if (boolSubNodeResult)
+                            {
+                                boolOperationChildNodeResult = true;
                                 break;
                             }
-                        }
-                        // default is "any", replace above with a switch() should more than two checktypes be required
-                        else if (boolSubNodeResult)
-                        {
-                            boolOperationChildNodeResult = true;
-                            break;
                         }
                     }
                 }

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -40,6 +40,7 @@ Application Changes:
 - Fixed a bug, where Chummer would crash when adding an AI program with a different category selected.
 - Fixed a bug, where Karma costs for Ai programs weren't saved.
 - Gave all advanced AI programs unique UUIDs instead of all sharing one with the browse common program.
+- Added a new operation to XML node filtering, "exists", which simply checks whether a specific node exists.
 
 Data Changes: 
 
@@ -68,6 +69,8 @@ Data Changes:
 - Added entries for the following knowledge skills from Run Faster: Farming, Foster System, Critters, Strategy, DIY, Mechanics, Fashion Design (the Professional version of Fashion), Crook Hangouts, Administration, Magical Law, Drones (removed the spec from Vehicles), Law Enforcement Procedures (separate from Security Procedures), Lone Star Procedures, Codes, Black Markets, National Threats, Government Procedures, Security Procedures, Smuggler Safehouses, Smuggler Routes, Blade Design, Gun Trivia, Magical Theory (Street), Magical Security, Megacorp Law (Street), Charity Shelters, Alchemy (Professional), Telesma, Foreign Military, NAN Military, Peacekeepers, Military Vehicles, Tir Military Vehicles, Matrix Threats, Psychology, Sociology, Philosophy, Journalism.
 - Fixed incorrect references to the Pilot Anthroform skill.
 - Fixed missing skill bonuses for the High School life module. 
+- Fixed weapon mods with useskill-reliant filtering not working for weapons without a useskill tag, but whose weapon category would be covered by the skill specified in useskill.
+- Fixed most Improvised Weapons using the Exotic Melee Weapon skill instead of the Clubs or Blades skills (Blades for weapons that can only be used by stabbing), and also fixed the Hammer/Sledgehammer and Pool Cue improvised weapons not being eligible for the Hammers and Staves specializations respectively within Clubs.
 
 New Strings:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -75,6 +75,22 @@ Data Changes:
 New Strings:
 
 - Tip_RemainingModCapacity
+- Message_DroneIllegalDowngrade
+- String_ExpenseLearnProgram
+- Message_DeleteAIProgram
+- Checkbox_SelectAIProgram_LimitList
+- MessageTitle_SelectAIProgram_AdvancedProgramRequirement
+- Message_SelectAIProgram_AdvancedProgramRequirement
+- Title_SelectAIProgram
+- Node_SelectedAIPrograms
+- String_Requires
+- Button_AddProgram
+- Label_AIProgramsAdvancedPrograms
+- Tab_AdvancedPrograms
+- Label_Options_NewAIAdvancedProgram
+- Label_Options_NewAIProgram
+- Label_SummaryAIAdvancedPrograms
+- Label_SummaryAINormalPrograms
 
 Build 188
 

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -3465,7 +3465,7 @@
 			<avail>0</avail>
 			<cost>0</cost>
 			<allowaccessory>false</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3484,7 +3484,7 @@
 			<ammo>0</ammo>
 			<avail>0</avail>
 			<cost>0</cost>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3524,7 +3524,7 @@
 			<avail>0</avail>
 			<cost>30</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3544,7 +3544,7 @@
 			<avail>0</avail>
 			<cost>0</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Blades</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3564,7 +3564,7 @@
 			<avail>0</avail>
 			<cost>20</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3584,7 +3584,8 @@
 			<avail>0</avail>
 			<cost>30</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
+			<spec>Hammers</spec>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3604,7 +3605,7 @@
 			<avail>As weapon</avail>
 			<cost>As weapon</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3624,7 +3625,8 @@
 			<avail>0</avail>
 			<cost>45</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
+			<spec>Staves</spec>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3644,7 +3646,7 @@
 			<avail>As weapon</avail>
 			<cost>As weapon</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -3664,7 +3666,8 @@
 			<avail>1</avail>
 			<cost>40</cost>
 			<allowaccessory>true</allowaccessory>
-			<useskill>Exotic Melee Weapon</useskill>
+			<useskill>Clubs</useskill>
+			<spec>Hammers</spec>
 			<source>RG</source>
 			<page>22</page>
 		</weapon>
@@ -8985,6 +8988,15 @@
 				<weapondetails>
 					<OR>
 						<useskill>Pistols</useskill>
+						<AND>
+							<useskill NOT="" operation="exists" />
+							<OR>
+								<category>Tasers</category>
+								<category>Holdouts</category>
+								<category>Light Pistols</category>
+								<category>Heavy Pistols</category>
+							</OR>
+						</AND>
 						<category>Machine Pistols</category>
 						<conceal operation="lessthanequals">0</conceal>
 					</OR>
@@ -9539,6 +9551,14 @@
 				<OR>
 					<category>Assault Rifles</category>
 					<useskill>Longarms</useskill>
+					<AND>
+						<useskill NOT="" operation="exists" />
+						<OR>
+							<category>Shotguns</category>
+							<category>Sporting Rifles</category>
+							<category>Sniper Rifles</category>
+						</OR>
+					</AND>
 				</OR>
 			</required>
 			<source>HT</source>
@@ -9567,6 +9587,20 @@
 					<category>Assault Rifles</category>
 					<useskill>Longarms</useskill>
 					<useskill>Heavy Weapons</useskill>
+					<AND>
+						<useskill NOT="" operation="exists" />
+						<OR>
+							<category>Shotguns</category>
+							<category>Sporting Rifles</category>
+							<category>Sniper Rifles</category>
+							<category>Light Machine Guns</category>
+							<category>Medium Machine Guns</category>
+							<category>Heavy Machine Guns</category>
+							<category>Assault Cannons</category>
+							<category>Grenade Launchers</category>
+							<category>Missile Launchers</category>
+						</OR>
+					</AND>
 				</OR>
 			</required>
 			<source>HT</source>
@@ -9626,6 +9660,14 @@
 						<category>Heavy Pistols</category>
 						<category>Assault Rifles</category>
 						<useskill>Longarms</useskill>
+						<AND>
+							<useskill NOT="" operation="exists" />
+							<OR>
+								<category>Shotguns</category>
+								<category>Sporting Rifles</category>
+								<category>Sniper Rifles</category>
+							</OR>
+						</AND>
 					</OR>
 				</weapondetails>
 			</required>
@@ -9675,6 +9717,14 @@
 						<category>Heavy Pistols</category>
 						<category>Assault Rifles</category>
 						<useskill>Longarms</useskill>
+						<AND>
+							<useskill NOT="" operation="exists" />
+							<OR>
+								<category>Shotguns</category>
+								<category>Sporting Rifles</category>
+								<category>Sniper Rifles</category>
+							</OR>
+						</AND>
 					</OR>
 					<conceal operation="greaterthan">0</conceal>
 				</weapondetails>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -7483,6 +7483,10 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
 			<key>String_ExpenseLearnProgram</key>
 			<text>Apprentissage du programme d'IA</text>
 		</string>
+		<string>
+			<key>Message_DroneIllegalDowngrade</key>
+			<text>Les {0} drones suivants ont des rétrogradés qui trop réduisent leurs attributs:</text>
+		</string>
 	<!-- End Region -->
   </strings>
 </chummer>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -7450,7 +7450,7 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
 		</string>
 		<string>
 			<key>String_Requires</key>
-			<text>Prérequis du Programme:</text>
+			<text>Prérequis:</text>
 		</string>
 		<string>
 			<key>Node_SelectedAIPrograms</key>

--- a/Chummer/lang/jp.xml
+++ b/Chummer/lang/jp.xml
@@ -7476,6 +7476,10 @@
 			<key>String_ExpenseLearnProgram</key>
 			<text>Learned AI Program</text>
 		</string>
+		<string>
+			<key>Message_DroneIllegalDowngrade</key>
+			<text>The following {0} drones have downgrades which decrease their attributes too far:</text>
+		</string>
 	<!-- End Region -->
   </strings>
 </chummer>


### PR DESCRIPTION
Nightly-only changes:

- Added missing strings for illegal drone downgrade message to the Japanese and French files.
- Populated the New Strings section of the changelog with all AI-related new strings.

Application Changes:

- Added a new operation to XML node filtering, "exists", which simply checks whether a specific node exists.

Data Changes:

- Fixed weapon mods with useskill-reliant filtering not working for weapons without a useskill tag, but whose weapon category would be covered by the skill specified in useskill.
- Fixed most Improvised Weapons using the Exotic Melee Weapon skill instead of the Clubs or Blades skills (Blades for weapons that can only be used by stabbing), and also fixed the Hammer/Sledgehammer and Pool Cue improvised weapons not being eligible for the Hammers and Staves specializations respectively within Clubs.