### PR TITLE
Cutting Aces Fixes, Code Cleaning

### DIFF
--- a/Chummer/Backend/Equipment/Commlink.cs
+++ b/Chummer/Backend/Equipment/Commlink.cs
@@ -32,181 +32,14 @@ namespace Chummer.Backend.Equipment
 		/// <param name="blnCreateChildren">Whether or not child Gear should be created.</param>
 		public void Create(XmlNode objXmlGear, Character objCharacter, TreeNode objNode, int intRating, bool blnAddImprovements = true, bool blnCreateChildren = true)
 		{
-			_strName = objXmlGear["name"].InnerText;
-			_strCategory = objXmlGear["category"].InnerText;
-			_strAvail = objXmlGear["avail"].InnerText;
-			objXmlGear.TryGetField("cost", out _strCost);
-			objXmlGear.TryGetField("cost3", out _strCost3, "");
-			objXmlGear.TryGetField("cost6", out _strCost6, "");
-			objXmlGear.TryGetField("cost10", out _strCost10, "");
-			objXmlGear.TryGetField("armorcapacity", out _strArmorCapacity);
-			_nodBonus = objXmlGear["bonus"];
-			_intMaxRating = Convert.ToInt32(objXmlGear["rating"].InnerText);
-			_intRating = intRating;
-			_strSource = objXmlGear["source"].InnerText;
-			_strPage = objXmlGear["page"].InnerText;
+            base.Create(objXmlGear, objCharacter, objNode, intRating, new List<Weapon>(), new List<TreeNode>(), "", false, false, blnAddImprovements, blnCreateChildren);
+
 			_intDeviceRating = Convert.ToInt32(objXmlGear["devicerating"].InnerText);
-            
             
 			_intAttack = Convert.ToInt32(objXmlGear["attack"].InnerText);
 			_intSleaze= Convert.ToInt32(objXmlGear["sleaze"].InnerText);
 			_intDataProcessing = Convert.ToInt32(objXmlGear["dataprocessing"].InnerText);
 			_intFirewall = Convert.ToInt32(objXmlGear["firewall"].InnerText);
-
-			if (GlobalOptions.Instance.Language != "en-us")
-			{
-				XmlDocument objXmlDocument = XmlManager.Instance.Load("gear.xml");
-				XmlNode objGearNode = objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"" + _strName + "\"]");
-				if (objGearNode != null)
-				{
-					if (objGearNode["translate"] != null)
-						_strAltName = objGearNode["translate"].InnerText;
-					if (objGearNode["altpage"] != null)
-						_strAltPage = objGearNode["altpage"].InnerText;
-				}
-
-				if (_strAltName.StartsWith("Stacked Focus"))
-					_strAltName = _strAltName.Replace("Stacked Focus", LanguageManager.Instance.GetString("String_StackedFocus"));
-
-				objGearNode = objXmlDocument.SelectSingleNode("/chummer/categories/category[. = \"" + _strCategory + "\"]");
-				if (objGearNode != null)
-				{
-					if (objGearNode.Attributes["translate"] != null)
-						_strAltCategory = objGearNode.Attributes["translate"].InnerText;
-				}
-
-				if (_strAltCategory.StartsWith("Stacked Focus"))
-					_strAltCategory = _strAltCategory.Replace("Stacked Focus", LanguageManager.Instance.GetString("String_StackedFocus"));
-			}
-
-			string strSource = _guiID.ToString();
-
-			objNode.Text = DisplayNameShort;
-			objNode.Tag = _guiID.ToString();
-
-			// If the item grants a bonus, pass the information to the Improvement Manager.
-			if (objXmlGear["bonus"] != null)
-			{
-				ImprovementManager objImprovementManager;
-				if (blnAddImprovements)
-					objImprovementManager = new ImprovementManager(objCharacter);
-				else
-					objImprovementManager = new ImprovementManager(null);
-
-				if (!objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, strSource, objXmlGear["bonus"], false, 1, DisplayNameShort))
-				{
-					_guiID = Guid.Empty;
-					return;
-				}
-				if (objImprovementManager.SelectedValue != "")
-				{
-					_strExtra = objImprovementManager.SelectedValue;
-					objNode.Text += " (" + objImprovementManager.SelectedValue + ")";
-				}
-			}
-
-			// Check to see if there are any child elements.
-			if (objXmlGear.InnerXml.Contains("<gears>") && blnCreateChildren)
-			{
-				// Create Gear using whatever information we're given.
-				foreach (XmlNode objXmlChild in objXmlGear.SelectNodes("gears/gear"))
-				{
-					Gear objChild = new Gear(_objCharacter);
-					TreeNode objChildNode = new TreeNode();
-					objChild.Name = objXmlChild["name"].InnerText;
-					objChild.Category = objXmlChild["category"].InnerText;
-					objChild.Avail = "0";
-					objChild.Cost = "0";
-					objChild.Source = _strSource;
-					objChild.Page = _strPage;
-					objChild.Parent = this;
-					_objChildren.Add(objChild);
-
-					objChildNode.Text = objChild.DisplayName;
-					objChildNode.Tag = objChild.InternalId;
-					objNode.Nodes.Add(objChildNode);
-					objNode.Expand();
-				}
-
-				XmlDocument objXmlGearDocument = XmlManager.Instance.Load("gear.xml");
-				CreateChildren(objXmlGearDocument, objXmlGear, this, objNode, objCharacter, blnCreateChildren);
-			}
-
-			// Add the Copy Protection and Registration plugins to the Matrix program. This does not apply if Unwired is not enabled, Hacked is selected, or this is a Suite being added (individual programs will add it to themselves).
-			if (blnCreateChildren)
-			{
-				if ((_strCategory == "Matrix Programs" || _strCategory == "Skillsofts" || _strCategory == "Autosofts" || _strCategory == "Autosofts, Agent" || _strCategory == "Autosofts, Drone") && objCharacter.Options.BookEnabled("UN") && !_strName.StartsWith("Suite:"))
-				{
-					XmlDocument objXmlDocument = XmlManager.Instance.Load("gear.xml");
-
-					if (_objCharacter.Options.AutomaticCopyProtection)
-					{
-						Gear objPlugin1 = new Gear(_objCharacter);
-						TreeNode objPlugin1Node = new TreeNode();
-						objPlugin1.Create(objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"Copy Protection\"]"), objCharacter, objPlugin1Node, _intRating, null, null);
-						if (_intRating == 0)
-							objPlugin1.Rating = 1;
-						objPlugin1.Avail = "0";
-						objPlugin1.Cost = "0";
-						objPlugin1.Cost3 = "0";
-						objPlugin1.Cost6 = "0";
-						objPlugin1.Cost10 = "0";
-						objPlugin1.Capacity = "[0]";
-						objPlugin1.Parent = this;
-						_objChildren.Add(objPlugin1);
-						objNode.Nodes.Add(objPlugin1Node);
-					}
-
-					if (_objCharacter.Options.AutomaticRegistration)
-					{
-						Gear objPlugin2 = new Gear(_objCharacter);
-						TreeNode objPlugin2Node = new TreeNode();
-						objPlugin2.Create(objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"Registration\"]"), objCharacter, objPlugin2Node, 0, null, null);
-						objPlugin2.Avail = "0";
-						objPlugin2.Cost = "0";
-						objPlugin2.Cost3 = "0";
-						objPlugin2.Cost6 = "0";
-						objPlugin2.Cost10 = "0";
-						objPlugin2.Capacity = "[0]";
-						objPlugin2.Parent = this;
-						_objChildren.Add(objPlugin2);
-						objNode.Nodes.Add(objPlugin2Node);
-						objNode.Expand();
-					}
-
-					if ((objCharacter.Metatype == "A.I." || objCharacter.MetatypeCategory == "Technocritters" || objCharacter.MetatypeCategory == "Protosapients"))
-					{
-						Gear objPlugin3 = new Gear(_objCharacter);
-						TreeNode objPlugin3Node = new TreeNode();
-						objPlugin3.Create(objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"Ergonomic\"]"), objCharacter, objPlugin3Node, 0, null, null);
-						objPlugin3.Avail = "0";
-						objPlugin3.Cost = "0";
-						objPlugin3.Cost3 = "0";
-						objPlugin3.Cost6 = "0";
-						objPlugin3.Cost10 = "0";
-						objPlugin3.Capacity = "[0]";
-						objPlugin3.Parent = this;
-						_objChildren.Add(objPlugin3);
-						objNode.Nodes.Add(objPlugin3Node);
-
-						Gear objPlugin4 = new Gear(_objCharacter);
-						TreeNode objPlugin4Node = new TreeNode();
-						objPlugin4.Create(objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"Optimization\" and category = \"Program Options\"]"), objCharacter, objPlugin4Node, _intRating, null, null);
-						if (_intRating == 0)
-							objPlugin4.Rating = 1;
-						objPlugin4.Avail = "0";
-						objPlugin4.Cost = "0";
-						objPlugin4.Cost3 = "0";
-						objPlugin4.Cost6 = "0";
-						objPlugin4.Cost10 = "0";
-						objPlugin4.Capacity = "[0]";
-						objPlugin4.Parent = this;
-						_objChildren.Add(objPlugin4);
-						objNode.Nodes.Add(objPlugin4Node);
-						objNode.Expand();
-					}
-				}
-			}
 		}
 
 		/// <summary>
