### PR TITLE
CA Crash Fixes, Skills Additions

### DIFF
--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -93,6 +93,8 @@ Data Changes:
 - Added selection text fields to the following qualities: My Country Right or Wrong, Scorched, Social Stress, Disgraced, Sensei, Big Regret, Day Job, Driven, Emotional Attachment, Flashbacks, and Signature. Also added a contact selection field for Sensei.
 - Added content from Cutting Aces. 
 - Altered the behaviour of martial arts to only grant a free specialization if an optional rule is enabled. 
+- Added missing Active Skill specializations based on SR4a20th and rules for specializing for specific actions.
+- Added knowledge skills and knowledge skill specializations based on Market Panic and Chrome Flesh.
 
 New Strings:
 

--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -2521,7 +2521,7 @@
 			<page>136</page>
 		</armor>
 		<armor>
-			<id>c9424dfb-1e01-4073-995a-7935efc1894d</id>
+			<id>f22a86ba-e660-4c32-a998-d04def23d287</id>
 			<name>Scout's Tux</name>
 			<category>Specialty Armor</category>
 			<armor>8</armor>

--- a/Chummer/data/skills.xml
+++ b/Chummer/data/skills.xml
@@ -200,6 +200,7 @@
 			<specs>
 				<spec>Aura Reading</spec>
 				<spec>Astral Signatures</spec>
+				<spec>Psychometry</spec>
 				<spec>[Aura Type]</spec>
 			</specs>
 			<source>SR5</source>
@@ -341,9 +342,11 @@
 			<specs>
 				<spec>Analytical</spec>
 				<spec>Biochemistry</spec>
+				<spec>Drugs</spec>
 				<spec>Inorganic</spec>
 				<spec>Organic</spec>
 				<spec>Physical</spec>
+				<spec>Toxins</spec>
 			</specs>
 			<source>SR5</source>
 			<page>144</page>
@@ -389,7 +392,7 @@
 				<spec>Edit File</spec>
 				<spec>Matrix Perception</spec>
 				<spec>Matrix Search</spec>
-				<spec>[Action]</spec>
+				<spec>[Computer Matrix Action]</spec>
 			</specs>
 			<source>SR5</source>
 			<page>144</page>
@@ -454,6 +457,7 @@
 				<spec>Bodyware</spec>
 				<spec>Cyberlimbs</spec>
 				<spec>Headware</spec>
+				<spec>Nanoware</spec>
 				<spec>Repair</spec>
 			</specs>
 			<source>SR5</source>
@@ -552,6 +556,7 @@
 				<spec>Encryption</spec>
 				<spec>Jamming</spec>
 				<spec>Sensor Operations</spec>
+				<spec>[Electronic Warfare Matrix Action]</spec>
 			</specs>
 			<source>SR5</source>
 			<page>144</page>
@@ -581,12 +586,15 @@
 			<default>Yes</default>
 			<skillgroup>Influence</skillgroup>
 			<specs>
+				<spec>Catholic Church</spec>
 				<spec>Corporate</spec>
 				<spec>High Society</spec>
+				<spec>Mafia</spec>
 				<spec>Media</spec>
 				<spec>Mercenary</spec>
 				<spec>Street</spec>
 				<spec>Yakuza</spec>
+				<spec>[Culture or Subculture]</spec>
 			</specs>
 			<source>SR5</source>
 			<page>138</page>
@@ -735,6 +743,7 @@
 				<spec>Balance</spec>
 				<spec>Climbing</spec>
 				<spec>Dance</spec>
+				<spec>Dodging</spec>
 				<spec>Leaping</spec>
 				<spec>Parkour</spec>
 				<spec>Rolling</spec>
@@ -768,8 +777,10 @@
 			<specs>
 				<spec>Commlinks</spec>
 				<spec>Cyberdecks</spec>
+				<spec>Jack Out</spec>
 				<spec>Smartguns</spec>
 				<spec>[Hardware Type]</spec>
+				<spec>[Hardware Matrix Action]</spec>
 			</specs>
 			<source>SR5</source>
 			<page>145</page>
@@ -901,6 +912,7 @@
 				<spec>Long-Range Shots</spec>
 				<spec>Shotguns</spec>
 				<spec>Sniper Rifles</spec>
