### PR TITLE
Hard Targets and Stimtouch Hosiery Additions

### DIFF
--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -46,7 +46,7 @@ Application Changes:
 - Added filter and sort options for knowledge skills. 
 - Added some logic to prevent crashes if the Character Roster watch folder is deleted. 
 - Added drag-drop functionality to the character roster to enable more easily marking a character as a favourite.
-- Fixed an issue with life modules not properly adding qualities. 
+- Fixed an issue with life modules not properly adding qualities.
 
 Data Changes: 
 
@@ -79,6 +79,10 @@ Data Changes:
 - Fixed most Improvised Weapons using the Exotic Melee Weapon skill instead of the Clubs or Blades skills (Blades for weapons that can only be used by stabbing), and also fixed the Hammer/Sledgehammer and Pool Cue improvised weapons not being eligible for the Hammers and Staves specializations respectively within Clubs.
 - Implemented the Latent Dracomorphosis quality from Howling Shadows. This is achieved by using the Swap Quality function in Career Mode. 
 - Added an underbarrel grenade launcher to weapons.xml, and to the Matilda drone. 
+- Added contact types, knowledge skill specializations, and critters from Hard Targets.
+- Added entries for Fab Sensor, Fab Sensor Upkeep, Infected: Sukuyan, Corps Cadavre ritual, Zombie ritual, Máquina Conversion vehicle mod, Dynamic Tension Bow, and Collapsible Traditional Bow accessory from Hard Targets.
+- Added a weapon entry for Stimtouch Hosiery similar to how Grapple Gun adds a weapon entry.
+- Added extra filtering conditions to all Advanced Safety System accessories, Shock Pad, Concealed Quick-Draw Holster, Trigger Removal, and Smartgun System (both Internal and External) so that they do show up in even fewer invalid cases.
 
 New Strings:
 

--- a/Chummer/data/contacts.xml
+++ b/Chummer/data/contacts.xml
@@ -28,6 +28,7 @@
     <contact>Blogger</contact>
     <contact>Bodyguard</contact>
     <contact>Bookie</contact>
+	<contact>Cleaner</contact>
     <contact>Club Hopper</contact>
     <contact>Club Owner</contact>
     <contact>Company Man</contact>
@@ -52,12 +53,16 @@
     <contact>Hermetic Academic</contact>
     <contact>High Stakes Negotiator</contact>
     <contact>ID Manufacturer</contact>
+	<contact>Infobroker</contact>
     <contact>Janitor</contact>
     <contact>Mafia Consiglieri</contact>
     <contact>Mechanic</contact>
+	<contact>Mercenary Alchemist</contact>
     <contact>Mr. Johnson</contact>
     <contact>Nomad</contact>
     <contact>Ork Nation Organizer</contact>
+	<contact>Parabotanist</contact>
+	<contact>Parabiologist</contact>
     <contact>Paramed</contact>
     <contact>Paramed Shaman</contact>
     <contact>Parasecurity Expert</contact>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -11911,39 +11911,39 @@
     </metatype>
     <metatype>
       <id>3f0e3715-e626-4cbe-9e4b-f5b3df07f8b4</id>
-      <name>Boa Constrictor</name>
+      <name>Magui</name>
       <category>Mundane Critters</category>
       <karma>0</karma>
       <bodmin>6</bodmin>
       <bodmax>6</bodmax>
       <bodaug>6</bodaug>
-      <agimin>4</agimin>
-      <agimax>4</agimax>
-      <agiaug>4</agiaug>
-      <reamin>1</reamin>
-      <reamax>1</reamax>
-      <reaaug>1</reaaug>
-      <strmin>8</strmin>
-      <strmax>8</strmax>
-      <straug>8</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>5</intmin>
-      <intmax>5</intmax>
-      <intaug>5</intaug>
-      <logmin>1</logmin>
-      <logmax>1</logmax>
-      <logaug>1</logaug>
+      <agimin>6</agimin>
+      <agimax>6</agimax>
+      <agiaug>6</agiaug>
+      <reamin>3</reamin>
+      <reamax>3</reamax>
+      <reaaug>3</reaaug>
+      <strmin>12</strmin>
+      <strmax>12</strmax>
+      <straug>12</straug>
+      <chamin>3</chamin>
+      <chamax>3</chamax>
+      <chaaug>3</chaaug>
+      <intmin>6</intmin>
+      <intmax>6</intmax>
+      <intaug>6</intaug>
+      <logmin>4</logmin>
+      <logmax>4</logmax>
+      <logaug>4</logaug>
       <wilmin>2</wilmin>
       <wilmax>2</wilmax>
       <wilaug>2</wilaug>
       <inimin>3</inimin>
       <inimax>15</inimax>
       <iniaug>15</iniaug>
-      <edgmin>0</edgmin>
-      <edgmax>0</edgmax>
-      <edgaug>0</edgaug>
+      <edgmin>2</edgmin>
+      <edgmax>5</edgmax>
+      <edgaug>5</edgaug>
       <magmin>0</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
