### PR TITLE
Lifestyle Fixes

### DIFF
--- a/Chummer/Backend/Equipment/Lifestyle.cs
+++ b/Chummer/Backend/Equipment/Lifestyle.cs
@@ -819,8 +819,11 @@ namespace Chummer.Backend.Equipment
 					//Add the flat cost from Qualities.
 					if (objXmlQuality["cost"] != null && objXmlQuality["cost"].InnerText != "")
 					{
-						decCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
-					}
+                        if (objXmlQuality["category"]?.InnerText == "Contracts")
+                            decCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
+                        else
+                            decBaseCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
+                    }
 					//Add the percentage point modifiers from Qualities.
 					if (objXmlQuality["multiplier"] != null && objXmlQuality["multiplier"].InnerText != "")
 					{

--- a/Chummer/Backend/Equipment/Lifestyle.cs
+++ b/Chummer/Backend/Equipment/Lifestyle.cs
@@ -809,10 +809,12 @@ namespace Chummer.Backend.Equipment
 				decMultiplier = Convert.ToDecimal(objImprovementManager.ValueOf(Improvement.ImprovementType.LifestyleCost), GlobalOptions.Instance.CultureInfo);
 				if (_objType == LifestyleType.Standard)
 					decMultiplier += Convert.ToDecimal(objImprovementManager.ValueOf(Improvement.ImprovementType.BasicLifestyleCost), GlobalOptions.Instance.CultureInfo);
-				double dblRoommates = 1.0 + (0.1 * _intRoommates);
+                decimal decExtraMultiplierBaseOnly = 0;
+                double dblRoommates = 1.0 + (0.1 * _intRoommates);
 
 				decimal decBaseCost = Cost;
-				decimal decCost = 0;
+                decimal decExtraAssetCost = 0;
+				decimal decConstractCost = 0;
 				foreach (LifestyleQuality objQuality in _lstLifestyleQualities)
 				{
 					XmlNode objXmlQuality = objXmlDocument.SelectSingleNode("/chummer/qualities/quality[name = \"" + objQuality.Name.ToString() + "\"]");
@@ -820,29 +822,35 @@ namespace Chummer.Backend.Equipment
 					if (objXmlQuality["cost"] != null && objXmlQuality["cost"].InnerText != "")
 					{
                         if (objXmlQuality["category"]?.InnerText == "Contracts")
-                            decCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
+                            decConstractCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
                         else
-                            decBaseCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
+                            decExtraAssetCost += Convert.ToInt32(objXmlQuality["cost"].InnerText);
                     }
 					//Add the percentage point modifiers from Qualities.
 					if (objXmlQuality["multiplier"] != null && objXmlQuality["multiplier"].InnerText != "")
 					{
 						decMultiplier += Convert.ToDecimal(objXmlQuality["multiplier"].InnerText);
 					}
-				}
+                    //Add the percentage point modifiers from Qualities.
+                    if (objXmlQuality["multiplierbaseonly"] != null && objXmlQuality["multiplierbaseonly"].InnerText != "")
+                    {
+                        decExtraMultiplierBaseOnly += Convert.ToDecimal(objXmlQuality["multiplierbaseonly"].InnerText);
+                    }
+                }
 
 				decMultiplier = 1 + Convert.ToDecimal(decMultiplier / 100, GlobalOptions.Instance.CultureInfo);
-                
-				double dblPercentage = Convert.ToDouble(_intPercentage, GlobalOptions.Instance.CultureInfo) / 100.0;
+                decExtraMultiplierBaseOnly = Convert.ToDecimal(decExtraMultiplierBaseOnly / 100, GlobalOptions.Instance.CultureInfo);
 
-				intReturn = Convert.ToInt32(decBaseCost * decMultiplier);
-				intReturn += Convert.ToInt32(decCost);
+                double dblPercentage = Convert.ToDouble(_intPercentage, GlobalOptions.Instance.CultureInfo) / 100.0;
 