+				<spec>Sporting Rifles</spec>
 			</specs>
 			<source>SR5</source>
 			<page>132</page>
@@ -1177,6 +1189,7 @@
 				<spec>Desert</spec>
 				<spec>Jungle</spec>
 				<spec>Urban</spec>
+				<spec>Vehicle</spec>
 				<spec>Wilderness</spec>
 				<spec>[Terrain]</spec>
 			</specs>
@@ -1193,6 +1206,8 @@
 			<specs>
 				<spec>Data Bombs</spec>
 				<spec>[Complex Form]</spec>
+				<spec>[Program Type]</spec>
+				<spec>[Software Matrix Action]</spec>
 			</specs>
 			<source>SR5</source>
 			<page>145</page>
@@ -1723,6 +1738,30 @@
 				<spec>Tir Tairngire</spec>
 				<spec>Tsimshian Protectorate</spec>
 				<spec>Yukutan</spec>
+			</specs>
+		</skill>
+		<skill>
+			<id>c52d63de-ddc0-477f-bf46-33002f8f4aaa</id>
+			<name>BTLs</name>
+			<attribute>INT</attribute>
+			<category>Interest</category>
+			<default>No</default>
+			<skillgroup />
+			<specs>
+				<spec>Bunraku</spec>
+				<spec>Calhots</spec>
+				<spec>Crime Fantasy</spec>
+				<spec>Drug Emulation</spec>
+				<spec>Historical Fantasy</spec>
+				<spec>Hot-Sim Pornography</spec>
+				<spec>Mind Control Chips</spec>
+				<spec>Power Fantasy</spec>
+				<spec>Reality Enhancer</spec>
+				<spec>Revenge Fantasy</spec>
+				<spec>Snuff</spec>
+				<spec>Soma Chips</spec>
+				<spec>Synesthesia</spec>
+				<spec>Ultraviolence</spec>
 			</specs>
 		</skill>
 		<skill>
@@ -2622,11 +2661,21 @@
 			<default>No</default>
 			<skillgroup />
 			<specs>
+				<spec>Astral Dreams: Legend of Tenku</spec>
+				<spec>Awakening: 1949</spec>
+				<spec>Beat the Market</spec>
 				<spec>Dawn of Atlantis III</spec>
 				<spec>Dragon Storm</spec>
+				<spec>Fermat's Last Hermetic Equation</spec>
+				<spec>Galaxy Ten</spec>
 				<spec>Grand Larceny</spec>
 				<spec>Killing Floor</spec>
+				<spec>Life's a Bitch</spec>
+				<spec>Miracle Shooter</spec>
+				<spec>Noir Confidential</spec>
+				<spec>Run, Run Runner</spec>
 				<spec>Shadowrun Online</spec>
+				<spec>The Seelie Court</spec>
 			</specs>
 		</skill>
 		<skill>
@@ -3284,6 +3333,8 @@
 			<default>No</default>
 			<skillgroup />
 			<specs>
+				<spec>Betel</spec>
+				<spec>Binaural Beats</spec>
 				<spec>BTLs</spec>
 				<spec>Cram</spec>
 				<spec>Deepweed</spec>
@@ -3389,11 +3440,37 @@
 			<skillgroup />
 			<specs>
 				<spec>Action</spec>
+				<spec>Comedy</spec>
 				<spec>Cop</spec>
 				<spec>Documentary</spec>
+				<spec>Drama</spec>
 				<spec>Fantasy</spec>
+				<spec>Horror</spec>
 				<spec>Rom-Com</spec>
 				<spec>Sci-fi</spec>
+				<spec>Thriller</spec>
+			</specs>
+		</skill>
+		<skill>
+			<id>2ffc7361-466a-4f9e-a09c-f6c56046f2ef</id>
+			<name>Trideo Shows</name>
+			<attribute>INT</attribute>
+			<category>Interest</category>
+			<default>No</default>
+			<skillgroup />
+			<specs>
+				<spec>Action</spec>
+				<spec>Comedy</spec>
+				<spec>Cop</spec>
+				<spec>Documentary</spec>
+				<spec>Drama</spec>
+				<spec>Fantasy</spec>
+				<spec>Game Shows</spec>
+				<spec>Horror</spec>
+				<spec>Reality Shows</spec>
+				<spec>Rom-Com</spec>
+				<spec>Sci-fi</spec>
+				<spec>Thriller</spec>
 			</specs>
 		</skill>
 		<skill>