@@ -11953,25 +11953,32 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>3/7</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>8/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <enabletab>
           <name>critter</name>
         </enabletab>
       </bonus>
       <powers>
-        <power select="Bite: DV 3P, AP 0">Natural Weapon</power>
+		<power rating="2">Armor</power>
+        <power select="Bite: DV 6P, AP 0">Natural Weapon</power>
+		<power select="Horn: DV 6P, AP 1, Reach 1">Natural Weapon</power>
         <power select="Thermal">Enhanced Senses</power>
       </powers>
       <skills>
-        <skill rating="2">Climbing</skill>
-        <skill rating="2">Infiltration</skill>
-        <skill rating="2">Perception</skill>
-        <skill rating="2">Tracking</skill>
-        <skill rating="4">Unarmed Combat</skill>
+        <skill rating="4">Climbing</skill>
+        <skill rating="4">Sneaking</skill>
+        <skill rating="4">Perception</skill>
+        <skill rating="4">Tracking</skill>
+        <skill rating="6">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>98</page>
+      <source>HT</source>
+      <page>133</page>
     </metatype>
     <metatype>
       <id>c5172915-6a90-4b5d-a999-678828a1c10f</id>
@@ -14423,40 +14430,40 @@
 		</metatype>
 		<metatype>
 			<id>5709d57e-0ccf-4196-8ced-3fbee3a54a30</id>
-			<name>Giant Snowy Owl</name>
+			<name>Chickcharney</name>
 			<category>Paranormal Critters</category>
 			<karma>0</karma>
 			<bodmin>5</bodmin>
 			<bodmax>5</bodmax>
 			<bodaug>5</bodaug>
-			<agimin>4</agimin>
-			<agimax>4</agimax>
-			<agiaug>4</agiaug>
-			<reamin>3</reamin>
-			<reamax>3</reamax>
-			<reaaug>3</reaaug>
-			<strmin>4</strmin>
-			<strmax>4</strmax>
-			<straug>4</straug>
-			<chamin>2</chamin>
-			<chamax>2</chamax>
-			<chaaug>2</chaaug>
-			<intmin>4</intmin>
-			<intmax>4</intmax>
-			<intaug>4</intaug>
-			<logmin>2</logmin>
-			<logmax>2</logmax>
-			<logaug>2</logaug>
-			<wilmin>3</wilmin>
-			<wilmax>3</wilmax>
-			<wilaug>3</wilaug>
+			<agimin>5</agimin>
+			<agimax>5</agimax>
+			<agiaug>5</agiaug>
+			<reamin>6</reamin>
+			<reamax>6</reamax>
+			<reaaug>6</reaaug>
+			<strmin>6</strmin>
+			<strmax>6</strmax>
+			<straug>6</straug>
+			<chamin>5</chamin>
+			<chamax>5</chamax>
+			<chaaug>5</chaaug>
+			<intmin>3</intmin>
+			<intmax>3</intmax>
+			<intaug>3</intaug>
+			<logmin>5</logmin>
+			<logmax>5</logmax>
+			<logaug>5</logaug>
+			<wilmin>5</wilmin>
+			<wilmax>5</wilmax>
+			<wilaug>5</wilaug>
 			<inimin>2</inimin>
 			<inimax>13</inimax>
 			<iniaug>13</iniaug>
 			<edgmin>1</edgmin>
 			<edgmax>1</edgmax>
 			<edgaug>1</edgaug>
-			<magmin>2</magmin>
+			<magmin>5</magmin>
 			<magmax>6</magmax>
 			<magaug>6</magaug>
 			<resmin>0</resmin>
@@ -14465,32 +14472,33 @@
 			<essmin>0</essmin>
 			<essmax>6</essmax>
 			<essaug>6</essaug>
-			<movement>5/20, Fly 10/50</movement>
+			<depmin>0</depmin>
+			<depmax>0</depmax>
+			<depaug>0</depaug>
+			<walk>2/1/0</walk>
+			<run>6/0/0</run>
+			<sprint>2/1/0</sprint>
 			<bonus>
 				<addattribute>
 					<name>MAG</name>
 					<min>1</min>
 					<max>6</max>
 					<aug>6</aug>
-					<val>2</val>
+					<val>5</val>
 				</addattribute>
 				<enabletab>
 					<name>critter</name>
 				</enabletab>
+				<initiativepass>1</initiativepass>
 			</bonus>
-			<powers>
-				<power>Energy Aura</power>
-				<power select="Sight">Enhanced Senses</power>
-				<power select="Claw/Bite: DV 3P, AP 0">Natural Weapon</power>
-			</powers>
 			<skills>
