### PR TITLE
More Cutting Aces Fixes

### DIFF
--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -4360,7 +4360,7 @@
 			<range>LOS (A)</range>
 			<damage>0</damage>
 			<duration>S</duration>
-			<dv>F-3</dv>
+			<dv>F-1</dv>
 			<source>CA</source>
 			<page>153</page>
 		</spell>
@@ -4379,7 +4379,7 @@
 		</spell>
 		<spell>
 			<id>08863013-48b9-4c7f-9bb1-25951b984dc1</id>
-			<name>Detection</name>
+			<name>Consistency</name>
 			<descriptor>Psychic</descriptor>
 			<category>Detection</category>
 			<type>M</type>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -5790,6 +5790,9 @@
 			<pilot>3</pilot>
 			<seats>0</seats>
 			<sensor>3</sensor>
+			<gears>
+				<gear rating="3" maxrating="6">Sensor Array</gear>
+			</gears>
 			<avail>11</avail>
 			<cost>18000</cost>
 			<source>CA</source>
@@ -5807,6 +5810,9 @@
 			<pilot>1</pilot>
 			<seats>0</seats>
 			<sensor>1</sensor>
+			<gears>
+				<gear rating="1" maxrating="2">Sensor Array</gear>
+			</gears>
 			<avail>7</avail>
 			<cost>600</cost>
 			<source>CA</source>
@@ -5824,6 +5830,11 @@
 			<pilot>4</pilot>
 			<seats>0</seats>
 			<sensor>2</sensor>
+			<gears>
+				<gear rating="2" maxrating="4">Sensor Array</gear>
+				<gear rating="4" select="Armorer">Skill Autosoft</gear>
+				<gear select="Armorer">Tool Kit</gear>
+			</gears>
 			<avail>11</avail>
 			<cost>18000</cost>
 			<source>CA</source>


### PR DESCRIPTION
Nightly changes:

- Corrected drain code of Incubus Shroud.
- Corrected name of Consistency spell.
- Added properly rated Sensor Arrays to all Cutting Aces' drones.
- Added Armorer Tool Kit and R4 Skill Autosoft to Microweave Spider Drone.