@@ -3423,7 +3500,7 @@
 				<spec>Black Market Pipeline</spec>
 				<spec>Blackmail</spec>
 				<spec>BTL</spec>
-				<spec>Counterfitting</spec>
+				<spec>Counterfeiting</spec>
 				<spec>Drugs</spec>
 				<spec>Drug Dealers</spec>
 				<spec>Fencing</spec>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -8445,7 +8445,7 @@
 		<!-- End Region -->
 		<!-- Region Cutting Aces -->
 		<weapon>
-			<id>ad4a06e3-7f8e-4f05-a42e-5be2c875bb72</id>
+			<id>dfec9209-7bf7-49fa-b816-da173fad9963</id>
 			<name>Mortimer of London ‘Belgrave’ Sword Cane</name>
 			<category>Blades</category>
 			<type>Melee</type>
@@ -8465,7 +8465,7 @@
 			<page>132</page>
 		</weapon>
 		<weapon>
-			<id>e46fce7e-a1bf-416e-86ea-2608368b44fe</id>
+			<id>79cbec3d-d832-4b57-83e0-e2ffecbcdb0a</id>
 			<name>Hammerli 620S</name>
 			<category>Light Pistols</category>
 			<type>Ranged</type>
@@ -8524,7 +8524,7 @@
 		<page>133</page>
 	</weapon>
 	<weapon>
-		<id>9ed19faa-f870-4127-ac1d-7764b164b072</id>
+		<id>daa06575-86d4-449a-ba6f-85ad736c622e</id>
 		<name>Nemesis Arms Praetorian</name>
 		<category>Heavy Pistols</category>
 		<type>Ranged</type>
@@ -8555,7 +8555,7 @@
 		<page>134</page>
 	</weapon>
 	<weapon>
-		<id>9ed19faa-f870-4127-ac1d-7764b164b072</id>
+		<id>44802a19-05ea-4293-b234-a9d24155ce01</id>
 		<name>Stinger Pen Gun</name>
 		<category>Holdouts</category>
 		<type>Ranged</type>
@@ -8576,7 +8576,7 @@
 		<page>134</page>
 	</weapon>
 	<weapon>
-		<id>9ed19faa-f870-4127-ac1d-7764b164b072</id>
+		<id>a5bedab8-5421-4e70-9b9c-180ad91d0c0c</id>
 		<name>Injector Pen</name>
 		<category>Exotic Melee Weapons</category>
 		<type>Melee</type>
@@ -8598,7 +8598,7 @@
 		<page>134</page>
 	</weapon>
 	<weapon>
-		<id>9ed19faa-f870-4127-ac1d-7764b164b072</id>
+		<id>97037590-5324-4ab1-acdb-b2d204cb937a</id>
 		<name>Pepper Punch Pen</name>
 		<category>Exotic Ranged Weapons</category>
 		<type>Ranged</type>
@@ -8620,7 +8620,7 @@
 		<page>134</page>
 	</weapon>
 	<weapon>
-		<id>9ed19faa-f870-4127-ac1d-7764b164b072</id>
+		<id>06cc6008-2aa1-4d39-8a5c-884136d82fee</id>
 		<name>Modified Spray Pen</name>
 		<category>Exotic Ranged Weapons</category>
 		<type>Ranged</type>
@@ -8647,7 +8647,7 @@
 		<page>134</page>
 	</weapon>
 	<weapon>
-		<id>9ed19faa-f870-4127-ac1d-7764b164b072</id>
+		<id>bd9515ad-9d40-486e-974a-00babc4c24f9</id>
 		<name>Sap Cap</name>
 		<category>Clubs</category>
 		<type>Melee</type>


### PR DESCRIPTION
Nightly Changes:

- Fixed crashes that occured when selecting certain pieces of gear from Cutting Aces.

Data Changes:

- Added missing Active Skill specializations based on SR4a20th and rules for specializing for specific actions.
- Added knowledge skills and knowledge skill specializations based on Market Panic and Chrome Flesh.