@@ -218,117 +51,32 @@ namespace Chummer.Backend.Equipment
 		/// <param name="objWeaponNodes">List of Weapon TreeNodes created by copying the item.</param>
 		public void Copy(Commlink objGear, TreeNode objNode, List<Weapon> objWeapons, List<TreeNode> objWeaponNodes)
 		{
-			_strName = objGear.Name;
-			_strCategory = objGear.Category;
-			_intMaxRating = objGear.MaxRating;
-			_intMinRating = objGear.MinRating;
-			_intRating = objGear.Rating;
-			_intQty = objGear.Quantity;
-			_strCapacity = objGear.Capacity;
-			_strArmorCapacity = objGear.ArmorCapacity;
-			_strAvail = objGear.Avail;
-			_strAvail3 = objGear.Avail3;
-			_strAvail6 = objGear.Avail6;
-			_strAvail10 = objGear.Avail10;
-			_intCostFor = objGear.CostFor;
+            base.Copy(objGear, objNode, new List<Weapon>(), new List<TreeNode>());
 			_strOverclocked = objGear.Overclocked;
 			_intDeviceRating = objGear.DeviceRating;
 			_intAttack = objGear.Attack;
 			_intDataProcessing = objGear.DataProcessing;
 			_intFirewall = objGear.Firewall;
 			_intSleaze = objGear.Sleaze;
-			_strCost = objGear.Cost;
-			_strCost3 = objGear.Cost3;
-			_strCost6 = objGear.Cost6;
-			_strCost10 = objGear.Cost10;
-			_strSource = objGear.Source;
-			_strPage = objGear.Page;
-			_strExtra = objGear.Extra;
-			_blnBonded = objGear.Bonded;
-			_blnEquipped = objGear.Equipped;
-			_blnHomeNode = objGear.HomeNode;
-			_nodBonus = objGear.Bonus;
-			_nodWeaponBonus = objGear.WeaponBonus;
-			_guiWeaponID = Guid.Parse(objGear.WeaponID);
-			_strNotes = objGear.Notes;
-			_strLocation = objGear.Location;
-
-			objNode.Text = DisplayName;
-			objNode.Tag = _guiID.ToString();
-
-			foreach (Gear objGearChild in objGear.Children)
-			{
-				TreeNode objChildNode = new TreeNode();
-				Gear objChild = new Gear(_objCharacter);
-				if (objGearChild.GetType() == typeof(Commlink))
-				{
-					Commlink objCommlink = new Commlink(_objCharacter);
-					objCommlink.Copy(objGearChild, objChildNode, objWeapons, objWeaponNodes);
-					objChild = objCommlink;
-				}
-				else
-					objChild.Copy(objGearChild, objChildNode, objWeapons, objWeaponNodes);
-				_objChildren.Add(objChild);
-
-				objNode.Nodes.Add(objChildNode);
-				objNode.Expand();
-			}
-		}
+            _blnIsLivingPersona = objGear.IsLivingPersona;
+            _blnActiveCommlink = objGear.IsActive;
+    }
 
 		/// <summary>
-		/// Save the object's XML to the XmlWriter.
+		/// Core code to Save the object's XML to the XmlWriter.
 		/// </summary>
 		/// <param name="objWriter">XmlTextWriter to write with.</param>
-		public new void Save(XmlTextWriter objWriter)
+		public new void SaveInner(XmlTextWriter objWriter)
 		{
-			objWriter.WriteStartElement("gear");
-			objWriter.WriteElementString("guid", _guiID.ToString());
-			objWriter.WriteElementString("name", _strName);
-			objWriter.WriteElementString("category", _strCategory);
-			objWriter.WriteElementString("armorcapacity", _strArmorCapacity);
-			objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
-			objWriter.WriteElementString("rating", _intRating.ToString());
-			objWriter.WriteElementString("qty", _intQty.ToString());
-			objWriter.WriteElementString("avail", _strAvail);
-			objWriter.WriteElementString("cost", _strCost);
-			objWriter.WriteElementString("extra", _strExtra);
-			objWriter.WriteElementString("bonded", _blnBonded.ToString());
-			objWriter.WriteElementString("equipped", _blnEquipped.ToString());
-			objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
+            base.SaveInner(objWriter);
 			objWriter.WriteElementString("overclocked", _blnHomeNode.ToString());
-			if (_nodBonus != null)
-				objWriter.WriteRaw("<bonus>" + _nodBonus.InnerXml + "</bonus>");
-			else
-				objWriter.WriteElementString("bonus", "");
-			objWriter.WriteElementString("source", _strSource);
-			objWriter.WriteElementString("page", _strPage);
 			objWriter.WriteElementString("devicerating", _intDeviceRating.ToString());
 			objWriter.WriteElementString("attack", _intAttack.ToString());
 			objWriter.WriteElementString("sleaze", _intSleaze.ToString());
 			objWriter.WriteElementString("dataprocessing", _intDataProcessing.ToString());
 			objWriter.WriteElementString("firewall", _intFirewall.ToString());
-			objWriter.WriteElementString("gearname", _strGearName);
-			objWriter.WriteStartElement("children");
-			foreach (Gear objGear in _objChildren)
-			{
-				// Use the Gear's SubClass if applicable.
-				if (objGear.GetType() == typeof(Commlink))
-				{
-					Commlink objCommlink = new Commlink(_objCharacter);
-					objCommlink = (Commlink)objGear;
-					objCommlink.Save(objWriter);
-				}
-				else
-				{
-					objGear.Save(objWriter);
-				}
-			}
-			objWriter.WriteEndElement();
-			objWriter.WriteElementString("location", _strLocation);
-			objWriter.WriteElementString("notes", _strNotes);
-			objWriter.WriteElementString("discountedcost", DiscountCost.ToString());
+			objWriter.WriteElementString("livingpersona", _blnIsLivingPersona.ToString());
 			objWriter.WriteElementString("active", _blnActiveCommlink.ToString());
-			objWriter.WriteEndElement();
 		}
 
 		/// <summary>