-				<skill rating="3">Flight</skill>
-				<skill rating="4">Perception</skill>
-				<skill rating="3">Tracking</skill>
-				<skill rating="2">Unarmed Combat</skill>
+				<skill rating="2">Running</skill>
+				<skill rating="3">Perception</skill>
+				<skill rating="3">Sneaking</skill>
+				<skill rating="3">Unarmed Combat</skill>
 			</skills>
-			<source>HP</source>
-			<page>77</page>
+			<source>HT</source>
+			<page>132</page>
 		</metatype>
 		<metatype>
 			<id>ea637589-585a-4554-8c72-dfe3d0b3186d</id>
@@ -18580,37 +18588,37 @@
       <name>Night Manta</name>
       <category>Paranormal Critters</category>
       <karma>0</karma>
-      <bodmin>6</bodmin>
-      <bodmax>6</bodmax>
-      <bodaug>6</bodaug>
-      <agimin>6</agimin>
-      <agimax>6</agimax>
-      <agiaug>6</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>6</strmin>
-      <strmax>6</strmax>
-      <straug>6</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
-      <intmin>4</intmin>
-      <intmax>4</intmax>
-      <intaug>4</intaug>
-      <logmin>2</logmin>
-      <logmax>2</logmax>
-      <logaug>2</logaug>
-      <wilmin>3</wilmin>
-      <wilmax>3</wilmax>
-      <wilaug>3</wilaug>
+      <bodmin>9</bodmin>
+      <bodmax>9</bodmax>
+      <bodaug>9</bodaug>
+      <agimin>9</agimin>
+      <agimax>9</agimax>
+      <agiaug>9</agiaug>
+      <reamin>6</reamin>
+      <reamax>6</reamax>
+      <reaaug>6</reaaug>
+      <strmin>9</strmin>
+      <strmax>9</strmax>
+      <straug>9</straug>
+      <chamin>5</chamin>
+      <chamax>5</chamax>
+      <chaaug>5</chaaug>
+      <intmin>3</intmin>
+      <intmax>3</intmax>
+      <intaug>3</intaug>
+      <logmin>6</logmin>
+      <logmax>6</logmax>
+      <logaug>6</logaug>
+      <wilmin>2</wilmin>
+      <wilmax>2</wilmax>
+      <wilaug>2</wilaug>
       <inimin>2</inimin>
       <inimax>14</inimax>
       <iniaug>14</iniaug>
-      <edgmin>2</edgmin>
-      <edgmax>2</edgmax>
-      <edgaug>2</edgaug>
-      <magmin>4</magmin>
+      <edgmin>3</edgmin>
+      <edgmax>6</edgmax>
+      <edgaug>6</edgaug>
+      <magmin>5</magmin>
       <magmax>6</magmax>
       <magaug>6</magaug>
       <resmin>0</resmin>
@@ -18619,14 +18627,19 @@
       <essmin>0</essmin>
       <essmax>6</essmax>
       <essaug>6</essaug>
-      <movement>Swim 15/30</movement>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>1/2/0</walk>
+		<run>0/8/0</run>
+		<sprint>1/3/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
           <max>6</max>
           <aug>6</aug>
-          <val>4</val>
+          <val>5</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
@@ -18634,9 +18647,9 @@
         <reach>-1</reach>
       </bonus>
       <powers>
+		<power rating="6">Armor</power>
         <power>Dual Natured</power>
         <power select="Levitate">Innate Spell</power>
-        <power>Fear</power>
         <power select="Sting: DV 2P, AP 0, Ranged">Natural Weapon</power>
         <power select="Bite: DV 4P, AP 0">Natural Weapon</power>
         <power>Shadow Cloak</power>
@@ -18644,15 +18657,15 @@
         <power>Venom</power>
       </powers>
       <skills>
-        <skill rating="3">Exotic Ranged Weapon</skill>
+        <skill rating="3" spec="Tail Spikes">Exotic Ranged Weapon</skill>
         <skill rating="2">Perception</skill>
-        <skill rating="2">Shadowing</skill>
+        <skill rating="2">Sneaking</skill>
         <skill rating="4">Spellcasting</skill>
         <skill rating="2">Swimming</skill>
         <skill rating="3">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>108</page>
+      <source>HT</source>
+      <page>134</page>
     </metatype>
     <metatype>
       <id>1865812d-b29d-4887-b628-c57a18f38b5c</id>
@@ -37360,21 +37373,21 @@
       <name>Chupacabras</name>
       <category>Infected</category>
       <karma>0</karma>