+                int intBaseLifestyleCost = Convert.ToInt32(decBaseCost * (decMultiplier + decExtraMultiplierBaseOnly));
+                if (!_blnTrustFund)
+                {
+                    intReturn += intBaseLifestyleCost;
+                }
+                intReturn += Convert.ToInt32(decExtraAssetCost * decMultiplier);
 				intReturn = Convert.ToInt32(intReturn * dblPercentage);
-				if (_blnTrustFund)
-				{
-					intReturn += Convert.ToInt32(Convert.ToDouble(objImprovementManager.ValueOf(Improvement.ImprovementType.LifestyleCost), GlobalOptions.Instance.CultureInfo));
-				}
+                intReturn += Convert.ToInt32(decConstractCost);
 				return intReturn;
 			}
 		}

--- a/Chummer/Backend/Equipment/LifestyleQuality.cs
+++ b/Chummer/Backend/Equipment/LifestyleQuality.cs
@@ -39,7 +39,9 @@ namespace Chummer.Backend.Equipment
 					return QualityType.Negative;
 				case "Positive":
 					return QualityType.Positive;
-				default:
+                case "Contracts":
+                    return QualityType.Contracts;
+                default:
 					return QualityType.Entertainment;
 			}
 		}

--- a/Chummer/Classes/clsUnique.cs
+++ b/Chummer/Classes/clsUnique.cs
@@ -1052,7 +1052,8 @@ namespace Chummer
 		Positive = 0,
 		Negative = 1,          
         LifeModule = 2,
-        Entertainment = 3
+        Entertainment = 3,
+        Contracts = 4
 	}
 
 	/// <summary>

--- a/Chummer/Selection Forms/frmSelectLifestyleAdvanced.cs
+++ b/Chummer/Selection Forms/frmSelectLifestyleAdvanced.cs
@@ -474,8 +474,10 @@ namespace Chummer
 			int intBaseNuyen = 0;
             int intNuyen = 0;
             int intMultiplier = 0;
+            int intMultiplierBaseOnly = 0;
             int intExtraCostAssets = 0;
             int intExtraCostServicesOutings = 0;
+            int intExtraCostContracts = 0;
 
             // Calculate the limits of the 3 aspects.
             // Comforts. 
@@ -507,7 +509,8 @@ namespace Chummer
 						intMaxSec += Convert.ToInt32(objXmlNode["security"]?.InnerText);
 						intMinSec += Convert.ToInt32(objXmlNode["securityMinimum"]?.InnerText);
 						intMultiplier += Convert.ToInt32(objXmlNode["multiplier"]?.InnerText);
-						intNuyen += Convert.ToInt32(objXmlNode["cost"]?.InnerText);
+                        intMultiplierBaseOnly += Convert.ToInt32(objXmlNode["multiplierbaseonly"]?.InnerText);
+                        intBaseNuyen += Convert.ToInt32(objXmlNode["cost"]?.InnerText);
 					}
 				}
 				// Calculate the cost of Negative Qualities.
@@ -521,7 +524,8 @@ namespace Chummer
 						intMaxComfort += Convert.ToInt32(objXmlNode["comforts"]?.InnerText);
 					    intMaxSec += Convert.ToInt32(objXmlNode["security"]?.InnerText);
 						intMultiplier += Convert.ToInt32(objXmlNode["multiplier"]?.InnerText);
-                        intNuyen += Convert.ToInt32(objXmlNode["cost"]?.InnerText);
+                        intMultiplierBaseOnly += Convert.ToInt32(objXmlNode["multiplierbaseonly"]?.InnerText);
+                        intBaseNuyen += Convert.ToInt32(objXmlNode["cost"]?.InnerText);
 					}
 				}
                 // Calculate the cost of Entertainments.