@@ -337,159 +85,32 @@ namespace Chummer.Backend.Equipment
 		/// <param name="objNode">XmlNode to load.</param>
 		public new void Load(XmlNode objNode, bool blnCopy = false)
 		{
-			_guiID = Guid.Parse(objNode["guid"].InnerText);
-			_strName = objNode["name"].InnerText;
-			_strCategory = objNode["category"].InnerText;
-			objNode.TryGetField("armorcapacity", out _strArmorCapacity).ToString();
-			_intMaxRating = Convert.ToInt32(objNode["maxrating"].InnerText);
-			_intRating = Convert.ToInt32(objNode["rating"].InnerText);
-			_intQty = Convert.ToInt32(objNode["qty"].InnerText);
-			_strAvail = objNode["avail"].InnerText;
-			_strCost = objNode["cost"].InnerText;
-			_strExtra = objNode["extra"].InnerText;
+            base.Load(objNode, blnCopy);
 			objNode.TryGetField("overclocked", out _strOverclocked);
-			objNode.TryGetField("bonded", out _blnBonded);
-			objNode.TryGetField("equipped", out _blnEquipped);
-			objNode.TryGetField("homenode", out _blnHomeNode);
-			_nodBonus = objNode["bonus"];
-			_strSource = objNode["source"].InnerText;
-			objNode.TryGetField("page", out _strPage);
 			_intDeviceRating = Convert.ToInt32(objNode["devicerating"].InnerText);
 			objNode.TryGetField("attack", out _intAttack);
 			objNode.TryGetField("sleaze", out _intSleaze);
 			objNode.TryGetField("dataprocessing", out _intDataProcessing);
 			objNode.TryGetField("firewall", out _intFirewall);
-			objNode.TryGetField("gearname", out _strGearName);
-
-			if (objNode.InnerXml.Contains("<gear>"))
-			{
-				XmlNodeList nodChildren = objNode.SelectNodes("children/gear");
-				foreach (XmlNode nodChild in nodChildren)
-				{
-					switch (nodChild["category"].InnerText)
-					{
-						case "Commlinks":
-						case "Commlink Accessories":
-						case "Cyberdecks":
-						case "Rigger Command Consoles":
-							Commlink objCommlink = new Commlink(_objCharacter);
-							objCommlink.Load(nodChild, blnCopy);
-							objCommlink.Parent = this;
-							_objChildren.Add(objCommlink);
-							break;
-						default:
-							Gear objGear = new Gear(_objCharacter);
-							objGear.Load(nodChild, blnCopy);
-							objGear.Parent = this;
-							_objChildren.Add(objGear);
-							break;
-					}
-				}
-			}
-			objNode.TryGetField("location", out _strLocation);
-			objNode.TryGetField("notes", out _strNotes);
-			objNode.TryGetField("discountedcost", out _blnDiscountCost);
-			objNode.TryGetField("active", out _blnActiveCommlink);
-
-			if (GlobalOptions.Instance.Language != "en-us")
-			{
-				XmlDocument objXmlDocument = XmlManager.Instance.Load("gear.xml");
-				XmlNode objGearNode = objXmlDocument.SelectSingleNode("/chummer/gears/gear[name = \"" + _strName + "\"]");
-				if (objGearNode != null)
-				{
-					if (objGearNode["translate"] != null)
-						_strAltName = objGearNode["translate"].InnerText;
-					if (objGearNode["altpage"] != null)
-						_strAltPage = objGearNode["altpage"].InnerText;
-				}
-
-				if (_strAltName.StartsWith("Stacked Focus"))
-					_strAltName = _strAltName.Replace("Stacked Focus", LanguageManager.Instance.GetString("String_StackedFocus"));
-
-				objGearNode = objXmlDocument.SelectSingleNode("/chummer/categories/category[. = \"" + _strCategory + "\"]");
-				if (objGearNode != null)
-				{
-					if (objGearNode.Attributes["translate"] != null)
-						_strAltCategory = objGearNode.Attributes["translate"].InnerText;
-				}
-
-				if (_strAltCategory.StartsWith("Stacked Focus"))
-					_strAltCategory = _strAltCategory.Replace("Stacked Focus", LanguageManager.Instance.GetString("String_StackedFocus"));
-			}
-
-			if (blnCopy)
-			{
-				_guiID = Guid.NewGuid();
-				_strLocation = string.Empty;
-				_blnHomeNode = false;
-			}
+            objNode.TryGetField("livingpersona", out _blnIsLivingPersona);
+            objNode.TryGetField("active", out _blnActiveCommlink);
 		}
 
 		/// <summary>
-		/// Save the object's XML to the XmlWriter.
+		/// Core code to Save the object's XML to the XmlWriter.
 		/// </summary>
 		/// <param name="objWriter">XmlTextWriter to write with.</param>
-		public new void Print(XmlTextWriter objWriter)
+		public new void PrintInner(XmlTextWriter objWriter, bool blnIsCommlink = true, bool blnIsPersona = false)
 		{
-			objWriter.WriteStartElement("gear");
-			objWriter.WriteElementString("name", DisplayNameShort);
-			objWriter.WriteElementString("name_english", _strName);
-			if (DisplayCategory.EndsWith("s"))
-				objWriter.WriteElementString("category", DisplayCategory.Substring(0,DisplayCategory.Length -1));
-			else
-				objWriter.WriteElementString("category", DisplayCategory);
-			objWriter.WriteElementString("category_english", _strCategory);
-			objWriter.WriteElementString("iscommlink", true.ToString());
-			objWriter.WriteElementString("ispersona", IsLivingPersona.ToString());
-			//objWriter.WriteElementString("isnexus", (_strCategory == "Nexus").ToString());
-			objWriter.WriteElementString("isammo", (_strCategory == "Ammunition").ToString());
-			objWriter.WriteElementString("isprogram", IsProgram.ToString());
-			objWriter.WriteElementString("isos", false.ToString());
-			objWriter.WriteElementString("issin", false.ToString());
-			objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
-			objWriter.WriteElementString("rating", _intRating.ToString());
+            base.PrintInner(objWriter, true, IsLivingPersona);
+
 			objWriter.WriteElementString("attack", _intAttack.ToString());
 			objWriter.WriteElementString("sleaze", _intSleaze.ToString());
 			objWriter.WriteElementString("dataprocessing", _intDataProcessing.ToString());
 			objWriter.WriteElementString("firewall", _intFirewall.ToString());
-			objWriter.WriteElementString("qty", _intQty.ToString());
-			objWriter.WriteElementString("avail", TotalAvail(true));
-			objWriter.WriteElementString("avail_english", TotalAvail(true, true));
-			objWriter.WriteElementString("cost", TotalCost.ToString());
-			objWriter.WriteElementString("owncost", OwnCost.ToString());
-			objWriter.WriteElementString("extra", LanguageManager.Instance.TranslateExtra(_strExtra));
-			objWriter.WriteElementString("bonded", _blnBonded.ToString());
-			objWriter.WriteElementString("equipped", _blnEquipped.ToString());
-			objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
-			objWriter.WriteElementString("gearname", _strGearName);
-			objWriter.WriteElementString("source", _objCharacter.Options.LanguageBookShort(_strSource));
-			objWriter.WriteElementString("page", Page);
 			objWriter.WriteElementString("devicerating", TotalDeviceRating.ToString());
 			objWriter.WriteElementString("processorlimit", ProcessorLimit.ToString());
-			objWriter.WriteElementString("conditionmonitor", ConditionMonitor.ToString());
 			objWriter.WriteElementString("active", _blnActiveCommlink.ToString());
-			objWriter.WriteStartElement("children");
-			foreach (Gear objGear in _objChildren)
-			{
-				if (objGear.Category != "Commlink Upgrade" && objGear.Category != "Commlink Operating System Upgrade")
-				{
-					// Use the Gear's SubClass if applicable.
-					if (objGear.GetType() == typeof(Commlink))
-					{
-						Commlink objCommlink = new Commlink(_objCharacter);
-						objCommlink = (Commlink)objGear;
-						objCommlink.Print(objWriter);
-					}
-					else
-					{
-						objGear.Print(objWriter);
-					}
-				}
-			}
-			objWriter.WriteEndElement();
-			if (_objCharacter.Options.PrintNotes)
-				objWriter.WriteElementString("notes", _strNotes);
-			objWriter.WriteEndElement();
 		}
 		#endregion
 

--- a/Chummer/Backend/Equipment/Gear.cs
+++ b/Chummer/Backend/Equipment/Gear.cs
@@ -510,76 +510,103 @@ namespace Chummer.Backend.Equipment
 			}
 		}
 
-		/// <summary>
-		/// Save the object's XML to the XmlWriter.
+        /// <summary>
+		/// Begin to save the object's XML to the XmlWriter.
 		/// </summary>
 		/// <param name="objWriter">XmlTextWriter to write with.</param>