-      <bodmin>5</bodmin>
-      <bodmax>5</bodmax>
-      <bodaug>5</bodaug>
-      <agimin>3</agimin>
-      <agimax>3</agimax>
-      <agiaug>3</agiaug>
-      <reamin>4</reamin>
-      <reamax>4</reamax>
-      <reaaug>4</reaaug>
-      <strmin>3</strmin>
-      <strmax>3</strmax>
-      <straug>3</straug>
-      <chamin>1</chamin>
-      <chamax>1</chamax>
-      <chaaug>1</chaaug>
+      <bodmin>8</bodmin>
+      <bodmax>8</bodmax>
+      <bodaug>8</bodaug>
+      <agimin>8</agimin>
+      <agimax>8</agimax>
+      <agiaug>8</agiaug>
+      <reamin>6</reamin>
+      <reamax>6</reamax>
+      <reaaug>6</reaaug>
+      <strmin>6</strmin>
+      <strmax>6</strmax>
+      <straug>6</straug>
+      <chamin>2</chamin>
+      <chamax>2</chamax>
+      <chaaug>2</chaaug>
       <intmin>5</intmin>
       <intmax>5</intmax>
       <intaug>5</intaug>
@@ -37390,46 +37403,50 @@
       <edgmin>2</edgmin>
       <edgmax>2</edgmax>
       <edgaug>2</edgaug>
-      <magmin>4</magmin>
-      <magmax>4</magmax>
-      <magaug>4</magaug>
+      <magmin>5</magmin>
+      <magmax>5</magmax>
+      <magaug>5</magaug>
       <resmin>0</resmin>
-      <resmax>6</resmax>
-      <resaug>6</resaug>
+      <resmax>0</resmax>
+      <resaug>0</resaug>
       <essmin>0</essmin>
-      <essmax>5</essmax>
-      <essaug>5</essaug>
-      <movement>10/20</movement>
+      <essmax>6</essmax>
+      <essaug>6</essaug>
+      <depmin>0</depmin>
+		<depmax>0</depmax>
+		<depaug>0</depaug>
+		<walk>2/1/0</walk>
+		<run>8/0/0</run>
+		<sprint>3/1/0</sprint>
       <bonus>
         <addattribute>
           <name>MAG</name>
           <min>1</min>
-          <max>7</max>
-          <aug>7</aug>
-          <val>3</val>
+          <max>8</max>
+          <aug>8</aug>
+          <val>5</val>
         </addattribute>
         <enabletab>
           <name>critter</name>
         </enabletab>
+		<initiativepass>1</initiativepass>
       </bonus>
       <powers>
         <power>Concealment</power>
         <power>Essence Drain</power>
-        <power select="Pathogens, Toxins">Immunity</power>
-        <power select="Calw/Bite: (STR/2)P, AP -1, Reach -1">Natural Weapon</power>
+        <power select="Pathogens">Immunity</power>
+		<power select="Toxins">Immunity</power>
+        <power select="Calw/Bite: 6P, AP -1, Reach -1">Natural Weapon</power>
         <power>Paralyzing Touch</power>
-        <power select="Sunlight, Mild">Allergy</power>
-        <power select="Blood">Dietary Requirement</power>
-        <power>Essence Loss</power>
-        <power select="Fire">Vulnerability</power>
+		<power rating="4">Armor</power>
       </powers>
       <skills>
-        <skill rating="3">Climbing</skill>
-        <skill rating="4">Perception</skill>
-        <skill rating="3">Unarmed Combat</skill>
+        <skill rating="4">Climbing</skill>
+        <skill rating="5">Perception</skill>
+        <skill rating="4">Unarmed Combat</skill>
       </skills>
-      <source>RW</source>
-      <page>65</page>
+      <source>HT</source>
+      <page>132</page>
     </metatype>
     <metatype>
       <id>7a55d167-0942-4853-a63b-d2c01dbdfdf9</id>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -1539,6 +1539,7 @@
 		<gear>
 			<id>5d2fc041-c0cf-4a90-8918-be487a781e13</id>
 			<name>Stimtouch Hosiery</name>
+			<addweapon>Stimtouch Hosiery</addweapon>
 			<category>Extraction Devices</category>
 			<rating>0</rating>
 			<avail>6R</avail>
@@ -4394,6 +4395,18 @@
 		<!-- End Region -->
 		<!-- Region Sensors -->
 		<gear>
+			<id>fd1aac8c-3b55-4577-b2d6-20ec886eae0c</id>
+			<name>Fab Sensor</name>
+			<category>Sensor Functions</category>
+			<rating>8</rating>
+			<capacity>[1]</capacity>
+			<armorcapacity>[1]</armorcapacity>
+			<avail>+8R</avail>
+			<cost>4000</cost>
+			<source>HT</source>
+			<page>195</page>
+		</gear>
+		<gear>
 			<id>ce63e6c6-409a-49dd-bdcc-f8efb2f9dadf</id>
 			<name>X-Ray</name>
 			<category>Sensor Functions</category>
@@ -5595,6 +5608,16 @@
 		</gear>
 		<!-- End Region -->
 		<!-- Region Contracts and Upkeep -->