@@ -563,8 +567,11 @@ namespace Chummer
 					{
 						if (objXmlNode["cost"] != null)
 						{
-						    if (objQuality.Type == QualityType.Contracts || 
-                                objXmlNode["category"].InnerText.Equals("Entertainment - Outing") ||
+                            if (objQuality.Type == QualityType.Contracts)
+                            {
+                                intExtraCostContracts += Convert.ToInt32(objXmlNode["cost"].InnerText);
+                            }
+						    else if (objXmlNode["category"].InnerText.Equals("Entertainment - Outing") ||
 						        objXmlNode["category"].InnerText.Equals("Entertainment - Service"))
 						    {
 						        intExtraCostServicesOutings += Convert.ToInt32(objXmlNode["cost"].InnerText);
@@ -604,9 +611,9 @@ namespace Chummer
                 intLP += _intTravelerRdmLP;
             }
 
-	        intMultiplier += _objCharacter.Improvements.Where(objImprovement => objImprovement.ImproveType == Improvement.ImprovementType.LifestyleCost).Sum(objImprovement => objImprovement.Value);
+            intMultiplier += _objCharacter.Improvements.Where(objImprovement => objImprovement.ImproveType == Improvement.ImprovementType.LifestyleCost).Sum(objImprovement => objImprovement.Value);
 
-	        if (cboBaseLifestyle.SelectedValue.ToString() == "Street")
+            if (cboBaseLifestyle.SelectedValue.ToString() == "Street")
             {
                 intNuyen += Convert.ToInt32(nudSecurity.Value - intMinSec) * 50;
                 intNuyen += Convert.ToInt32(nudArea.Value - intMinArea) * 50;
@@ -617,17 +624,17 @@ namespace Chummer
             intMultiplier += Convert.ToInt32(nudSecurity.Value - intMinSec) * 10;
             intMultiplier += Convert.ToInt32(nudArea.Value - intMinArea) * 10;
             intMultiplier += Convert.ToInt32(nudComforts.Value - intMinComfort) * 10;
-            intBaseNuyen += Convert.ToInt32(objXmlLifestyle["cost"].InnerText);
-			intNuyen += Convert.ToInt32(intBaseNuyen * (intMultiplier / 100.0));
-            intNuyen += intBaseNuyen;
-            intNuyen += intExtraCostAssets;
-			intNuyen = Convert.ToInt32(Convert.ToDouble(intNuyen, GlobalOptions.Instance.CultureInfo) * Convert.ToDouble(nudPercentage.Value / 100, GlobalOptions.Instance.CultureInfo));
-            intNuyen = Convert.ToInt32(intNuyen / (Convert.ToInt32(nudRoommates.Value) + 1));
-            intNuyen += intExtraCostServicesOutings;
-			if (chkTrustFund.Checked)
-			{
-				intNuyen -= intBaseNuyen;
+            if (!chkTrustFund.Checked)
+            {
+                intBaseNuyen += Convert.ToInt32(objXmlLifestyle["cost"].InnerText);
+                intBaseNuyen += Convert.ToInt32(intBaseNuyen * ((intMultiplier + intMultiplierBaseOnly) / 100.0));
+                intNuyen += intBaseNuyen;
             }
+            intNuyen += intExtraCostAssets + Convert.ToInt32(intExtraCostAssets * (intMultiplier / 100.0));
+            intNuyen = Convert.ToInt32(Convert.ToDouble(intNuyen, GlobalOptions.Instance.CultureInfo) * Convert.ToDouble(nudPercentage.Value / 100, GlobalOptions.Instance.CultureInfo));
+            intNuyen = Convert.ToInt32(intNuyen / (Convert.ToInt32(nudRoommates.Value) + 1));
+            intNuyen += intExtraCostServicesOutings + Convert.ToInt32(intExtraCostServicesOutings * (intMultiplier / 100.0)); ;
+            intNuyen += intExtraCostContracts;
 			lblTotalLP.Text = intLP.ToString();
 			lblCost.Text = String.Format("{0:###,###,##0¥}", intNuyen);
 

--- a/Chummer/Selection Forms/frmSelectLifestyleAdvanced.cs
+++ b/Chummer/Selection Forms/frmSelectLifestyleAdvanced.cs
@@ -525,7 +525,7 @@ namespace Chummer
 					}
 				}
                 // Calculate the cost of Entertainments.
-				else if (objQuality.Type == QualityType.Entertainment)
+				else if (objQuality.Type == QualityType.Entertainment || objQuality.Type == QualityType.Contracts)
 				{
 					objXmlNode = _objXmlDocument.SelectSingleNode("/chummer/qualities/quality[name = \"" + objQuality.Name + "\"]");
 					if (objXmlNode != null)
@@ -551,19 +551,20 @@ namespace Chummer
 						    }
 						    break;
 				    }
-					string strLifestyleEntertainments = "";
+                    bool blnIsFree = false;
                     if (objXmlNode["allowed"] != null)
                     {
-                        strLifestyleEntertainments = objXmlNode["allowed"].InnerText;
+                        string strLifestyleEntertainments = objXmlNode["allowed"].InnerText;
+                        if (strLifestyleEntertainments.Contains(cboBaseLifestyle.SelectedValue.ToString()) || strLifestyleEntertainments.Contains(strLifestyleEquivalent))
+                            blnIsFree = true;
                     }
-					bool blnEntertainmentFree = strLifestyleEntertainments.Contains(cboBaseLifestyle.SelectedValue.ToString());
-				    bool blnEntertainmentFreeEqui = strLifestyleEntertainments.Contains(strLifestyleEquivalent); 
 
-					if (!(blnEntertainmentFreeEqui || blnEntertainmentFree))
+					if (!blnIsFree)
 					{
 						if (objXmlNode["cost"] != null)
 						{
-						    if (objXmlNode["category"].InnerText.Equals("Entertainment - Outing") ||
+						    if (objQuality.Type == QualityType.Contracts || 
+                                objXmlNode["category"].InnerText.Equals("Entertainment - Outing") ||
 						        objXmlNode["category"].InnerText.Equals("Entertainment - Service"))
 						    {
 						        intExtraCostServicesOutings += Convert.ToInt32(objXmlNode["cost"].InnerText);
@@ -575,7 +576,7 @@ namespace Chummer
 						}
 					}
 				}
-			}
+            }
             _blnSkipRefresh = true;
 
             nudComforts.Minimum = intMinComfort;

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -49,6 +49,8 @@ Application Changes:
 - Fixed an issue with life modules not properly adding qualities.
 - Fixed vehicle mod cost modifiers not being taken into account in Create mode.
 - Slighlty increased performance and portability for code related to vehicle mod costs.
+- Added a new lifestyle quality enum for Contracts and added handling code of lifestyle qualities of this enum.
+- Fixed a bug where non-Contract lifestyle qualities with a flat cost (e.g. Special Work Area) would not have their costs affected by cost multipliers.
 
 Data Changes: 
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -50,7 +50,8 @@ Application Changes:
 - Fixed vehicle mod cost modifiers not being taken into account in Create mode.
 - Slighlty increased performance and portability for code related to vehicle mod costs.
 - Added a new lifestyle quality enum for Contracts and added handling code of lifestyle qualities of this enum.
-- Fixed a bug where non-Contract lifestyle qualities with a flat cost (e.g. Special Work Area) would not have their costs affected by cost multipliers.
+- Fixed a bug where non-Contract lifestyle qualities with a flat cost (e.g. Special Work Area) would not have their costs affected by cost multipliers (note: Extra Secure is the only multiplier that does not affect asset costs, as it is explicitly stated so in Run Faster).
+- Fixed issues related to Trust Fund covering the incorrect amount of lifestyle costs in certain scenarios involving multipliers. 
 
 Data Changes: 
 

--- a/Chummer/data/lifestyles.xml
+++ b/Chummer/data/lifestyles.xml
@@ -902,7 +902,7 @@
 			<name>Extra Secure</name>
 			<lp>1</lp>
 			<category>Positive</category>
-			<multiplier>20</multiplier>
+			<multiplierbaseonly>20</multiplierbaseonly>
 			<source>SR5</source>
 			<page>370</page>
 		</quality>


### PR DESCRIPTION
Application Changes:

- Added a new lifestyle quality enum for Contracts and added handling code of lifestyle qualities of this enum.
- Fixed a bug where non-Contract lifestyle qualities with a flat cost (e.g. Special Work Area) would not have their costs affected by cost multipliers (note: Extra Secure is the only multiplier that does not affect asset costs, as it is explicitly stated so in Run Faster).
- Fixed issues related to Trust Fund covering the incorrect amount of lifestyle costs in certain scenarios involving multipliers. 