-		public void Save(XmlTextWriter objWriter)
+		public void SaveBegin(XmlTextWriter objWriter)
+        {
+            objWriter.WriteStartElement("gear");
+        }
+
+        /// <summary>
+		/// Core code to Save the object's XML to the XmlWriter.
+		/// </summary>
+		/// <param name="objWriter">XmlTextWriter to write with.</param>
+		public void SaveInner(XmlTextWriter objWriter)
+        {
+            objWriter.WriteElementString("guid", _guiID.ToString());
+            objWriter.WriteElementString("name", _strName);
+            objWriter.WriteElementString("category", _strCategory);
+            objWriter.WriteElementString("capacity", _strCapacity);
+            objWriter.WriteElementString("armorcapacity", _strArmorCapacity);
+            objWriter.WriteElementString("minrating", _intMinRating.ToString());
+            objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
+            objWriter.WriteElementString("rating", _intRating.ToString());
+            objWriter.WriteElementString("qty", _intQty.ToString());
+            objWriter.WriteElementString("avail", _strAvail);
+            objWriter.WriteElementString("avail3", _strAvail3);
+            objWriter.WriteElementString("avail6", _strAvail6);
+            objWriter.WriteElementString("avail10", _strAvail10);
+            if (_intCostFor > 1)
+                objWriter.WriteElementString("costfor", _intCostFor.ToString());
+            objWriter.WriteElementString("cost", _strCost);
+            objWriter.WriteElementString("cost3", _strCost3);
+            objWriter.WriteElementString("cost6", _strCost6);
+            objWriter.WriteElementString("cost10", _strCost10);
+            objWriter.WriteElementString("extra", _strExtra);
+            objWriter.WriteElementString("bonded", _blnBonded.ToString());
+            objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
+            if (_guiWeaponID != Guid.Empty)
+                objWriter.WriteElementString("weaponguid", _guiWeaponID.ToString());
+            if (_nodBonus != null)
+                objWriter.WriteRaw("<bonus>" + _nodBonus.InnerXml + "</bonus>");
+            else
+                objWriter.WriteElementString("bonus", "");
+            if (_nodWeaponBonus != null)
+                objWriter.WriteRaw("<weaponbonus>" + _nodWeaponBonus.InnerXml + "</weaponbonus>");
+            objWriter.WriteElementString("source", _strSource);
+            objWriter.WriteElementString("page", _strPage);
+            objWriter.WriteElementString("devicerating", _intDeviceRating.ToString());
+            objWriter.WriteElementString("gearname", _strGearName);
+            objWriter.WriteElementString("matrixcmfilled", _intMatrixCMFilled.ToString());
+            objWriter.WriteElementString("conditionmonitor", ConditionMonitor.ToString());
+            objWriter.WriteElementString("includedinparent", _blnIncludedInParent.ToString());
+            if (_intChildCostMultiplier != 1)
+                objWriter.WriteElementString("childcostmultiplier", _intChildCostMultiplier.ToString());
+            if (_intChildAvailModifier != 0)
+                objWriter.WriteElementString("childavailmodifier", _intChildAvailModifier.ToString());
+            objWriter.WriteStartElement("children");
+            foreach (Gear objGear in _objChildren)
+            {
+                // Use the Gear's SubClass if applicable.
+                if (objGear.GetType() == typeof(Commlink))
+                {
+                    Commlink objCommlink = new Commlink(_objCharacter);
+                    objCommlink = (Commlink)objGear;
+                    objCommlink.Save(objWriter);
+                }
+                else
+                {
+                    objGear.Save(objWriter);
+                }
+            }
+            objWriter.WriteEndElement();
+            objWriter.WriteElementString("location", _strLocation);
+            objWriter.WriteElementString("notes", _strNotes);
+            objWriter.WriteElementString("discountedcost", DiscountCost.ToString());
+        }
+
+        /// <summary>
+		/// End saving the object's XML to the XmlWriter.
+		/// </summary>
+		/// <param name="objWriter">XmlTextWriter to write with.</param>
+		public void SaveEnd(XmlTextWriter objWriter)
+        {
+            objWriter.WriteEndElement();
+            _objCharacter.SourceProcess(_strSource);
+        }
+
+        /// <summary>
+        /// Save the object's XML to the XmlWriter.
+        /// </summary>
+        /// <param name="objWriter">XmlTextWriter to write with.</param>
+        public void Save(XmlTextWriter objWriter)
 		{
-			objWriter.WriteStartElement("gear");
-			objWriter.WriteElementString("guid", _guiID.ToString());
-			objWriter.WriteElementString("name", _strName);
-			objWriter.WriteElementString("category", _strCategory);
-			objWriter.WriteElementString("capacity", _strCapacity);
-			objWriter.WriteElementString("armorcapacity", _strArmorCapacity);
-			objWriter.WriteElementString("minrating", _intMinRating.ToString());
-			objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
-			objWriter.WriteElementString("rating", _intRating.ToString());
-			objWriter.WriteElementString("qty", _intQty.ToString());
-			objWriter.WriteElementString("avail", _strAvail);
-			objWriter.WriteElementString("avail3", _strAvail3);
-			objWriter.WriteElementString("avail6", _strAvail6);
-			objWriter.WriteElementString("avail10", _strAvail10);
-			if (_intCostFor > 1)
-				objWriter.WriteElementString("costfor", _intCostFor.ToString());
-			objWriter.WriteElementString("cost", _strCost);
-			objWriter.WriteElementString("cost3", _strCost3);
-			objWriter.WriteElementString("cost6", _strCost6);
-			objWriter.WriteElementString("cost10", _strCost10);
-			objWriter.WriteElementString("extra", _strExtra);
-			objWriter.WriteElementString("bonded", _blnBonded.ToString());
-			objWriter.WriteElementString("equipped", _blnEquipped.ToString());
-			objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
-			if (_guiWeaponID != Guid.Empty)
-				objWriter.WriteElementString("weaponguid", _guiWeaponID.ToString());
-			if (_nodBonus != null)
-				objWriter.WriteRaw("<bonus>" + _nodBonus.InnerXml + "</bonus>");
-			else
-				objWriter.WriteElementString("bonus", "");
-			if (_nodWeaponBonus != null)
-				objWriter.WriteRaw("<weaponbonus>" + _nodWeaponBonus.InnerXml + "</weaponbonus>");
-			objWriter.WriteElementString("source", _strSource);
-			objWriter.WriteElementString("page", _strPage);
-			objWriter.WriteElementString("devicerating", _intDeviceRating.ToString());
-			objWriter.WriteElementString("gearname", _strGearName);
-			objWriter.WriteElementString("matrixcmfilled", _intMatrixCMFilled.ToString());
-			objWriter.WriteElementString("conditionmonitor", ConditionMonitor.ToString());
-			objWriter.WriteElementString("includedinparent", _blnIncludedInParent.ToString());
-			if (_intChildCostMultiplier != 1)
-				objWriter.WriteElementString("childcostmultiplier", _intChildCostMultiplier.ToString());
-			if (_intChildAvailModifier != 0)
-				objWriter.WriteElementString("childavailmodifier", _intChildAvailModifier.ToString());
-			objWriter.WriteStartElement("children");
-			foreach (Gear objGear in _objChildren)
-			{
-				// Use the Gear's SubClass if applicable.
-				if (objGear.GetType() == typeof(Commlink))
-				{
-					Commlink objCommlink = new Commlink(_objCharacter);
-					objCommlink = (Commlink)objGear;
-					objCommlink.Save(objWriter);
-				}
-				else
-				{
-					objGear.Save(objWriter);
-				}
-			}
-			objWriter.WriteEndElement();
-			objWriter.WriteElementString("location", _strLocation);
-			objWriter.WriteElementString("notes", _strNotes);
-			objWriter.WriteElementString("discountedcost", DiscountCost.ToString());
-			objWriter.WriteEndElement();
-			_objCharacter.SourceProcess(_strSource);
+            SaveBegin(objWriter);
+            SaveInner(objWriter);
+            SaveEnd(objWriter);
 		}
 
 		/// <summary>
@@ -815,73 +842,102 @@ namespace Chummer.Backend.Equipment
 			}
 		}
 
-		/// <summary>
-		/// Print the object's XML to the XmlWriter.
+        /// <summary>
+		/// Begin Print the object's XML to the XmlWriter.
 		/// </summary>
 		/// <param name="objWriter">XmlTextWriter to write with.</param>