+		<gear>
+			<id>20543d97-0eb6-4eda-b0d0-d18000a094ab</id>
+			<name>Fab Sensor Upkeep (1 Month Advance Payment)</name>
+			<category>Sensor Functions</category>
+			<rating>0</rating>
+			<avail>0</avail>
+			<cost>50</cost>
+			<source>HT</source>
+			<page>195</page>
+		</gear>
 		<gear>
 			<id>2f40c4cd-7582-4358-8752-91c9f94f5b6e</id>
 			<name>Symbiotes Upkeep (1 Month Advance Payment)</name>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -9627,6 +9627,261 @@
 			<page>140</page>
 		</quality>
 		<quality>
+			<id>3c746778-bec5-4b9b-a1a4-62ac6eb98342</id>
+			<name>Infected: Sukuyan (Human)</name>
+			<contributetolimit>no</contributetolimit>
+			<karma>27</karma>
+			<category>Positive</category>
+			<bonus>
+				<enabletab>
+					<name>critter</name>
+				</enabletab>
+				<initiativepass precedence="-1">1</initiativepass>
+				<movementmultiplier>1</movementmultiplier>
+				<optionalpowers>
+					<optionalpower select="Hearing">Enhanced Senses</optionalpower>
+					<optionalpower select="Smell">Enhanced Senses</optionalpower>
+					<optionalpower select="Thermographic Vision">Enhanced Senses</optionalpower>
+					<optionalpower select="Pathogens">Immunity</optionalpower>
+					<optionalpower select="Toxins">Immunity</optionalpower>
+				</optionalpowers>
+				<replaceattributes>
+					<replaceattribute>
+						<name>BOD</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>AGI</name>
+						<min>1</min>
+						<max>6</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>REA</name>
+						<min>1</min>
+						<max>8</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>STR</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>WIL</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>LOG</name>
+						<min>1</min>
+						<max>6</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>INT</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>CHA</name>
+						<min>1</min>
+						<max>8</max>
+					</replaceattribute>
+				</replaceattributes>
+				<selectattributes>
+					<selectattribute>
+						<attribute>BOD</attribute>
+						<attribute>REA</attribute>
+						<attribute>STR</attribute>
+						<val>1</val>
+					</selectattribute>
+					<selectattribute>
+						<attribute>BOD</attribute>
+						<attribute>REA</attribute>
+						<attribute>STR</attribute>
+						<val>1</val>
+					</selectattribute>
+					<selectattribute>
+						<attribute>WIL</attribute>
+						<attribute>INT</attribute>
+						<attribute>CHA</attribute>
+						<val>1</val>
+					</selectattribute>
+					<selectattribute>
+						<attribute>WIL</attribute>
+						<attribute>INT</attribute>
+						<attribute>CHA</attribute>
+						<val>1</val>
+					</selectattribute>
+				</selectattributes>
+				<critterpowers>
+					<power>Essence Drain</power>
+					<power select="Age">Immunity</power>
+					<power>Essence Loss</power>
+					<power>Dual Natured</power>
+					<power>Infection</power>
+					<power select="Wood, Severe">Allergy</power>
+					<power select="Sunlight, Severe">Allergy</power>
+					<power select="Metahuman Blood">Dietary Requirement</power>
+					<power select="Salt">Dietary Requirement</power>
+					<power select="Wood">Vulnerability</power>
+				</critterpowers>
+			</bonus>
+			<required>
+				<allof>
+					<metatype>Human</metatype>
+				</allof>
+			</required>
+			<forbidden>
+				<oneof>
+					<quality>Magic Resistance (Rating 1)</quality>
+					<quality>Magic Resistance (Rating 2)</quality>
+					<quality>Magic Resistance (Rating 3)</quality>
+					<quality>Magic Resistance (Rating 4)</quality>
+					<quality>Technomancer</quality>
+				</oneof>
+			</forbidden>
+			<naturalweapons>
+				<naturalweapon>
+					<name>Infected Bite</name>
+					<reach>-1</reach>
+					<damage>(STR+1)P</damage>
+					<ap>-1</ap>
+					<useskill>Unarmed Combat</useskill>
+					<accuracy>Physical</accuracy>
+					<source>RF</source>
+					<page>137</page>
+				</naturalweapon>
+			</naturalweapons>
+			<source>HT</source>
+			<page>127</page>
+		</quality>
+		<quality>
+			<id>735aee59-2236-43e4-b618-9b9923513597</id>
+			<name>Infected: Sukuyan (Non-Human)</name>
+			<contributetolimit>no</contributetolimit>
+			<karma>37</karma>
+			<category>Positive</category>
+			<bonus>
+				<enabletab>
+					<name>critter</name>
+				</enabletab>
+        <initiativepass precedence="-1">1</initiativepass>
+				<movementmultiplier>1</movementmultiplier>
+				<optionalpowers>
+					<optionalpower select="Hearing">Enhanced Senses</optionalpower>
+					<optionalpower select="Smell">Enhanced Senses</optionalpower>
+					<optionalpower select="Thermographic Vision">Enhanced Senses</optionalpower>
+					<optionalpower select="Pathogens">Immunity</optionalpower>
+					<optionalpower select="Toxins">Immunity</optionalpower>
+				</optionalpowers>
+				<replaceattributes>
+					<replaceattribute>
+						<name>BOD</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>AGI</name>
+						<min>1</min>
+						<max>6</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>REA</name>
+						<min>1</min>
+						<max>8</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>STR</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>WIL</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>LOG</name>
+						<min>1</min>
+						<max>6</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>INT</name>
+						<min>1</min>
+						<max>7</max>
+					</replaceattribute>
+					<replaceattribute>
+						<name>CHA</name>
+						<min>1</min>
+						<max>8</max>
+					</replaceattribute>
+				</replaceattributes>
+				<selectattributes>
+					<selectattribute>
+						<attribute>BOD</attribute>
+						<attribute>REA</attribute>
+						<attribute>STR</attribute>
+						<val>1</val>
+					</selectattribute>
+					<selectattribute>
+						<attribute>BOD</attribute>
+						<attribute>REA</attribute>
+						<attribute>STR</attribute>
+						<val>1</val>
+					</selectattribute>
+					<selectattribute>
+						<attribute>WIL</attribute>
+						<attribute>INT</attribute>
+						<attribute>CHA</attribute>
+						<val>1</val>
+					</selectattribute>
+					<selectattribute>
+						<attribute>WIL</attribute>
+						<attribute>INT</attribute>
+						<attribute>CHA</attribute>
+						<val>1</val>
+					</selectattribute>
+				</selectattributes>
+			<critterpowers>
+				<power>Essence Drain</power>
+				<power>Infection</power>
+				<power select="Age">Immunity</power>
+				<power>Essence Loss</power>
+				<power>Dual Natured</power>
+				<power select="Wood, Severe">Allergy</power>
+				<power select="Sunlight, Severe">Allergy</power>
+				<power select="Metahuman Blood">Dietary Requirement</power>
+				<power select="Salt">Dietary Requirement</power>
+				<power select="Wood">Vulnerability</power>
+			</critterpowers>
+			</bonus>
+			<forbidden>
+				<oneof>
+					<metatypecategory>Metasapient</metatypecategory>
+					<metatypecategory>Shapeshifter</metatypecategory>
+					<quality>Magic Resistance (Rating 1)</quality>
+					<quality>Magic Resistance (Rating 2)</quality>
+					<quality>Magic Resistance (Rating 3)</quality>
+					<quality>Magic Resistance (Rating 4)</quality>
+					<quality>Technomancer</quality>
+				</oneof>
+			</forbidden>
+			<naturalweapons>
+				<naturalweapon>
+					<name>Infected Bite</name>
+					<reach>-1</reach>
+					<damage>(STR+1)P</damage>
+					<ap>-1</ap>
+					<useskill>Unarmed Combat</useskill>
+					<accuracy>Physical</accuracy>
+					<source>RF</source>
+					<page>137</page>
+				</naturalweapon>
+			</naturalweapons>
+			<source>HT</source>
+			<page>127</page>
+		</quality>
+		<quality>
 			<id>652948f9-e629-4dea-bd13-776dd41ca6a1</id>
 			<name>Infected: Wendigo</name>
 			<contributetolimit>no</contributetolimit>