-		public void Print(XmlTextWriter objWriter)
+		public void PrintBegin(XmlTextWriter objWriter)
+        {
+            objWriter.WriteStartElement("gear");
+        }
+
+        /// <summary>
+		/// Core code to Print the object's XML to the XmlWriter.
+		/// </summary>
+		/// <param name="objWriter">XmlTextWriter to write with.</param>
+		public void PrintInner(XmlTextWriter objWriter, bool blnIsCommlink = false, bool blnIsPersona = false)
+        {
+            if ((_strCategory == "Foci" || _strCategory == "Metamagic Foci") && _blnBonded)
+            {
+                objWriter.WriteElementString("name", DisplayNameShort + " (" + LanguageManager.Instance.GetString("Label_BondedFoci") + ")");
+            }
+            else
+                objWriter.WriteElementString("name", DisplayNameShort);
+            objWriter.WriteElementString("name_english", _strName);
+            objWriter.WriteElementString("category", DisplayCategory);
+            objWriter.WriteElementString("category_english", _strCategory);
+            objWriter.WriteElementString("iscommlink", blnIsCommlink.ToString());
+            objWriter.WriteElementString("ispersona", blnIsPersona.ToString());
+            //objWriter.WriteElementString("isnexus", (_strCategory == "Nexus").ToString());
+            objWriter.WriteElementString("isammo", (_strCategory == "Ammunition").ToString());
+            objWriter.WriteElementString("isprogram", IsProgram.ToString());
+            objWriter.WriteElementString("isos", false.ToString());
+            if (_strName == "Fake SIN")
+                objWriter.WriteElementString("issin", true.ToString());
+            else
+                objWriter.WriteElementString("issin", false.ToString());
+            objWriter.WriteElementString("capacity", _strCapacity);
+            objWriter.WriteElementString("armorcapacity", _strArmorCapacity);
+            objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
+            objWriter.WriteElementString("rating", _intRating.ToString());
+            objWriter.WriteElementString("conditionmonitor", ConditionMonitor.ToString());
+            objWriter.WriteElementString("qty", _intQty.ToString());
+            objWriter.WriteElementString("avail", TotalAvail(true));
+            objWriter.WriteElementString("avail_english", TotalAvail(true, true));
+            objWriter.WriteElementString("cost", TotalCost.ToString());
+            objWriter.WriteElementString("owncost", OwnCost.ToString());
+            objWriter.WriteElementString("extra", LanguageManager.Instance.TranslateExtra(_strExtra));
+            objWriter.WriteElementString("bonded", _blnBonded.ToString());
+            objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
+            objWriter.WriteElementString("location", _strLocation);
+            objWriter.WriteElementString("gearname", _strGearName);
+            objWriter.WriteElementString("source", _objCharacter.Options.LanguageBookShort(_strSource));
+            objWriter.WriteElementString("page", Page);
+            objWriter.WriteStartElement("children");
+            foreach (Gear objGear in _objChildren)
+            {
+                // Use the Gear's SubClass if applicable.
+                if (objGear.GetType() == typeof(Commlink))
+                {
+                    Commlink objCommlink = new Commlink(_objCharacter);
+                    objCommlink = (Commlink)objGear;
+                    objCommlink.Print(objWriter);
+                }
+                else
+                {
+                    objGear.Print(objWriter);
+                }
+            }
+            objWriter.WriteEndElement();
+            if (_nodWeaponBonus != null)
+            {
+                objWriter.WriteElementString("weaponbonusdamage", WeaponBonusDamage());
+                objWriter.WriteElementString("weaponbonusdamage_english", WeaponBonusDamage(true));
+                objWriter.WriteElementString("weaponbonusap", WeaponBonusAP);
+            }
+            if (_objCharacter.Options.PrintNotes)
+                objWriter.WriteElementString("notes", _strNotes);
+        }
+
+        /// <summary>
+		/// End Print the object's XML to the XmlWriter.
+		/// </summary>
+		/// <param name="objWriter">XmlTextWriter to write with.</param>
+		public void PrintEnd(XmlTextWriter objWriter)
+        {
+            objWriter.WriteEndElement();
+        }
+
+        /// <summary>
+        /// Print the object's XML to the XmlWriter.
+        /// </summary>
+        /// <param name="objWriter">XmlTextWriter to write with.</param>
+        public void Print(XmlTextWriter objWriter)
 		{
-			objWriter.WriteStartElement("gear");
-			if ((_strCategory == "Foci" || _strCategory == "Metamagic Foci") && _blnBonded)
-			{
-				objWriter.WriteElementString("name", DisplayNameShort + " (" + LanguageManager.Instance.GetString("Label_BondedFoci") + ")");
-			}
-			else
-				objWriter.WriteElementString("name", DisplayNameShort);
-			objWriter.WriteElementString("name_english", _strName);
-			objWriter.WriteElementString("category", DisplayCategory);
-			objWriter.WriteElementString("category_english", _strCategory);
-			objWriter.WriteElementString("iscommlink", false.ToString());
-			objWriter.WriteElementString("ispersona", false.ToString());
-			//objWriter.WriteElementString("isnexus", (_strCategory == "Nexus").ToString());
-			objWriter.WriteElementString("isammo", (_strCategory == "Ammunition").ToString());
-			objWriter.WriteElementString("isprogram", IsProgram.ToString());
-			objWriter.WriteElementString("isos", false.ToString());
-			if (_strName == "Fake SIN")
-				objWriter.WriteElementString("issin", true.ToString());
-			else
-				objWriter.WriteElementString("issin", false.ToString());
-			objWriter.WriteElementString("capacity", _strCapacity);
-			objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
-			objWriter.WriteElementString("rating", _intRating.ToString());
-			objWriter.WriteElementString("qty", _intQty.ToString());
-			objWriter.WriteElementString("avail", TotalAvail(true));
-			objWriter.WriteElementString("avail_english", TotalAvail(true, true));
-			objWriter.WriteElementString("cost", TotalCost.ToString());
-			objWriter.WriteElementString("owncost", OwnCost.ToString());
-			objWriter.WriteElementString("extra", LanguageManager.Instance.TranslateExtra(_strExtra));
-			objWriter.WriteElementString("bonded", _blnBonded.ToString());
-			objWriter.WriteElementString("equipped", _blnEquipped.ToString());
-			objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
-			objWriter.WriteElementString("location", _strLocation);
-			objWriter.WriteElementString("gearname", _strGearName);
-			objWriter.WriteElementString("source", _objCharacter.Options.LanguageBookShort(_strSource));
-			objWriter.WriteElementString("page", Page);
-			objWriter.WriteStartElement("children");
-			foreach (Gear objGear in _objChildren)
-			{
-				// Use the Gear's SubClass if applicable.
-				if (objGear.GetType() == typeof(Commlink))
-				{
-					Commlink objCommlink = new Commlink(_objCharacter);
-					objCommlink = (Commlink)objGear;
-					objCommlink.Print(objWriter);
-				}
-				else
-				{
-					objGear.Print(objWriter);
-				}
-			}
-			objWriter.WriteEndElement();
-			if (_nodWeaponBonus != null)
-			{
-				objWriter.WriteElementString("weaponbonusdamage", WeaponBonusDamage());
-				objWriter.WriteElementString("weaponbonusdamage_english", WeaponBonusDamage(true));
-				objWriter.WriteElementString("weaponbonusap", WeaponBonusAP);
-			}
-			if (_objCharacter.Options.PrintNotes)
-				objWriter.WriteElementString("notes", _strNotes);
-			objWriter.WriteEndElement();
+            PrintBegin(objWriter);
+            PrintInner(objWriter);
+            PrintEnd(objWriter);
 		}
 		#endregion
 
@@ -1856,7 +1912,41 @@ namespace Chummer.Backend.Equipment
 					else
 						intReturn = 0;
 				}
-				else if (_strCost.Contains("Rating") || _strCost3.Contains("Rating") || _strCost6.Contains("Rating") || _strCost10.Contains("Rating"))
+                else if (_strCost.Contains("Children Cost") || _strCost3.Contains("Children Cost") || _strCost6.Contains("Children Cost") || _strCost10.Contains("Children Cost"))
+                {
+                    if (_objChildren.Capacity > 0)
+                    {
+                        string strCostExpression = "";
+
+                        if (_strCost != "")
+                            strCostExpression = _strCost;
+                        else
+                        {
+                            if (_intRating <= 3)
+                                strCostExpression = _strCost3;
+                            else if (_intRating <= 6)
+                                strCostExpression = _strCost6;
+                            else
+                                strCostExpression = _strCost10;
+                        }
+
+                        int intTotalChildrenCost = 0;
+                        foreach(Gear LoopGear in _objChildren)
+                        {
+                            intTotalChildrenCost += LoopGear.CalculatedCost;
+                        }
+
+                        XmlDocument objXmlDocument = new XmlDocument();
+                        XPathNavigator nav = objXmlDocument.CreateNavigator();
+                        string strCost = "";
+                        strCost = strCostExpression.Replace("Children Cost", intTotalChildrenCost.ToString());
+                        XPathExpression xprCost = nav.Compile(strCost);
+                        intReturn = Convert.ToInt32(nav.Evaluate(xprCost).ToString());
+                    }
+                    else
+                        intReturn = 0;
+                }
+                else if (_strCost.Contains("Rating") || _strCost3.Contains("Rating") || _strCost6.Contains("Rating") || _strCost10.Contains("Rating"))
 				{
 					// If the cost is determined by the Rating, evaluate the expression.
 					XmlDocument objXmlDocument = new XmlDocument();
@@ -1932,7 +2022,41 @@ namespace Chummer.Backend.Equipment
 					else
 						intReturn = 0;
 				}
-				else if (_strCost.StartsWith("Parent Cost"))
+                else if (_strCost.Contains("Children Cost") || _strCost3.Contains("Children Cost") || _strCost6.Contains("Children Cost") || _strCost10.Contains("Children Cost"))
+                {
+                    if (_objChildren.Capacity > 0)
+                    {
+                        string strCostExpression = "";
+
+                        if (_strCost != "")
+                            strCostExpression = _strCost;
+                        else
+                        {
+                            if (_intRating <= 3)
+                                strCostExpression = _strCost3;
+                            else if (_intRating <= 6)
+                                strCostExpression = _strCost6;
+                            else
+                                strCostExpression = _strCost10;
+                        }
+
+                        int intTotalChildrenCost = 0;
+                        foreach (Gear LoopGear in _objChildren)
+                        {
+                            intTotalChildrenCost += LoopGear.CalculatedCost;
+                        }
+
+                        XmlDocument objXmlDocument = new XmlDocument();
+                        XPathNavigator nav = objXmlDocument.CreateNavigator();
+                        string strCost = "";
+                        strCost = strCostExpression.Replace("Children Cost", intTotalChildrenCost.ToString());
+                        XPathExpression xprCost = nav.Compile(strCost);
+                        intReturn = Convert.ToInt32(nav.Evaluate(xprCost).ToString());
+                    }
+                    else
+                        intReturn = 0;
+                }
+                else if (_strCost.StartsWith("Parent Cost"))
 				{
 
 					XmlDocument objXmlDocument = new XmlDocument();
@@ -2051,7 +2175,41 @@ namespace Chummer.Backend.Equipment
 					else
 						intReturn = 0;
 				}
-				else if (_strCost.Contains("Rating") || _strCost3.Contains("Rating") || _strCost6.Contains("Rating") || _strCost10.Contains("Rating") || _strCost.Contains("*") || _strCost3.Contains("*") || _strCost6.Contains("*") || _strCost10.Contains("*"))
+                else if (_strCost.Contains("Children Cost") || _strCost3.Contains("Children Cost") || _strCost6.Contains("Children Cost") || _strCost10.Contains("Children Cost"))
+                {
+                    if (_objChildren.Capacity > 0)
+                    {
+                        string strCostExpression = "";
+
+                        if (_strCost != "")
+                            strCostExpression = _strCost;
+                        else
+                        {
+                            if (_intRating <= 3)
+                                strCostExpression = _strCost3;
+                            else if (_intRating <= 6)
+                                strCostExpression = _strCost6;
+                            else
+                                strCostExpression = _strCost10;
+                        }
+
+                        int intTotalChildrenCost = 0;
+                        foreach (Gear LoopGear in _objChildren)
+                        {
+                            intTotalChildrenCost += LoopGear.CalculatedCost;
+                        }
+
+                        XmlDocument objXmlDocument = new XmlDocument();
+                        XPathNavigator nav = objXmlDocument.CreateNavigator();
+                        string strCost = "";
+                        strCost = strCostExpression.Replace("Children Cost", intTotalChildrenCost.ToString());
+                        XPathExpression xprCost = nav.Compile(strCost);
+                        intReturn = Convert.ToInt32(nav.Evaluate(xprCost).ToString());
+                    }
+                    else
+                        intReturn = 0;
+                }
+                else if (_strCost.Contains("Rating") || _strCost3.Contains("Rating") || _strCost6.Contains("Rating") || _strCost10.Contains("Rating") || _strCost.Contains("*") || _strCost3.Contains("*") || _strCost6.Contains("*") || _strCost10.Contains("*"))
 				{
 					// If the cost is determined by the Rating, evaluate the expression.
 					XmlDocument objXmlDocument = new XmlDocument();

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -17657,19 +17657,16 @@ namespace Chummer
                     objNewGear = objCommlink;
                     break;
                 default:
-                    Gear objGear = new Gear(_objCharacter);
-                    objGear.Create(objXmlGear, _objCharacter, objNode, frmPickGear.SelectedRating, objWeapons, objWeaponNodes, "", false, false, true, true, frmPickGear.Aerodynamic);
-                    objGear.Quantity = frmPickGear.SelectedQty;
+                    objNewGear.Create(objXmlGear, _objCharacter, objNode, frmPickGear.SelectedRating, objWeapons, objWeaponNodes, "", false, false, true, true, frmPickGear.Aerodynamic);
+                    objNewGear.Quantity = frmPickGear.SelectedQty;
                     try
                     {
-                        nudGearQty.Increment = objGear.CostFor;
+                        nudGearQty.Increment = objNewGear.CostFor;
                         //nudGearQty.Minimum = nudGearQty.Increment;
                     }
                     catch
                     {
                     }
-
-                    objNewGear = objGear;
                     break;
             }
 

--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -1098,13 +1098,14 @@ namespace Chummer.Classes
 			bonusNode.TryGetField("connection", out connection, 1);
 			bool group = bonusNode["group"] != null;
 			bool free = bonusNode["free"] != null;
+            bool canwrite = bonusNode["canwrite"] != null;
 
 			Contact contact = new Contact(_objCharacter);
 			contact.Free = free;
 			contact.IsGroup = group;
 			contact.Loyalty = loyalty;
 			contact.Connection = connection;