--- a/Chummer/data/skills.xml
+++ b/Chummer/data/skills.xml
@@ -3060,6 +3060,7 @@
 				<spec>Home</spec>
 				<spec>Public Event</spec>
 				<spec>Vehicle</spec>
+				<spec>VIP</spec>
 			</specs>
 		</skill>
 		<skill>
@@ -3078,6 +3079,7 @@
 				<spec>Rapid Response</spec>
 				<spec>Border Patrol</spec>
 				<spec>Customs</spec>
+				<spec>VIP</spec>
 			</specs>
 		</skill>
 		<skill>
@@ -3312,6 +3314,7 @@
 			<default>No</default>
 			<skillgroup />
 			<specs>
+				<spec>Personalities</spec>
 				<spec>Ghost Cartels</spec>
 				<spec>Mafia</spec>
 				<spec>Triad</spec>
@@ -3447,6 +3450,7 @@
 				<spec>Talislegger</spec>
 				<spec>Taminous groups</spec>
 				<spec>White Collar</spec>
+				<spec>Wetwork</spec>
 			</specs>
 		</skill>
 		<skill>
@@ -4075,6 +4079,7 @@
 			<default>No</default>
 			<skillgroup />
 			<specs>
+				<spec>Cleaning</spec>
 				<spec>Thaumaturgic</spec>
 			</specs>
 		</skill>

--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -4310,6 +4310,32 @@
 			<page>192</page>
 			<id>bc8e70a9-2af6-4728-836d-daf19d5c61d4</id>
 		</spell>