-			contact.ReadOnly = true;
+			contact.ReadOnly = !canwrite;
 			_objCharacter.Contacts.Add(contact);
 
 			CreateImprovement(contact.GUID, Improvement.ImprovementSource.Quality, SourceName,

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -58,6 +58,9 @@ Application Changes:
 - Added optional rule for using the maximum drone attribute rule for Pilot.
 - Variable costs are now properly supported on Armor Mods, Weapons, and Weapon Accessories.
 - Added the ability for a lifestyle quality to only modify the base cost of the lifestyle, i.e. the cost without extra entertainment assets, instead of the extra asset costs factored in.
+- Added the ability to add contacts via improvements that are not read-only at character generation.
+- Gear can now have a cost based on the total cost of its children.
+- Modified the Commlink class so that it always executes the methods of its parent Gear class in its overriden methods wherever applicable (greatly improves code portability, as any changes to Gear's methods will be used by Commlink's methods).
 
 Data Changes: 
 

--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -3230,7 +3230,7 @@
 		<!-- Region Cutting Aces -->
 		<mod>
 			<id>151d8957-aeb1-4fda-af19-35f4c9c602e1</id>
-			<name>Voidblack Cothing</name>
+			<name>Voidblack Coating</name>
 			<category>General</category>
 			<armor>0</armor>
 			<maxrating>1</maxrating>
@@ -3246,23 +3246,11 @@
 			<category>General</category>
 			<armor>0</armor>
 			<maxrating>1</maxrating>
-			<armorcapacity>[6]</armorcapacity>
-			<avail>14F</avail>
-			<cost>3000</cost>
+			<armorcapacity>[0]</armorcapacity>
+			<avail>0</avail>
+			<cost>50</cost>
 			<source>CA</source>
 			<page>138</page>
-		</mod>
-		<mod>
-			<id>3e58b2bc-695f-43ca-a020-71e62e9a87c4</id>
-			<name>Distributed Deck</name>
-			<category>General</category>
-			<armor>0</armor>
-			<maxrating>1</maxrating>
-			<armorcapacity>[6]</armorcapacity>
-			<avail>+2</avail>
-			<cost>Variable(0-100000)</cost>
-			<source>CA</source>
-			<page>139</page>
 		</mod>
 		<!-- End Region -->
 	</mods>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -8258,6 +8258,18 @@
 			<source>SR5</source>
 			<page>449</page>
 		</gear>
+		<gear>
+			<id>01c28047-0446-4f3d-817d-4805317167ce</id>
+			<name>Distributed Deck</name>
+			<category>Armor Enhancements</category>
+			<rating>0</rating>
+			<armorcapacity>[6]</armorcapacity>
+			<addoncategory>Cyberdecks</addoncategory>
+			<avail>+2</avail>
+			<cost>Children Cost * 0.1</cost>
+			<source>CA</source>
+			<page>139</page>
+		</gear>
 		<!-- End Region -->
 		<!-- Region Commlink Accessories -->
 		<gear>

--- a/Chummer/data/lifemodules.xml
+++ b/Chummer/data/lifemodules.xml
@@ -7912,6 +7912,366 @@
 		</module>
 		<!-- End Region -->
 		<!-- End Region -->
+		<!--Region Cutting Aces -->
+		<!--Region Formative Years-->
+		<module>
+			<id>e80c51ca-d71e-47e5-91e4-22bff1a0d330</id>
+			<stage>Formative Years</stage>
+			<category>LifeModule</category>
+			<name>Brothel Child</name>
+			<karma>40</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+				</attributelevel>
+				<attributelevel>
+					<name>WIL</name>
+				</attributelevel>
+				<skilllevel>
+					<name>Etiquette</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Escape Artist</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Sneaking</name>
+					<val>3</val>
+				</skilllevel>
+				<knowledgeskilllevel>
+					<name>[Syndicate]</name>
+					<group>Street</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Language</group>
+					<val>1</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Language</group>
+					<val>1</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Language</group>
+					<val>1</val>
+				</knowledgeskilllevel>
+			</bonus>
+			<story>$real was brought up in a syndicate-run brothel with the help of $real's many "aunts". They taught $real to be polite and discreet, so as to never be seen by the clients, and some of the many languages $real heard during this time stuck with $real.</story>
+			<source>CA</source>
+			<page>103</page>
+		</module>
+		<module>
+			<id>8f17dd9b-6dc4-419a-94be-584ef6f24e41</id>
+			<stage>Formative Years</stage>
+			<category>LifeModule</category>
+			<name>Con Prop</name>
+			<karma>40</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+					<val>2</val>
+				</attributelevel>
+				<skilllevel>
+					<name>Animal Handling</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Etiquette</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Palming</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Performance</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Running</name>
+				</skilllevel>
+			</bonus>
+			<story>$real's parents were con artists, and the best thing to happen to them was $real. Who would ever suspect two doting parents and their lovely child? Who wouldn't pay attention to a terrified child that had "lost their parents"? With a cute animal or two added to the mix, $real could distract the best of them.</story>
+			<source>CA</source>
+			<page>103</page>
+		</module>
+		<!--End Region -->
+		<!--Region Teen Years-->
+		<module>
+			<id>8da867a2-29cd-440f-b567-ef32cbe0da30</id>
+			<stage>Teen Years</stage>
+			<category>LifeModule</category>
+			<name>The Easiest Mark</name>
+			<karma>50</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+				</attributelevel>
+				<attributelevel>
+					<name>INT</name>
+				</attributelevel>
+				<skillgrouplevel>
+					<name>Acting</name>
+					<val>2</val>
+				</skillgrouplevel>
+				<skilllevel>
+					<name>Forgery</name>
+					<val>3</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Perception</name>
+				</skilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Street</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Interest</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<addqualities>
+					<addquality>Big Regret</addquality>
+					<addquality>Wanted</addquality>
+				</addqualities>
+			</bonus>
+			<story>$real's parents never saw it coming. $real sold them out and milked them for all they had. $real was the invincible, the best in the world... at least, according to $real's assessment. It wasn't a walk in the park to constantly stay under the law's radar, but $real managed, even with the occasional unwelcome thoughts about $real's parents creeping into $real's mind.</story>
+			<source>CA</source>
+			<page>103</page>
+		</module>
+		<!--End Region -->
+		<!--Region Real Life-->
+		<module>
+			<id>e04175cd-7fde-4e10-83e3-4952a209f956</id>
+			<stage>Real Life</stage>
+			<category>LifeModule</category>
+			<name>Mr. Johnson</name>
+			<karma>100</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+				</attributelevel>
+				<skillgrouplevel>
+					<name>Influence</name>
+					<val>3</val>
+				</skillgrouplevel>
+				<skilllevel>
+					<name>Intimidation</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Perception</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Pistols</name>
+					<val>2</val>
+				</skilllevel>
+				<knowledgeskilllevel>
+					<name>Runner Hangouts</name>
+					<group>Street</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Megacorp]</name>
+					<group>Street</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>Economics</name>
+					<group>Academic</group>
+					<val>1</val>
+				</knowledgeskilllevel>
+				<addqualities>
+					<addquality>Records on File</addquality>
+				</addqualities>
+				<addcontact>
+					<loyalty>3</loyalty>
+					<connection>4</connection>
+					<free />
+					<canwrite />
+				</addcontact>
+				<addcontact>
+					<loyalty>3</loyalty>
+					<connection>4</connection>
+					<free />
+					<canwrite />
+				</addcontact>
+				<addcontact>
+					<loyalty>3</loyalty>
+					<connection>4</connection>
+					<free />
+					<canwrite />
+				</addcontact>
+			</bonus>
+			<story>$real is a professional Johnson. $real's job is to be the line between civilization - $real's corporation - and the necessary evil of the wild men, the savages of the street.</story>
+			<source>CA</source>
+			<page>103</page>
+		</module>
+		<module>
+			<id>814c5115-d978-4a20-8123-7e746ce52983</id>
+			<stage>Real Life</stage>
+			<category>LifeModule</category>
+			<name>Spy</name>
+			<karma>100</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+				</attributelevel>
+				<attributelevel>
+					<name>WIL</name>
+				</attributelevel>
+				<skilllevel>
+					<name>Computer</name>
+					<val>3</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Con</name>
+					<val>2</val>
+				</skilllevel>
+				<skillgrouplevel>
+					<name>Cracking</name>
+					<val>2</val>
+				</skillgrouplevel>
+				<skilllevel>
+					<name>Impersonation</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Palming</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Perception</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Sneaking</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Unarmed Combat</name>
+					<val>2</val>
+				</skilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Professional</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+			</bonus>
+			<story>$real is a real spy, a working spy. $real is embedded where they need to be, undercover, and keeps an eye out for documents their handlers want, always being cautious, discreet, and misleading.</story>
+			<source>CA</source>
+			<page>104</page>
+		</module>
+		<module>
+			<id>01438e64-30aa-4555-8b24-0833dfdcad99</id>
+			<stage>Real Life</stage>
+			<category>LifeModule</category>
+			<name>Escort</name>
+			<karma>100</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+					<val>2</val>
+				</attributelevel>
+				<skilllevel>
+					<name>Con</name>
+					<val>3</val>
+					<spec>Seduction</spec>
+				</skilllevel>
+				<skilllevel>
+					<name>Etiquette</name>
+					<val>3</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Blades</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Perception</name>
+				</skilllevel>
+				<skilllevel>
+					<name>Performance</name>
+					<val>2</val>
+				</skilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Interest</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Interest</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>[Any]</name>
+					<group>Interest</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<addqualities>
+					<addquality>Addiction (Moderate)</addquality>
+					<addquality>First Impression</addquality>
+					<addquality>Creature of Comfort (Middle)</addquality>
+				</addqualities>
+			</bonus>
+			<story>An escort is nothing as vulgar as a prostitute: prostitutes sell their flesh, $real sells an experience. $real knows how to set the mood, to build something up, to be something the rich and powerful must seem to have to earn and conquer.</story>
+			<source>CA</source>
+			<page>104</page>
+		</module>
+		<module>
+			<id>9ac85595-f57c-4197-86c2-e2c9e8b37ea0</id>
+			<stage>Real Life</stage>
+			<category>LifeModule</category>
+			<name>Street Preacher</name>
+			<karma>100</karma>
+			<bonus>
+				<attributelevel>
+					<name>CHA</name>
+				</attributelevel>
+				<attributelevel>
+					<name>WIL</name>
+					<val>2</val>
+				</attributelevel>
+				<skilllevel>
+					<name>Instruction</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Intimidation</name>
+					<val>2</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Leadership</name>
+					<val>3</val>
+				</skilllevel>
+				<skilllevel>
+					<name>Survival</name>
+					<spec>Urban</spec>
+				</skilllevel>
+				<knowledgeskilllevel>
+					<name>Theology</name>
+					<group>Academic</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>Area Knowledge: [City]</name>
+					<group>Street</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<knowledgeskilllevel>
+					<name>Sprawl Life</name>
+					<group>Street</group>
+					<val>3</val>
+				</knowledgeskilllevel>
+				<addqualities>
+					<addquality>Hobo with a Shotgun</addquality>
+					<addquality>High Pain Tolerance (Rating 2)</addquality>
+				</addqualities>
+			</bonus>
+			<story>A flood is coming that will wash away the filth from the streets, and $real has a message of salvation to deliver. Their mission is paramount, they know it. $real understands that salvation comes from odd angles in these godless times, and that they might have to do unconventional things for the greater good. $real's body is strong, and their resolve is stronger.</story>
+			<source>CA</source>
+			<page>104</page>
+		</module>
+		<!-- End Region -->
+		<!-- End Region -->
 	</modules>
 	<storybuilder>
 		<macros>

--- a/Chummer/data/lifestyles.xml
+++ b/Chummer/data/lifestyles.xml
@@ -1438,6 +1438,69 @@
 			<source>CA</source>
 			<page>138</page>
 		</quality>