+		<spell>
+			<id>1f10cb4f-67d6-4193-b897-1a7f5ab67c2a</id>
+			<name>Corps Cadavre</name>
+			<descriptor>Minion</descriptor>
+			<category>Rituals</category>
+			<type>M</type>
+			<range>Special</range>
+			<damage>0</damage>
+			<duration>Special</duration>
+			<dv>Special</dv>
+			<source>HT</source>
+			<page>129</page>
+		</spell>
+		<spell>
+			<id>bd2bfef0-9de4-4870-9822-cdd504f7560f</id>
+			<name>Zombie</name>
+			<descriptor>Minion</descriptor>
+			<category>Rituals</category>
+			<type>M</type>
+			<range>Special</range>
+			<damage>0</damage>
+			<duration>Special</duration>
+			<dv>Special</dv>
+			<source>HT</source>
+			<page>131</page>
+		</spell>
 		<!-- End Region -->
   </spells>
 </chummer>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -7072,6 +7072,17 @@
 			<page>170</page>
 		</mod>
 		<mod>
+			<id>1186ac2e-0353-4e2d-b688-626d809d6f44</id>
+			<name>Máquina Conversion</name>
+			<category>Cosmetic</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0</avail>
+			<cost>Body * 2</cost>
+			<source>HT</source>
+			<page>139</page>
+		</mod>
+		<mod>
 			<id>a586e8b6-2737-4baa-a343-f366d33fe57a</id>
 			<name>Metahuman Adjustment</name>
 			<category>Cosmetic</category>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -524,7 +524,6 @@
 			</accessories>
 			<source>RG</source>
 			<page>37</page>
-		
 		</weapon>
 		<weapon>
 			<id>cc446f64-1dbd-42dd-8fc4-ca17dc6bcf42</id>
@@ -2066,6 +2065,26 @@
 			<allowaccessory>true</allowaccessory>
 			<source>SR5</source>
 			<page>423</page>
+		</weapon>
+		<weapon>
+			<id>4f1d1416-5af6-4853-a1b3-2bb44a132d8f</id>
+			<name>Stimtouch Hosiery</name>
+			<category>Exotic Melee Weapons</category>
+			<hide>yes</hide>
+			<type>Melee</type>
+			<conceal>0</conceal>
+			<accuracy>Physical</accuracy>
+			<reach>0</reach>
+			<damage>8S(e)</damage>
+			<ap>-5</ap>
+			<mode>0</mode>
+			<rc>0</rc>
+			<ammo>0</ammo>
+			<avail>6R</avail>
+			<cost>0</cost>
+			<allowaccessory>true</allowaccessory>
+			<source>SS</source>
+			<page>178</page>s
 		</weapon>
 		<weapon>
 			<id>9c267b03-103e-43f4-bfe8-986c69dc17d2</id>
@@ -7876,6 +7895,27 @@
 			<page>183</page>
 		</weapon>
 		<weapon>
+			<id>c965dee9-de62-4569-b96a-4026105440b1</id>
+			<name>Dynamic Tension Bow</name>
+			<category>Bows</category>
+			<type>Ranged</type>
+			<conceal>8</conceal>
+			<spec>Bow</spec>
+			<accuracy>5</accuracy>
+			<reach>0</reach>
+			<damage>(Rating+2)P</damage>
+			<ap>-(Rating/4)</ap>
+			<mode>SS</mode>
+			<rc>0</rc>
+			<ammo>1</ammo>
+			<avail>12</avail>
+			<cost>1200</cost>
+			<allowaccessory>true</allowaccessory>
+			<useskill>Archery</useskill>
+			<source>HT</source>
+			<page>179</page>
+		</weapon>
+		<weapon>
 			<id>1c738c1d-7abc-4756-a683-f5bf92902671</id>
 			<name>Cavalier Arms Adder Silvergun</name>
 			<category>Light Pistols</category>
@@ -8612,6 +8652,29 @@
 			<rcgroup>2</rcgroup>
 			<avail>2</avail>
 			<cost>50</cost>
+			<required>
+				<weapondetails>
+					<OR>
+						<category operation="contains">Rifles</category>
+						<category>Shotguns</category>
+						<category>Light Machine Guns</category>
+						<category>Medium Machine Guns</category>
+						<category>Heavy Machine Guns</category>
+						<category>Underbarrel Weapons</category>
+						<category>Assault Cannons</category>
+						<category>Flamethrowers</category>
+						<category>Laser Weapons</category>
+						<category>Grenade Launchers</category>
+						<category>Missile Launchers</category>
+					</OR>
+				</weapondetails>
+			</required>
+			<forbidden>
+				<oneof>
+					<accessory>Stock Removal</accessory>
+					<accessory>Sawed Off/Shortbarrel and Stock Removal</accessory>
+				</oneof>
+			</forbidden>
 			<source>SR5</source>
 			<page>432</page>
 		</accessory>
@@ -8680,7 +8743,11 @@
 			<forbidden>
 				<oneof>
 					<accessory>Ceramic/Plasteel Components</accessory>
+					<accessory>Collapsible Traditional Bow</accessory>
 				</oneof>
+				<weapondetails>
+					<type>Melee</type>
+				</weapondetails>
 			</forbidden>
 			<accuracy>2</accuracy>
 			<rating>0</rating>
@@ -8700,7 +8767,11 @@
 			<forbidden>
 				<oneof>
 					<accessory>Ceramic/Plasteel Components</accessory>
+					<accessory>Collapsible Traditional Bow</accessory>
 				</oneof>
+				<weapondetails>
+					<type>Melee</type>
+				</weapondetails>
 			</forbidden>
 			<accuracy>2</accuracy>
 			<rating>0</rating>
@@ -8767,6 +8838,12 @@
 			<id>06e128ee-00fd-4992-8bf5-4be35815fd11</id>
 			<name>Advanced Safety System, Basic</name>
 			<mount/>
+			<required>
+				<oneof>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+				</oneof>
+			</required>
 			<forbidden>
 				<oneof>
 					<accessory>Advanced Safety System, Immobilization</accessory>
@@ -8846,6 +8923,12 @@
 			<id>fad8757c-622f-41ce-8412-8bbb6fbf6445</id>
 			<name>Advanced Safety System, Immobilization</name>
 			<mount/>
+			<required>
+				<oneof>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+				</oneof>
+			</required>
 			<forbidden>
 				<oneof>
 					<accessory>Advanced Safety System, Basic</accessory>
@@ -8864,6 +8947,12 @@
 			<id>c9739e50-bbaf-47e7-a19b-c3d7fd2b95af</id>
 			<name>Advanced Safety System, Self Destruct</name>
 			<mount/>
+			<required>
+				<oneof>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+				</oneof>
+			</required>
 			<forbidden>
 				<oneof>
 					<accessory>Advanced Safety System, Immobilization</accessory>
@@ -8882,6 +8971,12 @@
 			<id>25b695f8-ed5a-4b75-baf0-164dcde74f2d</id>
 			<name>Advanced Safety System, Explosive Self Destruct</name>
 			<mount/>
+			<required>
+				<oneof>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+				</oneof>
+			</required>
 			<forbidden>
 				<oneof>
 					<accessory>Advanced Safety System, Immobilization</accessory>
@@ -8900,6 +8995,12 @@
 			<id>b64d5256-0c24-4842-b05d-25ee735c9b6a</id>
 			<name>Advanced Safety System, Electro Shocker</name>
 			<mount/>
+			<required>
+				<oneof>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+				</oneof>
+			</required>
 			<forbidden>
 				<oneof>
 					<accessory>Advanced Safety System, Immobilization</accessory>
@@ -8937,6 +9038,11 @@
 			<conceal>-1</conceal>
 			<avail>6</avail>
 			<cost>275</cost>
+			<required>
+				<weapondetails>
+					<conceal operation="lessthanequals">0</conceal>
+				</weapondetails>
+			</required>
 			<source>RG</source>
 			<page>51</page>
 		</accessory>
@@ -9788,6 +9894,14 @@
 			<rating>0</rating>
 			<avail>2</avail>
 			<cost>50</cost>
+			<forbidden>
+				<weapondetails>
+					<OR>
+						<category>Bows</category>
+						<type>Melee</type>
+					</OR>
+				</weapondetails>
+			</forbidden>
 			<source>HT</source>
 			<page>182</page>
 		</accessory>
@@ -9801,6 +9915,30 @@
 			<cost>100</cost>
 			<source>HT</source>
 			<page>182</page>
+		</accessory>
+		<accessory>
+			<id>f277db83-e5f0-47c8-a465-e0307105796f</id>
+			<name>Collapsible Traditional Bow</name>
+			<mount/>
+			<rating>10</rating>
+			<avail>0</avail>
+			<cost>Rating * 50</cost>
+			<required>
+				<weapondetails>
+					<OR>
+						<category>Bows</category>
+						<spec>Bow</spec>
+					</OR>
+				</weapondetails>
+			</required>
+			<forbidden>
+				<oneof>
+					<accessory>Smartgun System, Internal</accessory>
+					<accessory>Smartgun System, External</accessory>
+				</oneof>
+			</forbidden>
+			<source>HT</source>
+			<page>197</page>
 		</accessory>
 		<!-- End Region -->
 	</accessories>


### PR DESCRIPTION
Data Changes:

- Added contact types, knowledge skill specializations, and critters from Hard Targets.
- Added entries for Fab Sensor, Fab Sensor Upkeep, Infected: Sukuyan, Corps Cadavre ritual, Zombie ritual, Máquina Conversion vehicle mod, Dynamic Tension Bow, and Collapsible Traditional Bow accessory from Hard Targets.
- Added a weapon entry for Stimtouch Hosiery similar to how Grapple Gun adds a weapon entry.
- Added extra filtering conditions to all Advanced Safety System accessories, Shock Pad, Concealed Quick-Draw Holster, Trigger Removal, and Smartgun System (both Internal and External) so that they do show up in even fewer invalid cases.