+		<quality>
+			<id>190ba01c-f04e-45a8-a0d1-d6fd073d61c1</id>
+			<name>CarnivoreGold</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
+		<quality>
+			<id>fe33b1e6-ad0f-44e4-b156-7c435f335682</id>
+			<name>MonaLisa</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
+		<quality>
+			<id>eeb6f3b7-70b3-478b-88c6-af47bb233b44</id>
+			<name>Pheromone Detection</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
+		<quality>
+			<id>7417c7e7-8940-47cf-9bd2-9f7193b5fbbf</id>
+			<name>Speech Template Comparison</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
+		<quality>
+			<id>49b01e13-4228-4390-a0c3-ffb6c6276e49</id>
+			<name>Target Tracking Software</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
+		<quality>
+			<id>d5239d1e-04ef-47a6-8065-a1559559a669</id>
+			<name>Thermal Mood Reading</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
+		<quality>
+			<id>c5eef5c6-288a-47c0-8d2a-42353a896077</id>
+			<name>Vocal Tension Lie Detection</name>
+			<category>Contracts</category>
+			<lp>0</lp>
+			<cost>250</cost>
+			<source>CA</source>
+			<page>144</page>
+		</quality>
 	<!-- End Region -->
 	</qualities>
 </chummer>

--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -1231,6 +1231,9 @@
 			<adeptway>0</adeptway>
 			<levels>yes</levels>
 			<limit>1</limit>
+			<bonus>
+				<judgeintentions>Rating</judgeintentions>
+			</bonus>
 			<source>CA</source>
 			<page>153</page>
 		</power>
@@ -1241,6 +1244,11 @@
 			<adeptway>0</adeptway>
 			<levels>yes</levels>
 			<limit>1</limit>
+			<required>
+        		<oneof>
+          			<power>Mimic</power>
+        		</oneof>
+      		</required>
 			<source>CA</source>
 			<page>153</page>
 		</power>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -5790,7 +5790,6 @@
 			<pilot>3</pilot>
 			<seats>0</seats>
 			<sensor>3</sensor>
-			<modslots>0</modslots>
 			<avail>11</avail>
 			<cost>18000</cost>
 			<source>CA</source>
@@ -5808,7 +5807,6 @@
 			<pilot>1</pilot>
 			<seats>0</seats>
 			<sensor>1</sensor>
-			<modslots>0</modslots>
 			<avail>7</avail>
 			<cost>600</cost>
 			<source>CA</source>
@@ -5826,7 +5824,6 @@
 			<pilot>4</pilot>
 			<seats>0</seats>
 			<sensor>2</sensor>
-			<modslots>0</modslots>
 			<avail>11</avail>
 			<cost>18000</cost>
 			<source>CA</source>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -8474,7 +8474,7 @@
 			<accuracy>5</accuracy>
 			<reach>0</reach>
 			<damage>6P</damage>
-			<ap>-</ap>
+			<ap>0</ap>
 			<mode>SA</mode>
 			<rc>0</rc>
 			<ammo>6(c)</ammo>
@@ -8495,6 +8495,7 @@
 					<name>Smartgun System, Internal</name>
 				</accessory>
 			</accessories>
+			<range>Heavy Pistols</range>
 			<source>CA</source>
 			<page>133</page>
 	</weapon>
@@ -8505,10 +8506,10 @@
 		<type>Ranged</type>
 		<conceal>-2</conceal>
 		<spec>Semi-Automatics</spec>
-		<accuracy>5</accuracy>
+		<accuracy>6</accuracy>
 		<reach>0</reach>
 		<damage>6P</damage>
-		<ap>-</ap>
+		<ap>0</ap>
 		<mode>SA/BF</mode>
 		<rc>0</rc>
 		<ammo>8(ML)x4</ammo>
@@ -8540,7 +8541,7 @@
 		<reach>0</reach>
 		<damage>8P</damage>
 		<ap>-1</ap>
-		<mode>SA/BF</mode>
+		<mode>SA</mode>
 		<rc>0</rc>
 		<ammo>12(c)</ammo>
 		<avail>9R</avail>
@@ -8579,8 +8580,8 @@
 		<mode>SS</mode>
 		<rc>0</rc>
 		<ammo>1(b)</ammo>
-		<avail>9R</avail>
-		<cost>700</cost>
+		<avail>6R</avail>
+		<cost>325</cost>
 		<allowaccessory>true</allowaccessory>
 		<accessorymounts />
 		<accessories />
@@ -8596,12 +8597,12 @@
 		<spec>Injector Pen</spec>
 		<accuracy>4</accuracy>
 		<reach>0</reach>
-		<damage>6P</damage>
+		<damage>As drug/toxin</damage>
 		<ap>-2</ap>
 		<mode>-</mode>
 		<rc>0</rc>
 		<ammo>0</ammo>
-		<avail>9R</avail>
+		<avail>9F</avail>
 		<cost>220</cost>
 		<allowaccessory>true</allowaccessory>
 		<accessorymounts />
@@ -8616,15 +8617,15 @@
 		<type>Ranged</type>
 		<conceal>-4</conceal>
 		<spec>Pepper Punch Pen</spec>
-		<accuracy>4</accuracy>
+		<accuracy>3</accuracy>
 		<reach>0</reach>
-		<damage>6P</damage>
-		<ap>-2</ap>
-		<mode>-</mode>
+		<damage>As Pepper Punch</damage>
+		<ap>0</ap>
+		<mode>SS</mode>
 		<rc>0</rc>
-		<ammo>0</ammo>
-		<avail>9R</avail>
-		<cost>220</cost>
+		<ammo>1(c)</ammo>
+		<avail>3</avail>
+		<cost>45</cost>
 		<allowaccessory>true</allowaccessory>
 		<accessorymounts />
 		<accessories />
@@ -8640,20 +8641,15 @@
 		<spec>Modified Spray Pen</spec>
 		<accuracy>3</accuracy>
 		<reach>0</reach>
-		<damage>0</damage>
-		<ap>-2</ap>
+		<damage>As drug/toxin</damage>
+		<ap>0</ap>
 		<mode>SS</mode>
 		<rc>0</rc>
 		<ammo>1(c)</ammo>
 		<avail>4F</avail>
-		<cost>220</cost>
+		<cost>60</cost>
 		<allowaccessory>true</allowaccessory>
-		<accessorymounts>
-			<mount>Barrel</mount>
-			<mount>Top</mount>
-			<mount>Stock</mount>
-			<mount>Side</mount>
-		</accessorymounts>
+		<accessorymounts />
 		<accessories />
 		<source>CA</source>
 		<page>134</page>
@@ -8663,7 +8659,7 @@
 		<name>Sap Cap</name>
 		<category>Clubs</category>
 		<type>Melee</type>
-		<conceal>-4</conceal>
+		<conceal>0</conceal>
 		<spec>Saps</spec>
 		<accuracy>4</accuracy>
 		<reach>0</reach>
@@ -8702,6 +8698,27 @@
 		<source>CA</source>
 		<page>135</page>
 	</weapon>
+		<weapon>
+			<id>b84e7ffe-acae-461c-a7ce-67056976a96e</id>
+			<name>Ares Briefcase Shield</name>
+			<category>Exotic Melee Weapons</category>
+			<hide>yes</hide>
+			<type>Melee</type>
+			<conceal>8</conceal>
+			<spec>Shields</spec>
+			<accuracy>3</accuracy>
+			<reach>0</reach>
+			<damage>(STR+2)P</damage>
+			<ap>0</ap>
+			<mode>0</mode>
+			<rc>0</rc>
+			<ammo>0</ammo>
+			<avail>14R</avail>
+			<cost>0</cost>
+			<allowaccessory>true</allowaccessory>
+			<source>CA</source>
+			<page>137</page>
+		</weapon>
 		<!-- End Region -->
 	</weapons>
 	<accessories>


### PR DESCRIPTION
Nightly changes:

- Added weapon entry for Ares Briefcase Shield.
- Fixed stats of various Cutting Aces weapons.
- Made Cutting Aces' drones modable.
- Added proper requirements to Osmosis adept power.
- Added Judge Intentions dice pool increase from Lie Detector adept power.
- Added all Cutting Aces subscriptions to lifestyle qualities.
- Added all Cutting Aces life modules.
- Corrected typo in Voidblack Coating name.
- Corrected stats of AR Fashion.
- Moved Distributed Deck into Armor Enhancements gear gategory so that it can support cyberdeck plugins.

Application changes:

- Added the ability to add contacts via improvements that are not read-only at character generation.
- Gear can now have a cost based on the total cost of its children.
- Modified the Commlink class so that it always executes the methods of its parent Gear class in its overriden methods wherever applicable (greatly improves code portability, as any changes to Gear's methods will be used by Commlink's methods).