### PR TITLE
Couple of Fixes/Additions

### DIFF
--- a/Chummer/Backend/Equipment/Armor.cs
+++ b/Chummer/Backend/Equipment/Armor.cs
@@ -1211,10 +1211,8 @@ namespace Chummer.Backend.Equipment
 					// This is only calculated if the Maximum Armor Modification rule is enabled.
 					if (_objCharacter.Options.MaximumArmorModifications)
 					{
-						double dblA = Math.Ceiling(Convert.ToDouble(_strA, GlobalOptions.Instance.CultureInfo) * 1.5);
-						double dblHighest = dblA;
-						double dblReturn = Math.Max(dblHighest, 6.0);
-						strReturn = dblReturn.ToString();
+						int intA = (3 * Convert.ToInt32(_strA, GlobalOptions.Instance.CultureInfo) + 1) / 2;
+						strReturn = Math.Max(intA, 6).ToString();
 					}
 					else
 						strReturn = "0";

--- a/Chummer/Backend/Equipment/Commlink.cs
+++ b/Chummer/Backend/Equipment/Commlink.cs
@@ -234,9 +234,7 @@ namespace Chummer.Backend.Equipment
 				// Adjust the stat to include the A.I.'s Home Node bonus.
 				if (_blnHomeNode)
 				{
-					decimal decBonus = Math.Ceiling(_objCharacter.CHA.TotalValue / 2m);
-					int intBonus = Convert.ToInt32(decBonus, GlobalOptions.Instance.CultureInfo);
-					intDeviceRating += intBonus;
+					intDeviceRating += (_objCharacter.CHA.TotalValue + 1) / 2;
 				}
 
 				return intDeviceRating;

--- a/Chummer/Backend/Equipment/Gear.cs
+++ b/Chummer/Backend/Equipment/Gear.cs
@@ -561,7 +561,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("devicerating", _intDeviceRating.ToString());
             objWriter.WriteElementString("gearname", _strGearName);
             objWriter.WriteElementString("matrixcmfilled", _intMatrixCMFilled.ToString());
-            objWriter.WriteElementString("conditionmonitor", ConditionMonitor.ToString());
+            objWriter.WriteElementString("conditionmonitor", MatrixCM.ToString());
             objWriter.WriteElementString("includedinparent", _blnIncludedInParent.ToString());
             if (_intChildCostMultiplier != 1)
                 objWriter.WriteElementString("childcostmultiplier", _intChildCostMultiplier.ToString());
@@ -880,7 +880,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("armorcapacity", _strArmorCapacity);
             objWriter.WriteElementString("maxrating", _intMaxRating.ToString());
             objWriter.WriteElementString("rating", _intRating.ToString());
-            objWriter.WriteElementString("conditionmonitor", ConditionMonitor.ToString());
+            objWriter.WriteElementString("conditionmonitor", MatrixCM.ToString());
             objWriter.WriteElementString("qty", _intQty.ToString());
             objWriter.WriteElementString("avail", TotalAvail(true));
             objWriter.WriteElementString("avail_english", TotalAvail(true, true));
@@ -2372,11 +2372,7 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				string strReturn = _strName;
-				if (_strAltName != string.Empty)
-					strReturn = _strAltName;
-
-				return strReturn;
+				return (_strAltName == string.Empty ? _strName : _strAltName);
 			}
 		}
 
@@ -2414,7 +2410,7 @@ namespace Chummer.Backend.Equipment
 				return "";
 			else
 			{
-				string strReturn = "";
+				string strReturn = "0";
 				// Use the damagereplace value if applicable.
 				if (_nodWeaponBonus["damagereplace"] != null)
 					strReturn = _nodWeaponBonus["damagereplace"].InnerText;
@@ -2423,8 +2419,6 @@ namespace Chummer.Backend.Equipment
 					// Use the damage bonus if available, otherwise use 0.
 					if (_nodWeaponBonus["damage"] != null)
 						strReturn = _nodWeaponBonus["damage"].InnerText;
-					else
-						strReturn = "0";
 
 					// Attach the type if applicable.
 					if (_nodWeaponBonus["damagetype"] != null)
@@ -2457,21 +2451,18 @@ namespace Chummer.Backend.Equipment
 					return "";
 				else
 				{
-					string strReturn = "";
+					string strReturn = "0";
 					// Use the apreplace value if applicable.
 					if (_nodWeaponBonus["apreplace"] != null)
 						strReturn = _nodWeaponBonus["apreplace"].InnerText;
-					else
-					{
-						// Use the ap bonus if available, otherwise use 0.
-						if (_nodWeaponBonus["ap"] != null)
-							strReturn = _nodWeaponBonus["ap"].InnerText;
-						else
-							strReturn = "0";
+                    // Use the ap bonus if available, otherwise use 0.
+                    else if (_nodWeaponBonus["ap"] != null)
+                    {
+                        strReturn = _nodWeaponBonus["ap"].InnerText;
 
-						// If this does not start with "-", add a "+" to the string.
-						if (!strReturn.StartsWith("-"))
-							strReturn = "+" + strReturn;
+                        // If this does not start with "-", add a "+" to the string.
+                        if (!strReturn.StartsWith("-"))
+                            strReturn = "+" + strReturn;	
 					}
 
 					return strReturn;
@@ -2486,17 +2477,10 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				if (_nodWeaponBonus == null)
-					return 0;
-				else
-				{
-					int intReturn = 0;
-
-					if (_nodWeaponBonus["rangebonus"] != null)
-						intReturn = Convert.ToInt32(_nodWeaponBonus["rangebonus"].InnerText);
-
-					return intReturn;
-				}
+                if (_nodWeaponBonus?["rangebonus"] != null)
+                    return Convert.ToInt32(_nodWeaponBonus["rangebonus"].InnerText);
+                else
+                    return 0;
 			}
 		}
 
@@ -2508,19 +2492,18 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				int baseMatrixBoxes = 8;
-				return baseMatrixBoxes;
+				return 8;
 			}
 		}
 
 		/// <summary>
-		/// Physical Condition Monitor boxes.
+		/// Matrix Condition Monitor boxes.
 		/// </summary>
 		public int MatrixCM
 		{
 			get
 			{
-				return BaseMatrixBoxes + Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_intDeviceRating, GlobalOptions.Instance.CultureInfo) / 2.0));
+				return BaseMatrixBoxes + (_intDeviceRating + 1) / 2;
 			}
 		}
 
@@ -2536,19 +2519,6 @@ namespace Chummer.Backend.Equipment
 			set
 			{
 				_intMatrixCMFilled = value;
-			}
-		}
-
-		/// <summary>
-		/// Matrix Condition Monitor for the Commlink.
-		/// </summary>
-		public int ConditionMonitor
-		{
-			get
-			{
-				double dblSystem = Math.Ceiling(Convert.ToDouble(DeviceRating, GlobalOptions.Instance.CultureInfo) / 2);
-				int intSystem = Convert.ToInt32(dblSystem, GlobalOptions.Instance.CultureInfo);
-				return 8 + intSystem;
 			}
 		}
 		#endregion

--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -1660,13 +1660,9 @@ namespace Chummer.Backend.Equipment
 						else
 							intAmmo = Convert.ToInt32(strThisAmmo);
 
-						if (intAmmoBonus != 0)
-						{
-							double dblBonus = Convert.ToDouble(intAmmoBonus, GlobalOptions.Instance.CultureInfo) / 100.0;
-							intAmmo += Convert.ToInt32(Math.Ceiling(Convert.ToDouble(intAmmo, GlobalOptions.Instance.CultureInfo) * dblBonus));
-						}
+                        intAmmo += (intAmmo * intAmmoBonus + 99) / 100;
 
-						if (extendedMax > 0 && strAmmo.Contains("(c)"))
+                        if (extendedMax > 0 && strAmmo.Contains("(c)"))
 						{
 							//Multiply by 2-4 and divide by 2 to get 1, 1.5 or 2 times orginal result
 							intAmmo = (intAmmo*(2 + extendedMax))/2; 
@@ -2634,11 +2630,11 @@ namespace Chummer.Backend.Equipment
 		/// <summary>
 		/// Weapon's total Range bonus from Accessories.
 		/// </summary>
-		public double RangeBonus
+		public int RangeBonus
 		{
 			get
 			{
-				int intRangeBonus = 100;
+				int intRangeBonus = 0;
 
 				// Weapon Mods.
 				foreach (WeaponAccessory objAccessory in _lstAccessories)
@@ -2665,10 +2661,7 @@ namespace Chummer.Backend.Equipment
 					}
 				}
 
-				double dblRangeBonus = Convert.ToDouble(intRangeBonus, GlobalOptions.Instance.CultureInfo);
-				dblRangeBonus /= 100;
-
-				return dblRangeBonus;
+				return intRangeBonus;
 			}
 		}
 
@@ -2679,14 +2672,9 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				int intMin = Range("min");
-				int intMax = Range("short");
-				double dblRangeBonus = RangeBonus;
-
-				double dblMin = Convert.ToDouble(intMin, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				double dblMax = Convert.ToDouble(intMax, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				intMin = Convert.ToInt32(Math.Ceiling(dblMin));
-				intMax = Convert.ToInt32(Math.Ceiling(dblMax));
+                int intRangeBonus = RangeBonus;
+                int intMin = (Range("min") * (100 + intRangeBonus) + 99) / 100;
+				int intMax = (Range("short") * (100 + intRangeBonus) + 99) / 100;
 
 				if (intMin == -1 && intMax == -1)
 					return "";
@@ -2702,14 +2690,9 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				int intMin = Range("short");
-				int intMax = Range("medium");
-				double dblRangeBonus = RangeBonus;
-
-				double dblMin = Convert.ToDouble(intMin, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				double dblMax = Convert.ToDouble(intMax, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				intMin = Convert.ToInt32(Math.Ceiling(dblMin));
-				intMax = Convert.ToInt32(Math.Ceiling(dblMax));
+                int intRangeBonus = RangeBonus;
+                int intMin = (Range("short") * (100 + intRangeBonus) + 99) / 100;
+                int intMax = (Range("medium") * (100 + intRangeBonus) + 99) / 100;
 
 				if (intMin == -1 && intMax == -1)
 					return "";
@@ -2725,15 +2708,10 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				int intMin = Range("medium");
-				int intMax = Range("long");
-				double dblRangeBonus = RangeBonus;
-
-				double dblMin = Convert.ToDouble(intMin, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				double dblMax = Convert.ToDouble(intMax, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				intMin = Convert.ToInt32(Math.Ceiling(dblMin));
-				intMax = Convert.ToInt32(Math.Ceiling(dblMax));
-
+                int intRangeBonus = RangeBonus;
+                int intMin = (Range("medium") * (100 + intRangeBonus) + 99) / 100;
+                int intMax = (Range("long") * (100 + intRangeBonus) + 99) / 100;
+                
 				if (intMin == -1 && intMax == -1)
 					return "";
 				else
@@ -2748,14 +2726,9 @@ namespace Chummer.Backend.Equipment
 		{
 			get
 			{
-				int intMin = Range("long");
-				int intMax = Range("extreme");
-				double dblRangeBonus = RangeBonus;
-
-				double dblMin = Convert.ToDouble(intMin, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				double dblMax = Convert.ToDouble(intMax, GlobalOptions.Instance.CultureInfo) * dblRangeBonus;
-				intMin = Convert.ToInt32(Math.Ceiling(dblMin));
-				intMax = Convert.ToInt32(Math.Ceiling(dblMax));
+                int intRangeBonus = RangeBonus;
+                int intMin = (Range("long") * (100 + intRangeBonus) + 99) / 100;
+                int intMax = (Range("extreme") * (100 + intRangeBonus) + 99) / 100;
 
 				if (intMin == -1 && intMax == -1)
 					return "";

--- a/Chummer/Backend/Shared Methods/CharacterShared.cs
+++ b/Chummer/Backend/Shared Methods/CharacterShared.cs
@@ -164,20 +164,20 @@ namespace Chummer
 			ImprovementManager _objImprovementManager)
 		{
 			// Condition Monitor.
-			double dblBOD = _objCharacter.BOD.TotalValue;
-			double dblWIL = _objCharacter.WIL.TotalValue;
+			int intBOD = _objCharacter.BOD.TotalValue;
+			int intWIL = _objCharacter.WIL.TotalValue;
 			int intCMPhysical = _objCharacter.PhysicalCM;
 			int intCMStun = _objCharacter.StunCM;
 
 			// Update the Condition Monitor labels.
 			lblPhysical.Text = intCMPhysical.ToString();
 			lblStun.Text = intCMStun.ToString();
-			string strCM = "8 + (BOD/2)(" + ((int) Math.Ceiling(dblBOD/2)).ToString() + ")";
+			string strCM = "8 + (BOD/2)(" + ((intBOD + 1)/2).ToString() + ")";
 			if (_objImprovementManager.ValueOf(Improvement.ImprovementType.PhysicalCM) != 0)
 				strCM += " + " + LanguageManager.Instance.GetString("Tip_Modifiers") + " (" +
 				         _objImprovementManager.ValueOf(Improvement.ImprovementType.PhysicalCM).ToString() + ")";
 			tipTooltip.SetToolTip(lblPhysical, strCM);
-			strCM = "8 + (WIL/2)(" + ((int) Math.Ceiling(dblWIL/2)).ToString() + ")";
+			strCM = "8 + (WIL/2)(" + ((intWIL + 1) / 2).ToString() + ")";
 			if (_objImprovementManager.ValueOf(Improvement.ImprovementType.StunCM) != 0)
 				strCM += " + " + LanguageManager.Instance.GetString("Tip_Modifiers") + " (" +
 				         _objImprovementManager.ValueOf(Improvement.ImprovementType.StunCM).ToString() + ")";

--- a/Chummer/Backend/Skills/Skill.core.cs
+++ b/Chummer/Backend/Skills/Skill.core.cs
@@ -306,6 +306,11 @@ namespace Chummer.Skills
 						if (objImprovement.ImprovedName == SkillGroup)
 							yield return objImprovement;
 						break;
+                    case Improvement.ImprovementType.SwapSkillAttribute:
+                    case Improvement.ImprovementType.SwapSkillSpecAttribute:
+                        if (objImprovement.Target == Name)
+                            yield return objImprovement;
+                        break;
 					case Improvement.ImprovementType.EnhancedArticulation:
 						if (Category == "Physical Active" && CharacterAttrib.PhysicalAttributes.Contains(AttributeObject.Abbrev))
 							yield return objImprovement;

--- a/Chummer/Backend/Skills/Skill.cs
+++ b/Chummer/Backend/Skills/Skill.cs
@@ -628,7 +628,7 @@ namespace Chummer.Skills
 
 				}
 
-				foreach (Improvement source in RelevantImprovements().Where(x => !x.AddToRating))
+				foreach (Improvement source in RelevantImprovements().Where(x => !x.AddToRating && x.ImproveType != Improvement.ImprovementType.SwapSkillAttribute && x.ImproveType != Improvement.ImprovementType.SwapSkillSpecAttribute))
 				{
 					s.Append(" + ");
 					s.Append(GetName(source));
@@ -667,6 +667,97 @@ namespace Chummer.Skills
 						}
 					}
 				}
+
+                foreach(Improvement objSwapSkillAttribute in RelevantImprovements().Where(x => x.ImproveType == Improvement.ImprovementType.SwapSkillAttribute || x.ImproveType == Improvement.ImprovementType.SwapSkillSpecAttribute))
+                {
+                    s.Append("\n");
+                    if (objSwapSkillAttribute.ImproveType == Improvement.ImprovementType.SwapSkillSpecAttribute)
+                        s.AppendFormat("{0}: ", objSwapSkillAttribute.Exclude);
+                    s.AppendFormat("{0} ", GetName(objSwapSkillAttribute));
+
+                    int intLoopAttribute = 0;
+                    switch (objSwapSkillAttribute.ImprovedName)
+                    {
+                        case "AGI":
+                            intLoopAttribute = CharacterObject.AGI.Value;
+                            break;
+                        case "STR":
+                            intLoopAttribute = CharacterObject.STR.Value;
+                            break;
+                        case "REA":
+                            intLoopAttribute = CharacterObject.REA.Value;
+                            break;
+                        case "CHA":
+                            intLoopAttribute = CharacterObject.CHA.Value;
+                            break;
+                        case "INT":
+                            intLoopAttribute = CharacterObject.INT.Value;
+                            break;
+                        case "LOG":
+                            intLoopAttribute = CharacterObject.LOG.Value;
+                            break;
+                        case "WIL":
+                            intLoopAttribute = CharacterObject.WIL.Value;
+                            break;
+                        case "EDG":
+                            intLoopAttribute = CharacterObject.EDG.Value;
+                            break;
+                        case "MAG":
+                            intLoopAttribute = CharacterObject.MAG.Value;
+                            break;
+                        case "RES":
+                            intLoopAttribute = CharacterObject.RES.Value;
+                            break;
+                        case "DEP":
+                            intLoopAttribute = CharacterObject.DEP.Value;
+                            break;
+                        case "BOD":
+                        default:
+                            intLoopAttribute = CharacterObject.BOD.Value;
+                            break;
+                    }
+                    int intBasePool = PoolOtherAttribute(intLoopAttribute);
+                    bool blnHaveSpec = false;
+
+                    if (objSwapSkillAttribute.ImproveType == Improvement.ImprovementType.SwapSkillSpecAttribute && 
+                        Specializations.Where(y => y.Name == objSwapSkillAttribute.Exclude).Any())
+                    {
+                        intBasePool += 2;
+                        blnHaveSpec = true;
+                    }
+                    s.Append(intBasePool);
+
+                    if (objSwapSkillAttribute.ImprovedName == "STR" || objSwapSkillAttribute.ImprovedName == "AGI")
+                    {
+                        foreach (Cyberware cyberware in _character.Cyberware.Where(x => x.Name.Contains(" Arm") || x.Name.Contains(" Hand")))
+                        {
+                            s.Append("\n");
+                            if (objSwapSkillAttribute.ImproveType == Improvement.ImprovementType.SwapSkillSpecAttribute)
+                                s.AppendFormat("{0}: ", objSwapSkillAttribute.Exclude);
+                            s.AppendFormat("{0} ", GetName(objSwapSkillAttribute));
+                            s.AppendFormat("{0} {1} ", cyberware.Location, cyberware.DisplayNameShort);
+                            if (cyberware.Grade != GlobalOptions.CyberwareGrades.GetGrade("Standard"))
+                            {
+                                s.AppendFormat("({0}) ", cyberware.Grade.DisplayName);
+                            }
+
+                            int intLoopPool = PoolOtherAttribute(Attribute == "STR" ? cyberware.TotalStrength : cyberware.TotalAgility);
+                            if (blnHaveSpec)
+                            {
+                                intLoopPool += 2;
+                            }
+
+                            if (cyberware.Location == CharacterObject.PrimaryArm || CharacterObject.Ambidextrous || cyberware.LimbSlotCount == 2)
+                            {
+                                s.Append(intLoopPool);
+                            }
+                            else
+                            {
+                                s.AppendFormat("{0} (-2 Off Hand)", intLoopPool - 2);
+                            }
+                        }
+                    }
+                }
 
 				return s.ToString();
 			}

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -1974,18 +1974,18 @@ namespace Chummer
             mnuSpecialToxicCritter.Visible = true;
 
             // Update the Critter's CharacterAttribute maximums to 1.5X their current value (or 1, whichever is higher).
-            _objCharacter.BOD.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.BOD.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.AGI.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.AGI.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.REA.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.REA.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.STR.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.STR.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.CHA.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.CHA.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.INT.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.INT.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.LOG.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.LOG.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.WIL.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.WIL.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.EDG.MetatypeMaximum = Math.Max(1, Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.EDG.Value, GlobalOptions.Instance.CultureInfo) * 1.5)));
-            _objCharacter.MAG.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.MAG.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
-            _objCharacter.RES.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.RES.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
-            _objCharacter.DEP.MetatypeMaximum = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(_objCharacter.DEP.Value, GlobalOptions.Instance.CultureInfo) * 1.5));
+            _objCharacter.BOD.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.BOD.Value + 1) / 2);
+            _objCharacter.AGI.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.AGI.Value + 1) / 2);
+            _objCharacter.REA.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.REA.Value + 1) / 2);
+            _objCharacter.STR.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.STR.Value + 1) / 2);
+            _objCharacter.CHA.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.CHA.Value + 1) / 2);
+            _objCharacter.INT.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.INT.Value + 1) / 2);
+            _objCharacter.LOG.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.LOG.Value + 1) / 2);
+            _objCharacter.WIL.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.WIL.Value + 1) / 2);
+            _objCharacter.EDG.MetatypeMaximum = Math.Max(1, (3 * _objCharacter.EDG.Value + 1) / 2);
+            _objCharacter.MAG.MetatypeMaximum = (3 * _objCharacter.MAG.Value + 1) / 2;
+            _objCharacter.RES.MetatypeMaximum = (3 * _objCharacter.RES.Value + 1) / 2;
+            _objCharacter.DEP.MetatypeMaximum = (3 * _objCharacter.DEP.Value + 1) / 2;
 
             _objCharacter.BOD.MetatypeMinimum = _objCharacter.BOD.Value;
             _objCharacter.AGI.MetatypeMinimum = _objCharacter.AGI.Value;
@@ -4604,10 +4604,9 @@ namespace Chummer
             {
 					if (objPowerControl.PowerObject.Name == "Improved Ability (skill)" && (objPowerControl.PowerObject.Extra == objSkill.Name || (objSkill.IsExoticSkill && objPowerControl.PowerObject.Extra == (objSkill.DisplayName + " (" + objSkill.Specialization + ")"))))
                     {
-                        double intImprovedAbilityMaximum = objSkill.Rating + (objSkill.Rating / 2);
-                        intImprovedAbilityMaximum = Convert.ToInt32(Math.Ceiling(intImprovedAbilityMaximum));
-						objPowerControl.PowerObject.MaxLevels = Convert.ToInt32(Math.Ceiling(intImprovedAbilityMaximum));
-                        objPowerControl.nudRating.Maximum = Convert.ToInt32(Math.Ceiling(intImprovedAbilityMaximum));
+                        int intImprovedAbilityMaximum = (3 * objSkill.Rating + 1) / 2;
+						objPowerControl.PowerObject.MaxLevels = intImprovedAbilityMaximum;
+                        objPowerControl.nudRating.Maximum = intImprovedAbilityMaximum;
                     }
             }
 			}
@@ -15495,11 +15494,6 @@ namespace Chummer
                     if (_objCharacter.DEPEnabled)
                         intMainAttribute = _objCharacter.DEP.TotalValue;
                     string strPersonaTip = "";
-                    int intFirewall = _objCharacter.WIL.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaFirewall);
-                    int intResponse = _objCharacter.INT.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaResponse);
-                    int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(intMainAttribute, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
-                    int intSystem = _objCharacter.LOG.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSystem);
-                    int intBiofeedback = _objCharacter.CHA.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaBiofeedback);
 
                     lblLivingPersonaDeviceRating.Text = intMainAttribute.ToString();
                     strPersonaTip = "RES (" + intMainAttribute.ToString() + ")";
@@ -15677,7 +15671,7 @@ namespace Chummer
 					intAttributeDiff += (_objCharacter.DEP.Value - _objCharacter.DEP.MetatypeMinimum);
 
 					// -1 Essence for every 2 points spent on Attributes.
-					intEssencePenalty += Convert.ToInt32(Math.Ceiling(Convert.ToDouble(intAttributeDiff, GlobalOptions.Instance.CultureInfo) / 2));
+					intEssencePenalty += (intAttributeDiff + 1) / 2;
 
                     // Run through the Qualities the Critter has and add up their Mutant Points.
                     foreach (Quality objQuality in _objCharacter.Qualities)
@@ -15701,7 +15695,7 @@ namespace Chummer
                         intSkillPoints = 0;
 
                     // Every 2 points causes another point of Essence loss.
-                    intEssencePenalty += Convert.ToInt32(Math.Ceiling(Convert.ToDouble(intSkillPoints, GlobalOptions.Instance.CultureInfo) / 2));
+                    intEssencePenalty += (intSkillPoints + 1) / 2;
 
                     intEssencePenalty += intQualityPoints;
 
@@ -15709,7 +15703,7 @@ namespace Chummer
                     if (intEssencePenalty > _objCharacter.ESS.MetatypeMaximum - 1)
                         intEssencePenalty = _objCharacter.ESS.MetatypeMaximum - 1;
                     // INT is reduced for every 2 points of ESS lost to a minimum of 1.
-                    intIntuitionPenalty = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(intEssencePenalty, GlobalOptions.Instance.CultureInfo) / 2));
+                    intIntuitionPenalty = (intEssencePenalty + 1) / 2;
                     if (_objCharacter.INT.TotalValue - intIntuitionPenalty < 1)
                         intIntuitionPenalty = _objCharacter.INT.TotalValue - 1;
 
@@ -21520,8 +21514,9 @@ namespace Chummer
 		{
 			double dblMultiplier = 1.0;
 			int intAmount = 0;
+            string strInitTip = "";
 
-			if (_objCharacter.MAGEnabled)
+            if (_objCharacter.MAGEnabled)
 			{
 				if (chkInitiationGroup.Checked)
 					dblMultiplier -= 0.1;
@@ -21530,8 +21525,10 @@ namespace Chummer
 				if (chkInitiationSchooling.Checked)
 					dblMultiplier -= 0.1;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
-				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble((10 + ((_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
-			}
+				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble(10 + (_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+
+                strInitTip = LanguageManager.Instance.GetString("Tip_ImproveInitiateGrade").Replace("{0}", (_objCharacter.InitiateGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
+            }
 			else
 			{
 				if (chkInitiationGroup.Checked)
@@ -21541,14 +21538,10 @@ namespace Chummer
 				if (chkInitiationSchooling.Checked)
 					dblMultiplier -= 0.1;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
-				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble((10 + ((_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
-			}
+				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble(10 + (_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
-			string strInitTip = "";
-			if (_objCharacter.MAGEnabled)
-				strInitTip = LanguageManager.Instance.GetString("Tip_ImproveInitiateGrade").Replace("{0}", (_objCharacter.InitiateGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
-			else
-				strInitTip = LanguageManager.Instance.GetString("Tip_ImproveSubmersionGrade").Replace("{0}", (_objCharacter.SubmersionGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
+                strInitTip = LanguageManager.Instance.GetString("Tip_ImproveSubmersionGrade").Replace("{0}", (_objCharacter.SubmersionGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
+            }
 
 			tipTooltip.SetToolTip(cmdAddMetamagic, strInitTip);
 		}

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -14302,23 +14302,26 @@ namespace Chummer
                 nudDEP.Value = _objCharacter.DEP.Base;
             }
 
-			// Metatypes cost Karma.
-            if (_objCharacter.BuildMethod == CharacterBuildMethod.Karma)
+            // Metatypes cost Karma.
+            if (_objOptions.MetatypeCostsKarma)
             {
-                lblKarmaMetatypeBP.Text = (_objCharacter.MetatypeBP).ToString() + " " +
-                                          LanguageManager.Instance.GetString("String_Karma");              
+                lblKarmaMetatypeBP.Text = (_objCharacter.MetatypeBP * _objOptions.MetatypeCostsKarmaMultiplier).ToString() + " " +
+                                          LanguageManager.Instance.GetString("String_Karma");
             }
             else
+            {
                 lblKarmaMetatypeBP.Text = "0 " + LanguageManager.Instance.GetString("String_Karma");
+            }
+            lblMetatypeBP.Text = lblKarmaMetatypeBP.Text;
 
             string strToolTip = _objCharacter.Metatype;
             if (_objCharacter.Metavariant != "")
             {
                 strToolTip += " (" + _objCharacter.Metavariant + ")";
-                strToolTip += " (" + _objCharacter.MetatypeBP.ToString() + ")";
-                tipTooltip.SetToolTip(lblKarmaMetatypeBP, strToolTip);
-                lblMetatypeBP.Text = (_objCharacter.MetatypeBP).ToString() + " " + LanguageManager.Instance.GetString("String_Karma");
             }
+            strToolTip += " (" + _objCharacter.MetatypeBP.ToString() + ")";
+            tipTooltip.SetToolTip(lblKarmaMetatypeBP, strToolTip);
+            
             _blnSkipUpdate = false;
 
             UpdateCharacterInfo();
@@ -21637,7 +21640,8 @@ namespace Chummer
             int intLOG = _objCharacter.LOG.Base - _objCharacter.LOG.MetatypeMinimum;
             int intWIL = _objCharacter.WIL.Base - _objCharacter.WIL.MetatypeMinimum;
             int intEDG = _objCharacter.EDG.Base - _objCharacter.EDG.MetatypeMinimum;
-	        int intMAG = Math.Max(_objCharacter.MAG.Base - _objCharacter.MAG.MetatypeMinimum, 0);
+            int intDEP = _objCharacter.DEP.Base - _objCharacter.DEP.MetatypeMinimum;
+            int intMAG = Math.Max(_objCharacter.MAG.Base - _objCharacter.MAG.MetatypeMinimum, 0);
 	        int intRES = Math.Max(_objCharacter.RES.Base - _objCharacter.RES.MetatypeMinimum, 0);
 
             // Build a list of the current Metatype's Improvements to remove if the Metatype changes.
@@ -21702,6 +21706,7 @@ namespace Chummer
             nudLOG.Maximum = _objCharacter.LOG.TotalMaximum;
             nudWIL.Maximum = _objCharacter.WIL.TotalMaximum;
             nudEDG.Maximum = _objCharacter.EDG.TotalMaximum;
+            nudDEP.Maximum = _objCharacter.DEP.TotalMaximum;
             if (_objCharacter.BuildMethod == CharacterBuildMethod.Karma)
             {
                 nudKMAG.Maximum = _objCharacter.MAG.TotalMaximum + intEssenceLoss;
@@ -21719,6 +21724,7 @@ namespace Chummer
             nudLOG.Minimum = _objCharacter.LOG.MetatypeMinimum;
             nudWIL.Minimum = _objCharacter.WIL.MetatypeMinimum;
             nudEDG.Minimum = _objCharacter.EDG.MetatypeMinimum;
+            nudDEP.Minimum = _objCharacter.DEP.MetatypeMinimum;
             nudMAG.Minimum = _objCharacter.MAG.MetatypeMinimum;
             nudRES.Minimum = _objCharacter.RES.MetatypeMinimum;
 
@@ -21731,6 +21737,7 @@ namespace Chummer
             _objCharacter.LOG.Value = _objCharacter.LOG.MetatypeMinimum + intLOG;
             _objCharacter.WIL.Value = _objCharacter.WIL.MetatypeMinimum + intWIL;
             _objCharacter.EDG.Value = _objCharacter.EDG.MetatypeMinimum + intEDG;
+            _objCharacter.DEP.Value = _objCharacter.DEP.MetatypeMinimum + intDEP;
             _objCharacter.MAG.Value = _objCharacter.MAG.MetatypeMinimum + intMAG;
             _objCharacter.RES.Value = _objCharacter.RES.MetatypeMinimum + intRES;
 
@@ -21743,6 +21750,7 @@ namespace Chummer
             nudLOG.Value = _objCharacter.LOG.Value;
             nudWIL.Value = _objCharacter.WIL.Value;
             nudEDG.Value = _objCharacter.EDG.Value;
+            nudDEP.Value = _objCharacter.DEP.Value;
             if (_objCharacter.MAG.Value < 1)
             {
                 if (nudMAG.Maximum < 1)
@@ -21810,11 +21818,16 @@ namespace Chummer
             tipTooltip.SetToolTip(lblMetatypeSource, _objOptions.LanguageBookLong(objMetatypeNode["source"].InnerText) + " " + LanguageManager.Instance.GetString("String_Page") + " " + strPage);
 
             // If we're working with Karma, the Metatype doesn't cost anything.
-            if (_objCharacter.BuildMethod == CharacterBuildMethod.Karma && _objOptions.MetatypeCostsKarma)
-                lblKarmaMetatypeBP.Text = (_objCharacter.MetatypeBP * _objOptions.MetatypeCostsKarmaMultiplier).ToString() + " " + LanguageManager.Instance.GetString("String_Karma");
+            if (_objOptions.MetatypeCostsKarma)
+            {
+                lblKarmaMetatypeBP.Text = (_objCharacter.MetatypeBP * _objOptions.MetatypeCostsKarmaMultiplier).ToString() + " " +
+                                          LanguageManager.Instance.GetString("String_Karma");
+            }
             else
+            {
                 lblKarmaMetatypeBP.Text = "0 " + LanguageManager.Instance.GetString("String_Karma");
-            lblMetatypeBP.Text = "0 " + LanguageManager.Instance.GetString("String_Karma");
+            }
+            lblMetatypeBP.Text = lblKarmaMetatypeBP.Text;
 
             string strToolTip = _objCharacter.Metatype;
             if (_objCharacter.Metavariant != "")

--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -39,8 +39,9 @@ namespace Chummer.Classes
 		public string ForcedValue;
 		public string LimitSelection;
 		public string SelectedValue;
+        public string SelectedTarget = "";
 
-		private readonly Improvement.ImprovementSource _objImprovementSource;
+        private readonly Improvement.ImprovementSource _objImprovementSource;
 		private readonly string _strUnique;
 		private readonly bool _blnConcatSelectedValue;
 		private readonly string _strFriendlyName;
@@ -55,12 +56,12 @@ namespace Chummer.Classes
 		private void CreateImprovement(string strImprovedName, Improvement.ImprovementSource objImprovementSource,
 			string strSourceName, Improvement.ImprovementType objImprovementType, string strUnique,
 			int intValue = 0, int intRating = 1, int intMinimum = 0, int intMaximum = 0, int intAugmented = 0,
-			int intAugmentedMaximum = 0, string strExclude = "", bool blnAddToRating = false)
+			int intAugmentedMaximum = 0, string strExclude = "", bool blnAddToRating = false, string strTarget = "")
 		{
 			_manager.CreateImprovement(strImprovedName, objImprovementSource,
 				strSourceName, objImprovementType, strUnique,
 				intValue, intRating, intMinimum, intMaximum, intAugmented,
-				intAugmentedMaximum, strExclude, blnAddToRating);
+				intAugmentedMaximum, strExclude, blnAddToRating, strTarget);
 		}
 		private bool CreateImprovements(Improvement.ImprovementSource objImprovementSource, string strSourceName,
 			XmlNode nodBonus, bool blnConcatSelectedValue = false, int intRating = 1, string strFriendlyName = "")
@@ -780,69 +781,212 @@ namespace Chummer.Classes
 		public void swapskillattribute(XmlNode bonusNode)
 		{
 			Log.Info("swapskillattribute");
-			// Display the Select Attribute window and record which Skill was selected.
-			frmSelectAttribute frmPickAttribute = new frmSelectAttribute();
-			if (_strFriendlyName != "")
-				frmPickAttribute.Description =
-					LanguageManager.Instance.GetString("String_Improvement_SelectAttributeNamed").Replace("{0}", _strFriendlyName);
-			else
-				frmPickAttribute.Description = LanguageManager.Instance.GetString("String_Improvement_SelectAttribute");
-
-			List<string> strValue = new List<string>();
-			strValue.Add("LOG");
-			strValue.Add("WIL");
-			strValue.Add("INT");
-			strValue.Add("CHA");
-			strValue.Add("EDG");
-			strValue.Add("MAG");
-			strValue.Add("RES");
-			frmPickAttribute.RemoveFromList(strValue);
+            List<string> strLimitValue = new List<string>();
+            if (bonusNode.InnerXml.Contains("<attribute>"))
+            {
+                foreach (XmlNode objXmlAttribute in bonusNode.SelectNodes("attribute"))
+                    strLimitValue.Add(objXmlAttribute.InnerText);
+            }
+            if (strLimitValue.Count == 1)
+                LimitSelection = strLimitValue.First();
 
 			Log.Info("swapskillattribute = " + bonusNode.OuterXml.ToString());
 
-			if (bonusNode.InnerXml.Contains("<attribute>"))
-			{
-				List<string> strLimitValue = new List<string>();
-				foreach (XmlNode objXmlAttribute in bonusNode.SelectNodes("attribute"))
-					strLimitValue.Add(objXmlAttribute.InnerText);
-				frmPickAttribute.LimitToList(strLimitValue);
-			}
-
-			// Check to see if there is only one possible selection because of _strLimitSelection.
-			if (ForcedValue != "")
+            // Check to see if there is only one possible selection because of _strLimitSelection.
+            if (ForcedValue != "")
 				LimitSelection = ForcedValue;
 
 			Log.Info("_strForcedValue = " + ForcedValue);
 			Log.Info("_strLimitSelection = " + LimitSelection);
 
 			if (LimitSelection != "")
+            {
+                SelectedValue = LimitSelection;
+            }
+            else
 			{
-				frmPickAttribute.SingleAttribute(LimitSelection);
-				frmPickAttribute.Opacity = 0;
-			}
+                // Display the Select Attribute window and record which Skill was selected.
+                frmSelectAttribute frmPickAttribute = new frmSelectAttribute();
+                if (_strFriendlyName != "")
+                    frmPickAttribute.Description =
+                        LanguageManager.Instance.GetString("String_Improvement_SelectAttributeNamed").Replace("{0}", _strFriendlyName);
+                else
+                    frmPickAttribute.Description = LanguageManager.Instance.GetString("String_Improvement_SelectAttribute");
 
-			frmPickAttribute.ShowDialog();
+                if (strLimitValue.Count > 0)
+                    frmPickAttribute.LimitToList(strLimitValue);
 
-			// Make sure the dialogue window was not canceled.
-			if (frmPickAttribute.DialogResult == DialogResult.Cancel)
-			{
-				throw new AbortedException();
-			}
+                frmPickAttribute.ShowDialog();
 
-			SelectedValue = frmPickAttribute.SelectedAttribute;
-			if (_blnConcatSelectedValue)
-				SourceName += " (" + SelectedValue + ")";
+                // Make sure the dialogue window was not canceled.
+                if (frmPickAttribute.DialogResult == DialogResult.Cancel)
+                {
+                    throw new AbortedException();
+                }
+
+                SelectedValue = frmPickAttribute.SelectedAttribute;
+
+                if (_blnConcatSelectedValue)
+                    SourceName += " (" + SelectedValue + ")";
+            }
+
+            strLimitValue.Clear();
+            if (bonusNode.InnerXml.Contains("<limittoskill>"))
+            {
+                SelectedTarget = bonusNode.SelectSingleNode("limittoskill").InnerText;
+            }
+            else
+            {
+                // Display the Select Attribute window and record which Skill was selected.
+                frmSelectSkill frmPickSkill = new frmSelectSkill(_objCharacter);
+                if (_strFriendlyName != "")
+                    frmPickSkill.Description = LanguageManager.Instance.GetString("String_Improvement_SelectSkillNamed")
+                        .Replace("{0}", _strFriendlyName);
+                else
+                    frmPickSkill.Description = LanguageManager.Instance.GetString("String_Improvement_SelectSkill");
+
+                if (bonusNode.OuterXml.Contains("<skillgroup>"))
+                    frmPickSkill.OnlySkillGroup = bonusNode.SelectSingleNode("skillgroup").InnerText;
+                else if (bonusNode.OuterXml.Contains("<skillcategory>"))
+                    frmPickSkill.OnlyCategory = bonusNode.SelectSingleNode("skillcategory").InnerText;
+                else if (bonusNode.OuterXml.Contains("<excludecategory>"))
+                    frmPickSkill.ExcludeCategory = bonusNode.SelectSingleNode("excludecategory").InnerText;
+                else if (bonusNode.OuterXml.Contains("<limittoattribute>"))
+                    frmPickSkill.LinkedAttribute = bonusNode.SelectSingleNode("limittoattribute").InnerText;
+
+                frmPickSkill.ShowDialog();
+
+                // Make sure the dialogue window was not canceled.
+                if (frmPickSkill.DialogResult == DialogResult.Cancel)
+                {
+                    throw new AbortedException();
+                }
+
+                SelectedTarget = frmPickSkill.SelectedSkill;
+
+                if (_blnConcatSelectedValue)
+                    SourceName += " (" + SelectedTarget + ")";
+            }
 
 			Log.Info("_strSelectedValue = " + SelectedValue);
 			Log.Info("SourceName = " + SourceName);
 
 			Log.Info("Calling CreateImprovement");
-			CreateImprovement(frmPickAttribute.SelectedAttribute, _objImprovementSource, SourceName,
-				Improvement.ImprovementType.SwapSkillAttribute, _strUnique);
+			CreateImprovement(SelectedValue, _objImprovementSource, SourceName, Improvement.ImprovementType.SwapSkillAttribute, _strUnique,
+                0, 1, 0, 0, 0, 0, "", false, SelectedTarget);
 		}
 
-		// Select a Spell.
-		public void selectspell(XmlNode bonusNode)
+        // Select an CharacterAttribute to use instead of the default on a skill.
+        public void swapskillspecattribute(XmlNode bonusNode)
+        {
+            Log.Info("swapskillspecattribute");
+            List<string> strLimitValue = new List<string>();
+            if (bonusNode.InnerXml.Contains("<attribute>"))
+            {
+                foreach (XmlNode objXmlAttribute in bonusNode.SelectNodes("attribute"))
+                    strLimitValue.Add(objXmlAttribute.InnerText);
+            }
+            if (strLimitValue.Count == 1)
+                LimitSelection = strLimitValue.First();
+
+            Log.Info("swapskillspecattribute = " + bonusNode.OuterXml.ToString());
+
+            // Check to see if there is only one possible selection because of _strLimitSelection.
+            if (ForcedValue != "")
+                LimitSelection = ForcedValue;
+
+            Log.Info("_strForcedValue = " + ForcedValue);
+            Log.Info("_strLimitSelection = " + LimitSelection);
+
+            if (LimitSelection != "")
+            {
+                SelectedValue = LimitSelection;
+            }
+            else
+            {
+                // Display the Select Attribute window and record which Skill was selected.
+                frmSelectAttribute frmPickAttribute = new frmSelectAttribute();
+                if (_strFriendlyName != "")
+                    frmPickAttribute.Description =
+                        LanguageManager.Instance.GetString("String_Improvement_SelectAttributeNamed").Replace("{0}", _strFriendlyName);
+                else
+                    frmPickAttribute.Description = LanguageManager.Instance.GetString("String_Improvement_SelectAttribute");
+
+                if (strLimitValue.Count > 0)
+                    frmPickAttribute.LimitToList(strLimitValue);
+
+                frmPickAttribute.ShowDialog();
+
+                // Make sure the dialogue window was not canceled.
+                if (frmPickAttribute.DialogResult == DialogResult.Cancel)
+                {
+                    throw new AbortedException();
+                }
+
+                SelectedValue = frmPickAttribute.SelectedAttribute;
+
+                if (_blnConcatSelectedValue)
+                    SourceName += " (" + SelectedValue + ")";
+            }
+
+            strLimitValue.Clear();
+            if (bonusNode.InnerXml.Contains("<limittoskill>"))
+            {
+                SelectedTarget = bonusNode.SelectSingleNode("limittoskill").InnerText;
+            }
+            else
+            {
+                // Display the Select Attribute window and record which Skill was selected.
+                frmSelectSkill frmPickSkill = new frmSelectSkill(_objCharacter);
+                if (_strFriendlyName != "")
+                    frmPickSkill.Description = LanguageManager.Instance.GetString("String_Improvement_SelectSkillNamed")
+                        .Replace("{0}", _strFriendlyName);
+                else
+                    frmPickSkill.Description = LanguageManager.Instance.GetString("String_Improvement_SelectSkill");
+
+                if (bonusNode.OuterXml.Contains("<skillgroup>"))
+                    frmPickSkill.OnlySkillGroup = bonusNode.SelectSingleNode("skillgroup").InnerText;
+                else if (bonusNode.OuterXml.Contains("<skillcategory>"))
+                    frmPickSkill.OnlyCategory = bonusNode.SelectSingleNode("skillcategory").InnerText;
+                else if (bonusNode.OuterXml.Contains("<excludecategory>"))
+                    frmPickSkill.ExcludeCategory = bonusNode.SelectSingleNode("excludecategory").InnerText;
+                else if (bonusNode.OuterXml.Contains("<limittoattribute>"))
+                    frmPickSkill.LinkedAttribute = bonusNode.SelectSingleNode("limittoattribute").InnerText;
+
+                frmPickSkill.ShowDialog();
+
+                // Make sure the dialogue window was not canceled.
+                if (frmPickSkill.DialogResult == DialogResult.Cancel)
+                {
+                    throw new AbortedException();
+                }
+
+                SelectedTarget = frmPickSkill.SelectedSkill;
+
+                if (_blnConcatSelectedValue)
+                    SourceName += " (" + SelectedTarget + ")";
+            }
+
+            // TODO: Allow selection of specializations through frmSelectSkillSpec
+            string strSpec = "";
+            try
+            {
+                strSpec = bonusNode["spec"].InnerText;
+            }
+            catch
+            {
+            }
+
+            Log.Info("_strSelectedValue = " + SelectedValue);
+            Log.Info("SourceName = " + SourceName);
+
+            Log.Info("Calling CreateImprovement");
+            CreateImprovement(SelectedValue, _objImprovementSource, SourceName, Improvement.ImprovementType.SwapSkillSpecAttribute, _strUnique,
+                0, 1, 0, 0, 0, 0, strSpec, false, SelectedTarget);
+        }
+
+        // Select a Spell.
+        public void selectspell(XmlNode bonusNode)
 		{
 			Log.Info("selectspell");
 			// Display the Select Spell window.

--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -3050,8 +3050,7 @@ namespace Chummer.Classes
 						else
 						{
 							// we have to adjust the number of free levels.
-							decimal decLevels = Convert.ToDecimal(_intRating) / 4;
-							decLevels = Math.Floor(decLevels / objExistingPower.PointsPerLevel);
+							decimal decLevels = Math.Floor(Convert.ToDecimal(_intRating) / 4.0m / objExistingPower.PointsPerLevel);
 							objExistingPower.FreeLevels += Convert.ToInt32(decLevels);
 							if (objExistingPower.Rating < _intRating)
 								objExistingPower.Rating = objExistingPower.FreeLevels;
@@ -3385,9 +3384,8 @@ namespace Chummer.Classes
 						}
 						else
 						{
-							decimal decLevels = Convert.ToDecimal(_intRating) / 4;
-							decLevels = Math.Floor(decLevels / objPower.PointsPerLevel);
-							objPower.FreeLevels += Convert.ToInt32(decLevels);
+                            decimal decLevels = Math.Floor(Convert.ToDecimal(_intRating) / 4.0m / objPower.PointsPerLevel);
+                            objPower.FreeLevels += Convert.ToInt32(decLevels);
 							objPower.Rating += Convert.ToInt32(decLevels);
 						}
 						objPower.BonusSource = SourceName;
@@ -3452,9 +3450,8 @@ namespace Chummer.Classes
 						}
 						else
 						{
-							decimal decLevels = Convert.ToDecimal(_intRating) / 4;
-							decLevels = Math.Floor(decLevels / objPower.PointsPerLevel);
-							objPower.FreeLevels += Convert.ToInt32(decLevels);
+                            decimal decLevels = Math.Floor(Convert.ToDecimal(_intRating) / 4.0m / objPower.PointsPerLevel);
+                            objPower.FreeLevels += Convert.ToInt32(decLevels);
 							if (objPower.Rating < _intRating)
 								objPower.Rating = objPower.FreeLevels;
 						}

--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -2565,17 +2565,6 @@ namespace Chummer
             // If the character is a Technomancer, write out the Living Persona "Commlink".
             if (_blnTechnomancerEnabled)
             {
-                int intFirewall = _attWIL.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaFirewall);
-                int intResponse = _attINT.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaResponse);
-                int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(_attRES.TotalValue, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
-                int intSystem = _attLOG.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSystem);
-
-                // Make sure none of the Attributes exceed the Technomancer's RES.
-                intFirewall = Math.Min(intFirewall, _attRES.TotalValue);
-                intResponse = Math.Min(intResponse, _attRES.TotalValue);
-                intSignal = Math.Min(intSignal, _attRES.TotalValue);
-                intSystem = Math.Min(intSystem, _attRES.TotalValue);
-
                 Commlink objLivingPersona = new Commlink(this);
                 objLivingPersona.Name = LanguageManager.Instance.GetString("String_LivingPersona");
                 objLivingPersona.Category = LanguageManager.Instance.GetString("String_Commlink");
@@ -4777,11 +4766,8 @@ namespace Chummer
         {
             get
             {
-                int intReturn = 0;
                 // Subtract the character's current Essence from its maximum. Round the remaining amount up to get the total penalty to MAG and RES.
-                intReturn = Convert.ToInt32(Math.Ceiling(EssenceAtSpecialStart + _objImprovementManager.ValueOf(Improvement.ImprovementType.EssenceMax) - Essence));
-
-                return intReturn;
+                return Convert.ToInt32(Math.Ceiling(EssenceAtSpecialStart + _objImprovementManager.ValueOf(Improvement.ImprovementType.EssenceMax) - Essence));
             }
         }
 
@@ -5083,45 +5069,6 @@ namespace Chummer
         }
 
         /// <summary>
-        /// An A.I.'s Rating.
-        /// </summary>
-        public int Rating
-        {
-            get
-            {
-                double dblAverage = Convert.ToDouble(_attCHA.TotalValue, GlobalOptions.Instance.CultureInfo) + Convert.ToDouble(_attINT.TotalValue, GlobalOptions.Instance.CultureInfo) + Convert.ToDouble(_attLOG.TotalValue, GlobalOptions.Instance.CultureInfo) + Convert.ToDouble(_attWIL.TotalValue, GlobalOptions.Instance.CultureInfo);
-                dblAverage = Math.Ceiling(dblAverage / 4);
-                return Convert.ToInt32(dblAverage);
-            }
-        }
-
-        /// <summary>
-        /// An A.I.'s System.
-        /// </summary>
-        public int System
-        {
-            get
-            {
-                double dblAverage = Convert.ToDouble(_attINT.TotalValue, GlobalOptions.Instance.CultureInfo) + Convert.ToDouble(_attLOG.TotalValue, GlobalOptions.Instance.CultureInfo);
-                dblAverage = Math.Ceiling(dblAverage / 2);
-                return Convert.ToInt32(dblAverage);
-            }
-        }
-
-        /// <summary>
-        /// An A.I.'s Firewall.
-        /// </summary>
-        public int Firewall
-        {
-            get
-            {
-                double dblAverage = Convert.ToDouble(_attCHA.TotalValue, GlobalOptions.Instance.CultureInfo) + Convert.ToDouble(_attWIL.TotalValue, GlobalOptions.Instance.CultureInfo);
-                dblAverage = Math.Ceiling(dblAverage / 2);
-                return Convert.ToInt32(dblAverage);
-            }
-        }
-
-        /// <summary>
         /// An A.I.'s Signal.
         /// </summary>
         public int Signal
@@ -5208,8 +5155,7 @@ namespace Chummer
             get
             {
 				// Street Cred = Career Karma / 10, rounded down
-				double dblReturn = Math.Floor(Convert.ToDouble(CareerKarma / 10));
-                int intReturn = Convert.ToInt32(dblReturn);
+                int intReturn = CareerKarma / 10;
 
 				// Deduct burnt Street Cred.
 				intReturn -= _intBurntStreetCred;
@@ -5325,9 +5271,7 @@ namespace Chummer
 				if (_objOptions.UseCalculatedPublicAwareness)
 				{
 					// Public Awareness is calculated as (Street Cred + Notoriety) / 3, rounded down.
-					double dblAwareness = Convert.ToDouble(TotalStreetCred, GlobalOptions.Instance.CultureInfo) + Convert.ToDouble(TotalNotoriety, GlobalOptions.Instance.CultureInfo);
-					dblAwareness = Math.Floor(dblAwareness / 3);
-					intReturn += Convert.ToInt32(dblAwareness);
+					intReturn = (TotalStreetCred + TotalNotoriety) / 3;
 				}
 
 				ImprovementManager manager = new ImprovementManager(this);
@@ -5907,17 +5851,15 @@ namespace Chummer
         {
             get
             {
-				int intCMPhysical = 0;
+				int intCMPhysical = 8;
 				if (_strMetatype.Contains("A.I.") || _strMetatypeCategory == "Protosapients")
 				{
 					// A.I.s add 1/2 their System to Physical CM since they do not have BOD.
-					double dblDEP = _attDEP.TotalValue;
-					intCMPhysical = (int)Math.Ceiling(dblDEP / 2) + 8;
+					intCMPhysical += (_attDEP.TotalValue + 1) / 2;
 				}
 				else
 				{
-					double dblBOD = _attBOD.TotalValue;
-					intCMPhysical = (int)Math.Ceiling(dblBOD / 2) + 8;
+					intCMPhysical += (_attBOD.TotalValue + 1) / 2;
 				}
                 // Include Improvements in the Condition Monitor values.
                 intCMPhysical += Convert.ToInt32(_objImprovementManager.ValueOf(Improvement.ImprovementType.PhysicalCM));
@@ -5932,14 +5874,13 @@ namespace Chummer
         {
             get
             {
-                double dblWIL = _attWIL.TotalValue;
-                int intCMStun = (int)Math.Ceiling(dblWIL / 2) + 8;
-                // Include Improvements in the Condition Monitor values.
-                intCMStun += Convert.ToInt32(_objImprovementManager.ValueOf(Improvement.ImprovementType.StunCM));
-                if (_strMetatype.Contains("A.I.") || _strMetatypeCategory == "Protosapients")
-                {
-                    // A.I. do not have a Stun Condition Monitor.
-                    intCMStun = 0;
+                int intCMStun = 0;
+                // A.I. do not have a Stun Condition Monitor.
+                if (!(_strMetatype.Contains("A.I.") || _strMetatypeCategory == "Protosapients"))
+                { 
+                    intCMStun = 8 + (_attWIL.TotalValue + 1) / 2;
+                    // Include Improvements in the Condition Monitor values.
+                    intCMStun += Convert.ToInt32(_objImprovementManager.ValueOf(Improvement.ImprovementType.StunCM));
                 }
                 return intCMStun;
             }
@@ -5952,8 +5893,7 @@ namespace Chummer
         {
             get
             {
-                int intCMThreshold = 0;
-                intCMThreshold = 3 + Convert.ToInt32(_objImprovementManager.ValueOf(Improvement.ImprovementType.CMThreshold));
+                int intCMThreshold = 3 + _objImprovementManager.ValueOf(Improvement.ImprovementType.CMThreshold);
                 return intCMThreshold;
             }
         }
@@ -5977,13 +5917,12 @@ namespace Chummer
         {
             get
             {
-                // Characters get a number of overflow boxes equal to their BOD (plus any Improvements). One more boxes is added to mark the character as dead.
-                double dblBOD = _attBOD.TotalValue;
-                int intCMOverflow = Convert.ToInt32(dblBOD) + _objImprovementManager.ValueOf(Improvement.ImprovementType.CMOverflow) + 1;
-                if (_strMetatype.Contains("A.I.") || _strMetatypeCategory == "Protosapients")
+                int intCMOverflow = 0;
+                // A.I. do not have an Overflow Condition Monitor.
+                if (!(_strMetatype.Contains("A.I.") || _strMetatypeCategory == "Protosapients"))
                 {
-                    // A.I. do not have an Overflow Condition Monitor.
-                    intCMOverflow = 0;
+                    // Characters get a number of overflow boxes equal to their BOD (plus any Improvements). One more boxes is added to mark the character as dead.
+                    intCMOverflow = _attBOD.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.CMOverflow) + 1;
                 }
                 return intCMOverflow;
             }
@@ -6182,17 +6121,16 @@ namespace Chummer
 					if (_blnHasHomeNode && _strHomeNodeCategory == "Vehicle")
 					{
 						strReturn = _strHomeNodeHandling;
-						return strReturn;
 					}
 					else
 					{
 						strReturn = "0";
-						return strReturn;
 					}
-				}
+                    return strReturn;
+                }
 				else
 				{
-					intLimit = (Convert.ToInt32(Math.Ceiling(((Convert.ToDecimal(_attSTR.TotalValue) * 2) + Convert.ToDecimal(_attBOD.TotalValue) + Convert.ToDecimal(_attREA.TotalValue)) / 3)));
+					intLimit = (_attSTR.TotalValue * 2 + _attBOD.TotalValue + _attREA.TotalValue + 2) / 3;
 				}
 				intLimit += _objImprovementManager.ValueOf(Improvement.ImprovementType.PhysicalLimit);
 				strReturn = Convert.ToString(intLimit);
@@ -6207,12 +6145,11 @@ namespace Chummer
         {
             get
             {
-				int intLimit = 0;
+				int intLimit = (_attLOG.TotalValue * 2 + _attINT.TotalValue + _attWIL.TotalValue + 2) / 3;
                 if (_strMetatype == "A.I." && _blnHasHomeNode)
 				{
 					if (_strHomeNodeCategory == "Vehicle")
 					{
-						intLimit = Convert.ToInt32(Math.Ceiling(((Convert.ToDecimal(_attLOG.TotalValue) * 2) + Convert.ToDecimal(_attINT.TotalValue) + Convert.ToDecimal(_attWIL.TotalValue)) / 3));
 						if (_intHomeNodeSensor > intLimit)
 						{
 							intLimit = _intHomeNodeSensor;
@@ -6224,16 +6161,11 @@ namespace Chummer
 					}
 					else if (_strHomeNodeCategory == "Gear")
 					{
-						intLimit = Convert.ToInt32(Math.Ceiling(((Convert.ToDecimal(_attLOG.TotalValue) * 2) + Convert.ToDecimal(_attINT.TotalValue) + Convert.ToDecimal(_attWIL.TotalValue)) / 3));
-						if (_intHomeNodeDataProcessing > intLimit)
+                        if (_intHomeNodeDataProcessing > intLimit)
 						{
 							intLimit = _intHomeNodeDataProcessing;
 						}
 					}
-				}
-				else
-				{
-					intLimit = Convert.ToInt32(Math.Ceiling(((Convert.ToDecimal(_attLOG.TotalValue) * 2) + Convert.ToDecimal(_attINT.TotalValue) + Convert.ToDecimal(_attWIL.TotalValue)) / 3));
 				}
 				intLimit += _objImprovementManager.ValueOf(Improvement.ImprovementType.MentalLimit);
 				return intLimit;
@@ -6252,16 +6184,16 @@ namespace Chummer
 				{
 					if (_intHomeNodeDataProcessing >= _intHomeNodePilot)
 					{
-						intLimit = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(_attCHA.TotalValue) + Convert.ToDecimal(_intHomeNodeDataProcessing) + Convert.ToDecimal(_attWIL.TotalValue) + Math.Ceiling(Essence)) / 3));
+						intLimit = (_attCHA.TotalValue + _intHomeNodeDataProcessing + _attWIL.TotalValue + Convert.ToInt32(Math.Ceiling(Essence)) + 2) / 3;
 					}
 					else
 					{
-						intLimit = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(_attCHA.TotalValue) + Convert.ToDecimal(_intHomeNodePilot) + Convert.ToDecimal(_attWIL.TotalValue) + Math.Ceiling(Essence)) / 3));
-					}
+						intLimit = (_attCHA.TotalValue + _intHomeNodePilot + _attWIL.TotalValue + Convert.ToInt32(Math.Ceiling(Essence)) + 2) / 3;
+                    }
 				}
 				else
 				{
-					intLimit = Convert.ToInt32(Math.Ceiling(((Convert.ToDecimal(_attCHA.TotalValue) * 2) + Convert.ToDecimal(_attWIL.TotalValue) + Math.Ceiling(Essence)) / 3));
+					intLimit = (_attCHA.TotalValue * 2 + _attWIL.TotalValue + Convert.ToInt32(Math.Ceiling(Essence)) + 2) / 3;
 				}
                 intLimit += _objImprovementManager.ValueOf(Improvement.ImprovementType.SocialLimit);
                 return intLimit;
@@ -6349,11 +6281,11 @@ namespace Chummer
 	            objXmlDocument = XmlManager.Instance.Load(_blnIsCritter ? "critters.xml" : "metatypes.xml");
 	            XmlNode objXmlNode = objXmlDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + _strMetatype + "\"]");
 	                
-                objXmlNode.TryGetField("movement", out _strMovement);
+                objXmlNode.TryGetField("movement", out strReturn);
 				objXmlNode.TryGetField("run", out _strRun);
 				objXmlNode.TryGetField("walk", out _strWalk);
 				objXmlNode.TryGetField("sprint", out _strSprint);
-				if (_strMovement == "Special")
+				if (strReturn == "Special")
 						{
 							return "Special";
 						}
@@ -6566,13 +6498,13 @@ namespace Chummer
 					return "Special";
 				}
 
-				string strReturn = "";
-				XmlDocument objXmlDocument = new XmlDocument();
+                string strReturn = "";
+                XmlDocument objXmlDocument = new XmlDocument();
 				objXmlDocument = XmlManager.Instance.Load(_blnIsCritter ? "critters.xml" : "metatypes.xml");
 				XmlNode objXmlNode = objXmlDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + _strMetatype + "\"]");
 
-				objXmlNode.TryGetField("movement", out _strMovement);
-				if (_strMovement == "Special")
+				objXmlNode.TryGetField("movement", out strReturn);
+				if (strReturn == "Special")
 				{
 					return "Special";
 				}
@@ -6598,8 +6530,8 @@ namespace Chummer
 				objXmlDocument = XmlManager.Instance.Load(_blnIsCritter ? "critters.xml" : "metatypes.xml");
 				XmlNode objXmlNode = objXmlDocument.SelectSingleNode("/chummer/metatypes/metatype[name = \"" + _strMetatype + "\"]");
 
-				objXmlNode.TryGetField("movement", out _strMovement);
-				if (_strMovement == "Special")
+				objXmlNode.TryGetField("movement", out strReturn);
+				if (strReturn == "Special")
 				{
 					return "Special";
 				}

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -178,7 +178,8 @@ namespace Chummer
 	        UnarmedReach,
 			SkillSpecialization,
             AIProgram,
-            CritterPowerLevel
+            CritterPowerLevel,
+            SwapSkillSpecAttribute
         }
 
         public enum ImprovementSource
@@ -228,6 +229,7 @@ namespace Chummer
         private int _intRating = 1;
 		private string _strExclude = "";
 		private string _strUniqueName = "";
+        private string _strTarget = "";
         private ImprovementType _objImprovementType;
         private ImprovementSource _objImprovementSource;
 		private bool _blnCustom = false;
@@ -276,7 +278,8 @@ namespace Chummer
 			objWriter.WriteStartElement("improvement");
 			if (_strUniqueName != "")
 				objWriter.WriteElementString("unique", _strUniqueName);
-			objWriter.WriteElementString("improvedname", _strImprovedName);
+            objWriter.WriteElementString("target", _strTarget);
+            objWriter.WriteElementString("improvedname", _strImprovedName);
 			objWriter.WriteElementString("sourcename", _strSourceName);
 			objWriter.WriteElementString("min", _intMin.ToString());
 			objWriter.WriteElementString("max", _intMax.ToString());
@@ -315,7 +318,14 @@ namespace Chummer
 			catch
 			{
 			}
-			_strImprovedName = objNode["improvedname"].InnerText;
+            try
+            {
+                _strTarget = objNode["target"].InnerText;
+            }
+            catch
+            {
+            }
+            _strImprovedName = objNode["improvedname"].InnerText;
 			_strSourceName = objNode["sourcename"].InnerText;
 			try
 			{
@@ -546,10 +556,19 @@ namespace Chummer
 			set { _blnAddToRating = value; }
 			}
 
-		/// <summary>
-		/// Whether or not the Improvement is enabled and provided its bonus.
+        /// <summary>
+		/// The target of an improvement, e.g. the skill whose attributes should be swapped
 		/// </summary>
-		public bool Enabled
+		public string Target
+        {
+            get { return _strTarget; }
+            set { _strTarget = value; }
+        }
+
+        /// <summary>
+        /// Whether or not the Improvement is enabled and provided its bonus.
+        /// </summary>
+        public bool Enabled
 		{
 			get { return _blnEnabled; }
 			set { _blnEnabled = value; }
@@ -1123,970 +1142,382 @@ namespace Chummer
 				// Remove the Improvement.
 				_objCharacter.Improvements.Remove(objImprovement);
 
-				if (objImprovement.ImproveType == Improvement.ImprovementType.SkillLevel)
-				{
-					//TODO: Come back here and figure out wtf this did? Think it removed nested lifemodule skills? //Didn't this handle the collapsing knowledge skills thing?
-					//for (int i = _objCharacter.SkillsSection.Skills.Count - 1; i >= 0; i--)
-					//{
-					//	//wrote as foreach first, modify collection, not want rename
-					//	Skill skill = _objCharacter.SkillsSection.Skills[i];
-					//	for (int j = skill.Fold.Count - 1; j >= 0; j--)
-					//	{
-					//		Skill fold = skill.Fold[i];
-					//		if (fold.Id.ToString() == objImprovement.ImprovedName)
-					//		{
-					//			skill.Free(fold);
-					//			_objCharacter.SkillsSection.Skills.Remove(fold);
-					//		}
-					//	}
+                // See if the character has anything else that is granting them the same bonus as this improvement
+                bool blnHasDuplicate = _objCharacter.Improvements.Where(x => x.SourceName != objImprovement.SourceName && 
+                                                                        x.ImproveType == objImprovement.ImproveType && 
+                                                                        x.UniqueName == objImprovement.UniqueName && 
+                                                                        x.ImprovedName == objImprovement.ImprovedName).Any();
 
-					//	if (skill.Id.ToString() == objImprovement.ImprovedName)
-					//	{
-					//		while(skill.Fold.Count > 0) skill.Free(skill.Fold[0]);
-					//		//empty list, can't call clear as exposed list is RO
-
-					//		_objCharacter.SkillsSection.Skills.Remove(skill);
-					//	}
-					//}
-				}
-
-				if (objImprovement.ImproveType == Improvement.ImprovementType.SkillsoftAccess)
-			    {
-					_objCharacter.SkillsSection.KnowledgeSkills.RemoveAll(_objCharacter.SkillsSection.KnowsoftSkills.Contains);
-			    }
-
-                if (objImprovement.ImproveType == Improvement.ImprovementType.SkillKnowledgeForced)
+                switch (objImprovement.ImproveType)
                 {
-	                Guid guid = Guid.Parse(objImprovement.ImprovedName);
-	                _objCharacter.SkillsSection.KnowledgeSkills.RemoveAll(skill => skill.Id == guid);
-	                _objCharacter.SkillsSection.KnowsoftSkills.RemoveAll(skill => skill.Id == guid);
-                }
+                    case Improvement.ImprovementType.SkillLevel:
+                        //TODO: Come back here and figure out wtf this did? Think it removed nested lifemodule skills? //Didn't this handle the collapsing knowledge skills thing?
+                        //for (int i = _objCharacter.SkillsSection.Skills.Count - 1; i >= 0; i--)
+                        //{
+                        //	//wrote as foreach first, modify collection, not want rename
+                        //	Skill skill = _objCharacter.SkillsSection.Skills[i];
+                        //	for (int j = skill.Fold.Count - 1; j >= 0; j--)
+                        //	{
+                        //		Skill fold = skill.Fold[i];
+                        //		if (fold.Id.ToString() == objImprovement.ImprovedName)
+                        //		{
+                        //			skill.Free(fold);
+                        //			_objCharacter.SkillsSection.Skills.Remove(fold);
+                        //		}
+                        //	}
 
-                // Remove "free" adept powers if any.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.AdeptPower)
-                {
-					// Load the power from XML.
-					// objImprovement.Notes = name of the mentor spirit choice. Find the power name from here.
-					// TODO: Fix this properly. Generates a null exception if multiple adept powers are added by the improvement, as with the Dragonslayer Mentor Spirit. 
-	                try
-	                {
-		                XmlDocument objXmlMentorDocument = new XmlDocument();
-		                objXmlMentorDocument = XmlManager.Instance.Load("mentors.xml");
-		                XmlNode objXmlMentorBonus =
-			                objXmlMentorDocument.SelectSingleNode("/chummer/mentors/mentor/choices/choice[name = \"" +
-			                                                      objImprovement.Notes +
-			                                                      "\"]");
-		                XmlNodeList objXmlPowerList = objXmlMentorBonus["bonus"].SelectNodes("specificpower");
-		                foreach (XmlNode objXmlSpecificPower in objXmlPowerList)
-		                {
-			                // Get the Power information
-			                XmlDocument objXmlDocument = new XmlDocument();
-			                objXmlDocument = XmlManager.Instance.Load("powers.xml");
+                        //	if (skill.Id.ToString() == objImprovement.ImprovedName)
+                        //	{
+                        //		while(skill.Fold.Count > 0) skill.Free(skill.Fold[0]);
+                        //		//empty list, can't call clear as exposed list is RO
 
-			                string strPowerName = objXmlSpecificPower["name"].InnerText;
-
-			                // Find the power (if it still exists)
-			                foreach (Power objPower in _objCharacter.Powers)
-			                {
-				                if (objPower.Name == strPowerName)
-				                {
-					                // Disable the free property and remove any free levels.
-					                objPower.Free = false;
-					                objPower.FreeLevels = 0;
-				                }
-			                }
-		                }
-	                }
-	                catch
-	                {
-
-	                }
-                }
-                if (objImprovement.ImproveType == Improvement.ImprovementType.Attribute)
-                {
-                    CharacterAttrib objChangedAttribute = null;
-                    switch (objImprovement.ImprovedName)
-                    {
-                        case "AGI":
-                            objChangedAttribute = _objCharacter.AGI;
-                            break;
-                        case "REA":
-                            objChangedAttribute = _objCharacter.REA;
-                            break;
-                        case "STR":
-                            objChangedAttribute = _objCharacter.STR;
-                            break;
-                        case "CHA":
-                            objChangedAttribute = _objCharacter.CHA;
-                            break;
-                        case "INT":
-                            objChangedAttribute = _objCharacter.INT;
-                            break;
-                        case "LOG":
-                            objChangedAttribute = _objCharacter.LOG;
-                            break;
-                        case "WIL":
-                            objChangedAttribute = _objCharacter.WIL;
-                            break;
-                        case "EDG":
-                            objChangedAttribute = _objCharacter.EDG;
-                            break;
-                        case "MAG":
-                            objChangedAttribute = _objCharacter.MAG;
-                            break;
-                        case "RES":
-                            objChangedAttribute = _objCharacter.RES;
-                            break;
-                        case "DEP":
-                            objChangedAttribute = _objCharacter.DEP;
-                            break;
-                        case "BOD":
-                        default:
-                            objChangedAttribute = _objCharacter.BOD;
-                            break;
-                    }
-                    if (objImprovement.Minimum > 0)
-                    {
-                        objChangedAttribute.Value -= objImprovement.Minimum;
-                    }
-                }
-                // Determine if access to any Special Attributes have been lost.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.Attribute &&
-				    objImprovement.UniqueName == "enableattribute")
-				{
-					if (objImprovement.ImprovedName == "MAG")
-					{
-						// See if the character has anything else that is granting them access to MAG.
-						bool blnFound = false;
-						foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-						{
-							// Skip items from the current Improvement source.
-							if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-							{
-								if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Attribute &&
-								    objCharacterImprovement.UniqueName == "enableattribute" && objCharacterImprovement.ImprovedName == "MAG")
-								{
-									blnFound = true;
-									break;
-								}
-							}
-						}
-
-						if (!blnFound)
-							_objCharacter.MAGEnabled = false;
-					}
-					else if (objImprovement.ImprovedName == "RES")
-					{
-						// See if the character has anything else that is granting them access to RES.
-						bool blnFound = false;
-						foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-						{
-							// Skip items from the current Improvement source.
-							if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-							{
-								if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Attribute &&
-								    objCharacterImprovement.UniqueName == "enableattribute" && objCharacterImprovement.ImprovedName == "RES")
-								{
-									blnFound = true;
-									break;
-								}
-							}
-						}
-
-						if (!blnFound)
-							_objCharacter.RESEnabled = false;
-					}
-                    else if (objImprovement.ImprovedName == "DEP")
-                    {
-                        // See if the character has anything else that is granting them access to RES.
-                        bool blnFound = false;
-                        foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                        {
-                            // Skip items from the current Improvement source.
-                            if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                            {
-                                if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Attribute &&
-                                    objCharacterImprovement.UniqueName == "enableattribute" && objCharacterImprovement.ImprovedName == "DEP")
-                                {
-                                    blnFound = true;
-                                    break;
-                                }
-                            }
-                        }
-
-                        if (!blnFound)
-                            _objCharacter.DEPEnabled = false;
-                    }
-                }
-
-				// Determine if access to any special tabs have been lost.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.SpecialTab && objImprovement.UniqueName == "enabletab")
-				{
-					bool blnFound = false;
-					switch (objImprovement.ImprovedName)
-					{
-						case "Magician":
-							// See if the character has anything else that is granting them access to the Magician tab.
-							foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-							{
-								// Skip items from the current Improvement source.
-								if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-								{
-									if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-									    objCharacterImprovement.UniqueName == "enabletab" && objCharacterImprovement.ImprovedName == "Magician")
-									{
-										blnFound = true;
-										break;
-									}
-								}
-							}
-							
-							if (!blnFound)
-								_objCharacter.MagicianEnabled = false;
-							break;
-						case "Adept":
-							// See if the character has anything else that is granting them access to the Adept tab.
-							foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-							{
-								// Skip items from the current Improvement source.
-								if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-								{
-									if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-									    objCharacterImprovement.UniqueName == "enabletab" && objCharacterImprovement.ImprovedName == "Adept")
-									{
-										blnFound = true;
-										break;
-									}
-								}
-							}
-
-							if (!blnFound)
-								_objCharacter.AdeptEnabled = false;
-							break;
-						case "Technomancer":
-							// See if the character has anything else that is granting them access to the Technomancer tab.
-							foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-							{
-								// Skip items from the current Improvement source.
-								if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-								{
-									if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-									    objCharacterImprovement.UniqueName == "enabletab" && objCharacterImprovement.ImprovedName == "Technomancer")
-									{
-										blnFound = true;
-										break;
-									}
-								}
-							}
-
-							if (!blnFound)
-								_objCharacter.TechnomancerEnabled = false;
-							break;
-                        case "Advanced Programs":
-                            // See if the character has anything else that is granting them access to the Advanced Programs tab.
-                            foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                            {
-                                // Skip items from the current Improvement source.
-                                if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                                {
-                                    if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-                                        objCharacterImprovement.UniqueName == "enabletab" && objCharacterImprovement.ImprovedName == "Advanced Programs")
-                                    {
-                                        blnFound = true;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (!blnFound)
-                                _objCharacter.AdvancedProgramsEnabled = false;
-                            break;
-						case "Critter":
-							// See if the character has anything else that is granting them access to the Critter tab.
-							foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-							{
-								// Skip items from the current Improvement source.
-								if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-								{
-									if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-									    objCharacterImprovement.UniqueName == "enabletab" && objCharacterImprovement.ImprovedName == "Critter")
-									{
-										blnFound = true;
-										break;
-									}
-								}
-							}
-
-							if (!blnFound)
-								_objCharacter.CritterEnabled = false;
-							break;
-						case "Initiation":
-							// See if the character has anything else that is granting them access to the Initiation tab.
-							foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-							{
-								// Skip items from the current Improvement source.
-								if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-								{
-									if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-									    objCharacterImprovement.UniqueName == "enabletab" && objCharacterImprovement.ImprovedName == "Initiation")
-									{
-										blnFound = true;
-										break;
-									}
-								}
-							}
-
-							if (!blnFound)
-								_objCharacter.InitiationEnabled = false;
-							break;
-					}
-				}
-
-                // Determine if access to any special tabs has been regained
-                if (objImprovement.ImproveType == Improvement.ImprovementType.SpecialTab && objImprovement.UniqueName == "disabletab")
-                {
-                    bool blnFound = false;
-                    switch (objImprovement.ImprovedName)
-                    {
-                        case "Cyberware":
-                            // See if the character has anything else that is prohibiting them access to the Cyberware tab.
-                            foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                            {
-                                // Skip items from the current Improvement source.
-                                if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                                {
-                                    if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SpecialTab &&
-                                        objCharacterImprovement.UniqueName == "disabletab" && objCharacterImprovement.ImprovedName == "Cyberware")
-                                    {
-                                        blnFound = true;
-                                        break;
-                                    }
-                                }
-                            }
-
-                            if (!blnFound)
-                                _objCharacter.CyberwareDisabled = false;
-                            break;
-                    }
-                }
-
-                // Turn of the Black Market flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.BlackMarketDiscount)
-				{
-					bool blnFound = false;
-					// See if the character has anything else that is granting them access to Black Market.
-					foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-					{
-						// Skip items from the current Improvement source.
-						if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-						{
-							if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.BlackMarketDiscount)
-							{
-								blnFound = true;
-								break;
-							}
-						}
-					}
-
-					if (!blnFound)
-					{
-						_objCharacter.BlackMarketDiscount = false;
-						if (!_objCharacter.Created)
-						{
-							foreach (Vehicle objVehicle in _objCharacter.Vehicles)
-							{
-								objVehicle.BlackMarketDiscount = false;
-								foreach (Weapon objWeapon in objVehicle.Weapons)
-								{
-									objWeapon.DiscountCost = false;
-									foreach (WeaponAccessory objWeaponAccessory in objWeapon.WeaponAccessories)
-									{
-										objWeaponAccessory.DiscountCost = false;
-									}
-								}
-								foreach (Gear objGear in objVehicle.Gear)
-								{
-									objGear.DiscountCost = false;
-								}
-								foreach (VehicleMod objMod in objVehicle.Mods)
-								{
-									objMod.DiscountCost = false;
-								}
-							}
-							foreach (Weapon objWeapon in _objCharacter.Weapons)
-							{
-								objWeapon.DiscountCost = false;
-								foreach (WeaponAccessory objWeaponAccessory in objWeapon.WeaponAccessories)
-								{
-									objWeaponAccessory.DiscountCost = false;
-								}
-							}
-							foreach (Gear objGear in _objCharacter.Gear)
-							{
-								objGear.DiscountCost = false;
-
-								foreach (Gear objChild in objGear.Children)
-								{
-									objChild.DiscountCost = false;
-								}
-							}
-						}
-					}
-				}
-
-				// Turn of the Uneducated flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.Uneducated)
-				{
-					bool blnFound = false;
-					// See if the character has anything else that is granting them access to Uneducated.
-					foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-					{
-						// Skip items from the current Improvement source.
-						if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-						{
-							if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Uneducated)
-							{
-								blnFound = true;
-								break;
-							}
-						}
-					}
-
-					if (!blnFound)
-						_objCharacter.SkillsSection.Uneducated = false;
-				}
-
-				// Turn off the Uncouth flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.Uncouth)
-				{
-					bool blnFound = false;
-					// See if the character has anything else that is granting them access to Uncouth.
-					foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-					{
-						// Skip items from the current Improvement source.
-						if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-						{
-							if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Uncouth)
-							{
-								blnFound = true;
-								break;
-							}
-						}
-					}
-
-					if (!blnFound)
-						_objCharacter.SkillsSection.Uncouth = false;
-                }
-
-                // Turn off the FriendsInHighPlaces flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.FriendsInHighPlaces)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to FriendsInHighPlaces.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.FriendsInHighPlaces)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.FriendsInHighPlaces = false;
-                }
-
-                // Turn off the SchoolOfHardKnocks flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.SchoolOfHardKnocks)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to SchoolOfHardKnocks.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.SchoolOfHardKnocks)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.SkillsSection.SchoolOfHardKnocks = false;
-                }
-
-                //Turn off the Ex-Con flag if it is being removed
-			    if (objImprovement.ImproveType == Improvement.ImprovementType.ExCon)
-			    {
-                     bool blnFound = false;
-                     // See if the character has anything else that is granting them access to SchoolOfHardKnocks.
-                     foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                     {
-                         // Skip items from the current Improvement source.
-                         if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                         {
-                             if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.ExCon)
-                             {
-                                 blnFound = true;
-                                 break;
-                             }
-                         }
-                     }
- 
-                     if (!blnFound)
-                         _objCharacter.ExCon = false;
- 			    }
-
-                // Turn off the FriendsInHighPlaces flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.FriendsInHighPlaces)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to FriendsInHighPlaces.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.FriendsInHighPlaces)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.FriendsInHighPlaces = false;
-                }
-                // Turn off the JackOfAllTrades flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.JackOfAllTrades)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to JackOfAllTrades.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.JackOfAllTrades)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.SkillsSection.JackOfAllTrades = false;
-				}
-				// Turn off the prototypetranshuman flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.PrototypeTranshuman)
-				{
-					bool blnFound = false;
-					// See if the character has anything else that is granting them access to prototypetranshuman.
-					foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-					{
-						// Skip items from the current Improvement source.
-						if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-						{
-							if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.PrototypeTranshuman)
-							{
-								blnFound = true;
-								break;
-							}
-						}
-					}
-
-					if (!blnFound)
-						_objCharacter.PrototypeTranshuman = 0;
-				}
-				// Turn off the CollegeEducation flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.CollegeEducation)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to CollegeEducation.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.CollegeEducation)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.SkillsSection.CollegeEducation = false;
-                }
-                // Turn off the Erased flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.Erased)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to Erased.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Erased)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.Erased = false;
-                }
-                // Turn off the BornRich flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.BornRich)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to BornRich.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.BornRich)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.BornRich = false;
-                }
-                // Turn off the Fame flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.Fame)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to Fame.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Fame)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.Fame = false;
-                }
-                // Turn off the LightningReflexes flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.LightningReflexes)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to LightningReflexes.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.LightningReflexes)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.LightningReflexes = false;
-                }
-                // Turn off the Linguist flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.Linguist)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to Linguist.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Linguist)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.SkillsSection.Linguist = false;
-                }
-                // Turn off the MadeMan flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.MadeMan)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to MadeMan.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.MadeMan)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.MadeMan = false;
-				}
-
-				// Turn off the Ambidextrous flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.Ambidextrous)
-				{
-					bool blnFound = false;
-					// See if the character has anything else that is granting them access to Ambidextrous.
-					foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-					{
-						// Skip items from the current Improvement source.
-						if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-						{
-							if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Ambidextrous)
-							{
-								blnFound = true;
-								break;
-							}
-						}
-					}
-
-					if (!blnFound)
-						_objCharacter.Ambidextrous = false;
-				}
-
-				// Turn off the Overclocker flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.Overclocker)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to Overclocker.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.Overclocker)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.Overclocker = false;
-                }
-                // Turn off the RestrictedGear flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.RestrictedGear)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to RestrictedGear.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.RestrictedGear)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.RestrictedGear = false;
-                }
-                // Turn off the TechSchool flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.TechSchool)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to TechSchool.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.TechSchool)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.SkillsSection.TechSchool = false;
-                }
-                // Turn off the TrustFund flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.TrustFund)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to TrustFund.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.TrustFund)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.TrustFund = 0;
-                }
-                // Turn off the ExCon flag if it is being removed.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.ExCon)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to ExCon.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.ExCon)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-                        _objCharacter.ExCon = false;
-                }
-				// Turn off the BlackMarketDiscount flag if it is being removed.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.BlackMarketDiscount)
-                {
-                    bool blnFound = false;
-                    // See if the character has anything else that is granting them access to BlackMarket.
-                    foreach (Improvement objCharacterImprovement in _objCharacter.Improvements)
-                    {
-                        // Skip items from the current Improvement source.
-                        if (objCharacterImprovement.SourceName != objImprovement.SourceName)
-                        {
-                            if (objCharacterImprovement.ImproveType == Improvement.ImprovementType.BlackMarketDiscount)
-                            {
-                                blnFound = true;
-                                break;
-                            }
-                        }
-                    }
-
-                    if (!blnFound)
-	                {
-		                _objCharacter.BlackMarketDiscount = false;
-	                }
-                }
-                // If the last instance of Adapsin is being removed, convert all Adapsin Cyberware Grades to their non-Adapsin version.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.Adapsin)
-				{
-					if (!_objCharacter.AdapsinEnabled)
-					{
-						foreach (Cyberware objCyberware in _objCharacter.Cyberware)
-						{
-							if (objCyberware.Grade.Adapsin)
-							{
-								// Determine which GradeList to use for the Cyberware.
-								GradeList objGradeList;
-								if (objCyberware.SourceType == Improvement.ImprovementSource.Bioware)
-									objGradeList = GlobalOptions.BiowareGrades;
-								else
-									objGradeList = GlobalOptions.CyberwareGrades;
-
-								objCyberware.Grade = objGradeList.GetGrade(objCyberware.Grade.Name.Replace("(Adapsin)", string.Empty).Trim());
-							}
-						}
-					}
-				}
-
-                // Remove MadeMan tag from a contact
-				if (objImprovement.ImproveType == Improvement.ImprovementType.ContactMadeMan)
-			    {
-			        Contact contact = (from c in _objCharacter.Contacts
-			            where c.GUID == objImprovement.ImprovedName
-			            select c).First();
-
-			        contact.MadeMan = false;
-				}
-
-				if (objImprovement.ImproveType == Improvement.ImprovementType.AddContact)
-				{
-					Contact contact = (from c in _objCharacter.Contacts
-									   where c.GUID == objImprovement.ImprovedName
-									   select c).First();
-
-					_objCharacter.Contacts.Remove(contact);
-				}
-
-				// Decrease the character's Initiation Grade.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.Initiation)
-					_objCharacter.InitiateGrade -= objImprovement.Value;
-
-				// Decrease the character's Submersion Grade.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.Submersion)
-					_objCharacter.SubmersionGrade -= objImprovement.Value;
-				
-				//Remove special (magical/resonance) skills
-				if (objImprovement.ImproveType == Improvement.ImprovementType.SpecialSkills)
-				{
-					_objCharacter.SkillsSection.RemoveSkills((SkillsSection.FilterOptions)Enum.Parse(typeof(SkillsSection.FilterOptions), objImprovement.ImprovedName));
-				}
-
-				//Remove qualities that were granted by the Improvement.
-				if (objImprovement.ImproveType == Improvement.ImprovementType.SpecificQuality)
-				{
-					foreach (Quality objQuality in _objCharacter.Qualities.Where(objQuality => objImprovement.ImprovedName == objQuality.InternalId))
-					{
-						_objCharacter.Qualities.Remove(objQuality);
-						break;
-					}
-				}
-				if (objImprovement.ImproveType == Improvement.ImprovementType.SkillSpecialization)
-				{
-					Skill objSkill = _objCharacter.SkillsSection.Skills.First(x => x.Name == objImprovement.ImprovedName);
-					if (objSkill != null)
-					{
-						SkillSpecialization objSkillSpec = objSkill.Specializations.First(x => x.Name == objImprovement.UniqueName);
-						objSkill.Specializations.Remove(objSkillSpec);
-					}
-				}
-
-                // Remove AI programs that were granted by the Improvement.
-                if (objImprovement.ImproveType == Improvement.ImprovementType.AIProgram)
-                {
-                    foreach (AIProgram objProgram in _objCharacter.AIPrograms.Where(objProgram => objImprovement.ImprovedName == objProgram.InternalId))
-                    {
-                        _objCharacter.AIPrograms.Remove(objProgram);
+                        //		_objCharacter.SkillsSection.Skills.Remove(skill);
+                        //	}
+                        //}
                         break;
-                    }
+                    case Improvement.ImprovementType.SwapSkillAttribute:
+                    case Improvement.ImprovementType.SwapSkillSpecAttribute:
+                        _objCharacter.SkillsSection.ForceProperyChangedNotificationAll(nameof(Skill.PoolToolTip));
+                        break;
+                    case Improvement.ImprovementType.SkillsoftAccess:
+                        _objCharacter.SkillsSection.KnowledgeSkills.RemoveAll(_objCharacter.SkillsSection.KnowsoftSkills.Contains);
+                        break;
+                    case Improvement.ImprovementType.SkillKnowledgeForced:
+                        Guid guid = Guid.Parse(objImprovement.ImprovedName);
+                        _objCharacter.SkillsSection.KnowledgeSkills.RemoveAll(skill => skill.Id == guid);
+                        _objCharacter.SkillsSection.KnowsoftSkills.RemoveAll(skill => skill.Id == guid);
+                        break;
+                    case Improvement.ImprovementType.AdeptPower:
+                        // Load the power from XML.
+                        // objImprovement.Notes = name of the mentor spirit choice. Find the power name from here.
+                        // TODO: Fix this properly. Generates a null exception if multiple adept powers are added by the improvement, as with the Dragonslayer Mentor Spirit. 
+                        try
+                        {
+                            XmlDocument objXmlMentorDocument = new XmlDocument();
+                            objXmlMentorDocument = XmlManager.Instance.Load("mentors.xml");
+                            XmlNode objXmlMentorBonus =
+                                objXmlMentorDocument.SelectSingleNode("/chummer/mentors/mentor/choices/choice[name = \"" +
+                                                                      objImprovement.Notes +
+                                                                      "\"]");
+                            XmlNodeList objXmlPowerList = objXmlMentorBonus["bonus"].SelectNodes("specificpower");
+                            foreach (XmlNode objXmlSpecificPower in objXmlPowerList)
+                            {
+                                // Get the Power information
+                                XmlDocument objXmlDocument = new XmlDocument();
+                                objXmlDocument = XmlManager.Instance.Load("powers.xml");
+
+                                string strPowerName = objXmlSpecificPower["name"].InnerText;
+
+                                // Find the power (if it still exists)
+                                foreach (Power objPower in _objCharacter.Powers)
+                                {
+                                    if (objPower.Name == strPowerName)
+                                    {
+                                        // Disable the free property and remove any free levels.
+                                        objPower.Free = false;
+                                        objPower.FreeLevels = 0;
+                                    }
+                                }
+                            }
+                        }
+                        catch
+                        {
+                        }
+                        break;
+                    case Improvement.ImprovementType.Attribute:
+                        CharacterAttrib objChangedAttribute = null;
+                        switch (objImprovement.ImprovedName)
+                        {
+                            case "AGI":
+                                objChangedAttribute = _objCharacter.AGI;
+                                break;
+                            case "REA":
+                                objChangedAttribute = _objCharacter.REA;
+                                break;
+                            case "STR":
+                                objChangedAttribute = _objCharacter.STR;
+                                break;
+                            case "CHA":
+                                objChangedAttribute = _objCharacter.CHA;
+                                break;
+                            case "INT":
+                                objChangedAttribute = _objCharacter.INT;
+                                break;
+                            case "LOG":
+                                objChangedAttribute = _objCharacter.LOG;
+                                break;
+                            case "WIL":
+                                objChangedAttribute = _objCharacter.WIL;
+                                break;
+                            case "EDG":
+                                objChangedAttribute = _objCharacter.EDG;
+                                break;
+                            case "MAG":
+                                objChangedAttribute = _objCharacter.MAG;
+                                break;
+                            case "RES":
+                                objChangedAttribute = _objCharacter.RES;
+                                break;
+                            case "DEP":
+                                objChangedAttribute = _objCharacter.DEP;
+                                break;
+                            case "BOD":
+                            default:
+                                objChangedAttribute = _objCharacter.BOD;
+                                break;
+                        }
+                        if (objImprovement.Minimum > 0)
+                        {
+                            objChangedAttribute.Value -= objImprovement.Minimum;
+                        }
+
+                        // Determine if access to any Special Attributes have been lost.
+                        if (objImprovement.UniqueName == "enableattribute" && !blnHasDuplicate)
+                        {
+                            switch (objImprovement.ImprovedName)
+                            {
+                                case "MAG":
+                                    _objCharacter.MAGEnabled = false;
+                                    break;
+                                case "RES":
+                                    _objCharacter.RESEnabled = false;
+                                    break;
+                                case "DEP":
+                                    _objCharacter.DEPEnabled = false;
+                                    break;
+                            }
+                        }
+                        break;
+                    case Improvement.ImprovementType.SpecialTab:
+                        // Determine if access to any special tabs have been lost.
+                        if (!blnHasDuplicate)
+                        {
+                            if (objImprovement.UniqueName == "enabletab")
+                            {
+                                switch (objImprovement.ImprovedName)
+                                {
+                                    case "Magician":
+                                        _objCharacter.MagicianEnabled = false;
+                                        break;
+                                    case "Adept":
+                                        _objCharacter.AdeptEnabled = false;
+                                        break;
+                                    case "Technomancer":
+                                        _objCharacter.TechnomancerEnabled = false;
+                                        break;
+                                    case "Advanced Programs":
+                                        _objCharacter.AdvancedProgramsEnabled = false;
+                                        break;
+                                    case "Critter":
+                                        _objCharacter.CritterEnabled = false;
+                                        break;
+                                    case "Initiation":
+                                        _objCharacter.InitiationEnabled = false;
+                                        break;
+                                    default:
+                                        break;
+                                }
+                            }
+                            // Determine if access to any special tabs has been regained
+                            else if (objImprovement.UniqueName == "disabletab")
+                            {
+                                switch (objImprovement.ImprovedName)
+                                {
+                                    case "Cyberware":
+                                        _objCharacter.CyberwareDisabled = false;
+                                        break;
+                                }
+                            }
+                        }
+                        break;
+                    case Improvement.ImprovementType.BlackMarketDiscount:
+                        if (!blnHasDuplicate)
+                        {
+                            _objCharacter.BlackMarketDiscount = false;
+                            if (!_objCharacter.Created)
+                            {
+                                foreach (Vehicle objVehicle in _objCharacter.Vehicles)
+                                {
+                                    objVehicle.BlackMarketDiscount = false;
+                                    foreach (Weapon objWeapon in objVehicle.Weapons)
+                                    {
+                                        objWeapon.DiscountCost = false;
+                                        foreach (WeaponAccessory objWeaponAccessory in objWeapon.WeaponAccessories)
+                                        {
+                                            objWeaponAccessory.DiscountCost = false;
+                                        }
+                                    }
+                                    foreach (Gear objGear in objVehicle.Gear)
+                                    {
+                                        objGear.DiscountCost = false;
+                                    }
+                                    foreach (VehicleMod objMod in objVehicle.Mods)
+                                    {
+                                        objMod.DiscountCost = false;
+                                    }
+                                }
+                                foreach (Weapon objWeapon in _objCharacter.Weapons)
+                                {
+                                    objWeapon.DiscountCost = false;
+                                    foreach (WeaponAccessory objWeaponAccessory in objWeapon.WeaponAccessories)
+                                    {
+                                        objWeaponAccessory.DiscountCost = false;
+                                    }
+                                }
+                                foreach (Gear objGear in _objCharacter.Gear)
+                                {
+                                    objGear.DiscountCost = false;
+
+                                    foreach (Gear objChild in objGear.Children)
+                                    {
+                                        objChild.DiscountCost = false;
+                                    }
+                                }
+                            }
+                        }
+                        break;
+                    case Improvement.ImprovementType.Uneducated:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.Uneducated = false;
+                        break;
+                    case Improvement.ImprovementType.Uncouth:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.Uncouth = false;
+                        break;
+                    case Improvement.ImprovementType.FriendsInHighPlaces:
+                        if (!blnHasDuplicate)
+                            _objCharacter.FriendsInHighPlaces = false;
+                        break;
+                    case Improvement.ImprovementType.SchoolOfHardKnocks:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.SchoolOfHardKnocks = false;
+                        break;
+                    case Improvement.ImprovementType.ExCon:
+                        if (!blnHasDuplicate)
+                            _objCharacter.ExCon = false;
+                        break;
+                    case Improvement.ImprovementType.JackOfAllTrades:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.JackOfAllTrades = false;
+                        break;
+                    case Improvement.ImprovementType.PrototypeTranshuman:
+                        if (!blnHasDuplicate)
+                            _objCharacter.PrototypeTranshuman = 0;
+                        break;
+                    case Improvement.ImprovementType.CollegeEducation:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.CollegeEducation = false;
+                        break;
+                    case Improvement.ImprovementType.Erased:
+                        if (!blnHasDuplicate)
+                            _objCharacter.Erased = false;
+                        break;
+                    case Improvement.ImprovementType.BornRich:
+                        if (!blnHasDuplicate)
+                            _objCharacter.BornRich = false;
+                        break;
+                    case Improvement.ImprovementType.Fame:
+                        if (!blnHasDuplicate)
+                            _objCharacter.Fame = false;
+                        break;
+                    case Improvement.ImprovementType.LightningReflexes:
+                        if (!blnHasDuplicate)
+                            _objCharacter.LightningReflexes = false;
+                        break;
+                    case Improvement.ImprovementType.Linguist:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.Linguist = false;
+                        break;
+                    case Improvement.ImprovementType.MadeMan:
+                        if (!blnHasDuplicate)
+                            _objCharacter.MadeMan = false;
+                        break;
+                    case Improvement.ImprovementType.Ambidextrous:
+                        if (!blnHasDuplicate)
+                            _objCharacter.Ambidextrous = false;
+                        break;
+                    case Improvement.ImprovementType.Overclocker:
+                        if (!blnHasDuplicate)
+                            _objCharacter.Overclocker = false;
+                        break;
+                    case Improvement.ImprovementType.RestrictedGear:
+                        if (!blnHasDuplicate)
+                            _objCharacter.RestrictedGear = false;
+                        break;
+                    case Improvement.ImprovementType.TechSchool:
+                        if (!blnHasDuplicate)
+                            _objCharacter.SkillsSection.TechSchool = false;
+                        break;
+                    case Improvement.ImprovementType.TrustFund:
+                        if (!blnHasDuplicate)
+                            _objCharacter.TrustFund = 0;
+                        break;
+                    case Improvement.ImprovementType.Adapsin:
+                        if (!_objCharacter.AdapsinEnabled)
+                        {
+                            foreach (Cyberware objCyberware in _objCharacter.Cyberware)
+                            {
+                                if (objCyberware.Grade.Adapsin)
+                                {
+                                    // Determine which GradeList to use for the Cyberware.
+                                    GradeList objGradeList;
+                                    if (objCyberware.SourceType == Improvement.ImprovementSource.Bioware)
+                                        objGradeList = GlobalOptions.BiowareGrades;
+                                    else
+                                        objGradeList = GlobalOptions.CyberwareGrades;
+
+                                    objCyberware.Grade = objGradeList.GetGrade(objCyberware.Grade.Name.Replace("(Adapsin)", string.Empty).Trim());
+                                }
+                            }
+                        }
+                        break;
+                    case Improvement.ImprovementType.ContactMadeMan:
+                        Contact MadeManContact = (from c in _objCharacter.Contacts
+                                           where c.GUID == objImprovement.ImprovedName
+                                           select c).First();
+
+                        MadeManContact.MadeMan = false;
+                        break;
+                    case Improvement.ImprovementType.AddContact:
+                        Contact NewContact = (from c in _objCharacter.Contacts
+                                           where c.GUID == objImprovement.ImprovedName
+                                           select c).First();
+
+                        _objCharacter.Contacts.Remove(NewContact);
+                        break;
+                    case Improvement.ImprovementType.Initiation:
+                        _objCharacter.InitiateGrade -= objImprovement.Value;
+                        break;
+                    case Improvement.ImprovementType.Submersion:
+                        _objCharacter.SubmersionGrade -= objImprovement.Value;
+                        break;
+                    case Improvement.ImprovementType.SpecialSkills:
+                        _objCharacter.SkillsSection.RemoveSkills((SkillsSection.FilterOptions)Enum.Parse(typeof(SkillsSection.FilterOptions), objImprovement.ImprovedName));
+                        break;
+                    case Improvement.ImprovementType.SpecificQuality:
+                        foreach (Quality objQuality in _objCharacter.Qualities.Where(objQuality => objImprovement.ImprovedName == objQuality.InternalId))
+                        {
+                            _objCharacter.Qualities.Remove(objQuality);
+                            break;
+                        }
+                        break;
+                    case Improvement.ImprovementType.SkillSpecialization:
+                        Skill objSkill = _objCharacter.SkillsSection.Skills.First(x => x.Name == objImprovement.ImprovedName);
+                        if (objSkill != null)
+                        {
+                            SkillSpecialization objSkillSpec = objSkill.Specializations.First(x => x.Name == objImprovement.UniqueName);
+                            objSkill.Specializations.Remove(objSkillSpec);
+                        }
+                        break;
+                    case Improvement.ImprovementType.AIProgram:
+                        foreach (AIProgram objProgram in _objCharacter.AIPrograms.Where(objProgram => objImprovement.ImprovedName == objProgram.InternalId))
+                        {
+                            _objCharacter.AIPrograms.Remove(objProgram);
+                            break;
+                        }
+                        break;
+                    default:
+                        break;
                 }
             }
 
@@ -2115,7 +1546,7 @@ namespace Chummer
 		public void CreateImprovement(string strImprovedName, Improvement.ImprovementSource objImprovementSource,
 			string strSourceName, Improvement.ImprovementType objImprovementType, string strUnique,
 			int intValue = 0, int intRating = 1, int intMinimum = 0, int intMaximum = 0, int intAugmented = 0,
-			int intAugmentedMaximum = 0, string strExclude = "", bool blnAddToRating = false)
+			int intAugmentedMaximum = 0, string strExclude = "", bool blnAddToRating = false, string strTarget = "")
 		{
             Log.Enter("CreateImprovement");
 			Log.Info(
@@ -2158,9 +1589,10 @@ namespace Chummer
 			objImprovement.AugmentedMaximum = intAugmentedMaximum;
 			objImprovement.Exclude = strExclude;
 			objImprovement.AddToRating = blnAddToRating;
+            objImprovement.Target = strTarget;
 
-			// Do not attempt to add the Improvements if the Character is null (as a result of Cyberware being added to a VehicleMod).
-			if (_objCharacter != null)
+            // Do not attempt to add the Improvements if the Character is null (as a result of Cyberware being added to a VehicleMod).
+            if (_objCharacter != null)
 			{
 				// Add the Improvement to the list.
 				_objCharacter.Improvements.Add(objImprovement);

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -816,7 +816,7 @@ namespace Chummer
             
 			if (strValue.Contains("Rating") || strValue.Contains("BOD") || strValue.Contains("AGI") || strValue.Contains("REA") ||
 			    strValue.Contains("STR") || strValue.Contains("CHA") || strValue.Contains("INT") || strValue.Contains("LOG") ||
-			    strValue.Contains("WIL") || strValue.Contains("EDG") || strValue.Contains("MAG") || strValue.Contains("RES"))
+			    strValue.Contains("WIL") || strValue.Contains("EDG") || strValue.Contains("DEP") || strValue.Contains("MAG") || strValue.Contains("RES"))
 			{
 				// If the value contain an CharacterAttribute name, replace it with the character's CharacterAttribute.
 				strValue = strValue.Replace("BOD", _objCharacter.BOD.TotalValue.ToString());
@@ -828,7 +828,8 @@ namespace Chummer
 				strValue = strValue.Replace("LOG", _objCharacter.LOG.TotalValue.ToString());
 				strValue = strValue.Replace("WIL", _objCharacter.WIL.TotalValue.ToString());
 				strValue = strValue.Replace("EDG", _objCharacter.EDG.TotalValue.ToString());
-				strValue = strValue.Replace("MAG", _objCharacter.MAG.TotalValue.ToString());
+                strValue = strValue.Replace("DEP", _objCharacter.DEP.TotalValue.ToString());
+                strValue = strValue.Replace("MAG", _objCharacter.MAG.TotalValue.ToString());
 				strValue = strValue.Replace("RES", _objCharacter.RES.TotalValue.ToString());
 
 				XmlDocument objXmlDocument = new XmlDocument();

--- a/Chummer/Classes/clsUnique.cs
+++ b/Chummer/Classes/clsUnique.cs
@@ -632,7 +632,7 @@ namespace Chummer
                                 intLimbTotal += intMeat;
                             intLimbCount = _objCharacter.Options.LimbCount;
                         }
-                        int intTotal = Convert.ToInt32(Math.Floor(Convert.ToDecimal((intLimbTotal), GlobalOptions.Instance.CultureInfo) / Convert.ToDecimal(intLimbCount, GlobalOptions.Instance.CultureInfo)));
+                        int intTotal = intLimbTotal / intLimbCount;
                         intReturn += intTotal;
                     }
                 }
@@ -748,7 +748,7 @@ namespace Chummer
                     intReturn = TotalMaximum + AugmentedMaximumModifiers;
 				else
 					intReturn = TotalMaximum + 4 + AugmentedMaximumModifiers;
-                    // intReturn = TotalMaximum + Convert.ToInt32(Math.Floor((Convert.ToDecimal(TotalMaximum, GlobalOptions.Instance.CultureInfo) / 2))) + AugmentedMaximumModifiers;
+                    // intReturn = TotalMaximum + (TotalMaximum / 2) + AugmentedMaximumModifiers;
 
 				if (intReturn < 0)
 					intReturn = 0;
@@ -3083,9 +3083,7 @@ namespace Chummer
 					{
 						// Calculate the Spell's Drain for the current Force.
 						xprDV = nav.Compile(_strDV.Replace("F", i.ToString()).Replace("/", " div "));
-						decimal decDV = Convert.ToDecimal(nav.Evaluate(xprDV).ToString());
-						decDV = Math.Floor(decDV);
-						int intDV = Convert.ToInt32(decDV);
+						int intDV = Convert.ToInt32(Math.Floor(Convert.ToDecimal(nav.Evaluate(xprDV).ToString())));
 						// Drain cannot be lower than 2.
 						if (intDV < 2)
 							intDV = 2;
@@ -8345,7 +8343,6 @@ namespace Chummer
 		{
 			get
 			{
-				int intCost = 0;
 				double dblCost = 10.0 + (_intGrade * _objOptions.KarmaInitiation);
 				double dblMultiplier = 1.0;
 				
@@ -8361,9 +8358,7 @@ namespace Chummer
                 if (_blnSchooling)
                     dblMultiplier -= 0.1;
 
-                intCost = Convert.ToInt32(Math.Ceiling(dblCost * dblMultiplier));
-
-				return intCost;
+                return Convert.ToInt32(Math.Ceiling(dblCost * dblMultiplier));
 			}
 		}
 

--- a/Chummer/Custom Content/override_cyberlimbheadware_cyberware.xml
+++ b/Chummer/Custom Content/override_cyberlimbheadware_cyberware.xml
@@ -18,7 +18,7 @@
     https://github.com/chummer5a/chummer5a
 -->
 
-<!-- This XML file removes the Headware subsystem from all cyberlimbs. -->
+<!-- This XML file removes the Headware subcategory from all cyberlimbs. -->
 <chummer>
 	<cyberwares>
 		<cyberware>
@@ -39,12 +39,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -66,12 +66,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -92,12 +92,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -118,12 +118,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -144,12 +144,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -170,12 +170,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -196,12 +196,12 @@
 					<physical>1</physical>
 				</conditionmonitor>
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -223,12 +223,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -250,12 +250,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -276,12 +276,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -302,12 +302,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -328,12 +328,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -354,12 +354,12 @@
 				</conditionmonitor>
 				<selectside />
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<subcategory>Bodyware</subcategory>
+				<subcategory>Cyberlimb Enhancement</subcategory>
+				<subcategory>Cyberlimb Accessory</subcategory>
+				<subcategory>Cyber Implant Weapon</subcategory>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>
@@ -380,12 +380,12 @@
 					<physical>1</physical>
 				</conditionmonitor>
 			</bonus>
-			<subsystems>
-				<subsystem>Bodyware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
+			<allowsubsystems>
+				<category>Bodyware</category>
+				<category>Cyberlimb Enhancement</category>
+				<category>Cyberlimb Accessory</category>
+				<category>Cyber Implant Weapon</category>
+			</allowsubsystems>
 			<source>SR5</source>
 			<page>456</page>
 		</cyberware>

--- a/Chummer/Custom Content/override_cyberlimbheadware_cyberware.xml
+++ b/Chummer/Custom Content/override_cyberlimbheadware_cyberware.xml
@@ -206,32 +206,6 @@
 			<page>456</page>
 		</cyberware>
 		<cyberware>
-			<id>ea676290-1859-4a56-86f8-a3fb90decc32</id>
-			<name>Obvious Skull</name>
-			<category>Cyberlimb</category>
-			<limbslot>skull</limbslot>
-			<ess>0.75</ess>
-			<capacity>4</capacity>
-			<avail>16</avail>
-			<cost>10000</cost>
-			<allowgear>
-				<gearcategory>Sensors</gearcategory>
-			</allowgear>
-			<bonus>
-				<conditionmonitor>
-					<physical>1</physical>
-				</conditionmonitor>
-			</bonus>
-			<subsystems>
-				<subsystem>Headware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
-			<source>SR5</source>
-			<page>456</page>
-		</cyberware>
-		<cyberware>
 			<id>f4a48c40-29df-4435-8d09-b1f3153d61ee</id>
 			<name>Synthetic Full Arm</name>
 			<category>Cyberlimb</category>
@@ -416,14 +390,15 @@
 			<page>456</page>
 		</cyberware>
 		<cyberware>
-			<id>992fbf6b-8f9a-4c27-a527-8705ecc3341f</id>
-			<name>Synthetic Skull</name>
+			<id>8af5027d-a504-484e-8089-c542a95d4831</id>
+			<name>Centaur Full Leg</name>
+			<hide />
 			<category>Cyberlimb</category>
-			<limbslot>skull</limbslot>
-			<ess>0.75</ess>
-			<capacity>2</capacity>
-			<avail>16</avail>
-			<cost>15000</cost>
+			<limbslot>leg</limbslot>
+			<ess>3</ess>
+			<capacity>20</capacity>
+			<avail>12</avail>
+			<cost>0</cost>
 			<allowgear>
 				<gearcategory>Sensors</gearcategory>
 			</allowgear>
@@ -432,14 +407,14 @@
 					<physical>1</physical>
 				</conditionmonitor>
 			</bonus>
-			<subsystems>
-				<subsystem>Headware</subsystem>
-				<subsystem>Cyberlimb Enhancement</subsystem>
-				<subsystem>Cyberlimb Accessory</subsystem>
-				<subsystem>Cyber Implant Weapon</subsystem>
-			</subsystems>
-			<source>SR5</source>
-			<page>456</page>
+			<allowsubsystems>
+				<category>Bodyware</category>
+				<category>Cyberlimb Enhancement</category>
+				<category>Cyberlimb Accessory</category>
+				<category>Cyber Implant Weapon</category>
+			</allowsubsystems>
+			<source>CF</source>
+			<page>87</page>
 		</cyberware>
 	</cyberwares>
 </chummer>

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -27,6 +27,7 @@ Application Changes:
 - Added code to prevent a crash if the PDF application/web browser has not been specified. 
 - Fixed an issue with Depth not updating properly when changing to and/or from a Depth-enabled metatype.
 - Fixed the metatype cost label in the sidebar not updating properly when loading characters with non-karma build methods and creating characters in life module build methods.
+- Fixed an issue with some Depth-linked improvements not being handled properly.
 
 Data Changes:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -45,7 +45,10 @@ Data Changes:
 - Liminal Body Centaur now comes with four full cyberlegs.
 - Fixed the Dual-Natured critter power to provide access to Assensing. 
 - Fixed incorrect cost discount for the Astral Hazing quality.
-
+- Vintage quality now properly doubles accessory cost and is mutually exclusive with electronic accessories.
+- Peak-Discharge Battery Packs no longer appear in the list of available accessories for weapons that cannot use them.
+- Added an item for an Optical Imaging Scope, just like how there is one for Optical Binoculars in the gear section.
+- Improved Range Finder now properly requires a Smartgun accessory.
 
 Custom Content Additions:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -28,6 +28,10 @@ Application Changes:
 - Fixed an issue with Depth not updating properly when changing to and/or from a Depth-enabled metatype.
 - Fixed the metatype cost label in the sidebar not updating properly when loading characters with non-karma build methods and creating characters in life module build methods.
 - Fixed an issue with some Depth-linked improvements not being handled properly.
+- Improvements now have a "target" member string.
+- Optimized the improvement removal code for size, readability, and portability.
+- Fixed the improvement for swapping the attributes of a skill. The results of such an improvement show up in the skill's dice tooltip.
+- Added an improvement for the swapping of attributes of a skill for a particular specialization. The results of such an improvement show up in the skill's dice tooltip.
 
 Data Changes:
 
@@ -53,6 +57,7 @@ Data Changes:
 - Added a vehicle mod for the illegal Reloading Drone autosoft for reloading forbidden weapons that costs 250.
 - Added an entry for a Smart Wig with an integrated Trode Net that costs 100 extra.
 - Added an improvement for the Intimidation limit bonus for Voice Warper.
+- Master Debater and Empathic Listener now have their effects represented in skill dice pool tooltips.
 
 Custom Content Additions:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -32,6 +32,12 @@ Application Changes:
 - Optimized the improvement removal code for size, readability, and portability.
 - Fixed the improvement for swapping the attributes of a skill. The results of such an improvement show up in the skill's dice tooltip.
 - Added an improvement for the swapping of attributes of a skill for a particular specialization. The results of such an improvement show up in the skill's dice tooltip.
+- Corrected the Condition Monitors of vehicles to use modified values for Body and Device Rating instead of only base values.
+- Corrected the Speed and Handling of vehicles to use modified values for Body instead of only base values.
+- Corrected the Device Rating of vehicles to be generated from Pilot rating instead of a base value of 3.
+- Optimized away some leftovers from SR4a that were taking up CPU time and lines.
+- Performed minor speed optimizations related to rounding of integer division results.
+- Fixed a crash when creating a piece of cyberware at a rating above its maximum or below its minimum.
 
 Data Changes:
 
@@ -58,6 +64,7 @@ Data Changes:
 - Added an entry for a Smart Wig with an integrated Trode Net that costs 100 extra.
 - Added an improvement for the Intimidation limit bonus for Voice Warper.
 - Master Debater and Empathic Listener now have their effects represented in skill dice pool tooltips.
+- Cybereyes and cyberears now come standard with Image Link and Sound Link respectively.
 
 Custom Content Additions:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -25,6 +25,8 @@ Application Changes:
 - Corrected handling of Redliner for Liminal Body, especially Liminal Body Centaur.
 - Fixed an issue where the cost of cyberware/bioware grandchildren subsystems had their costs ignored.
 - Added code to prevent a crash if the PDF application/web browser has not been specified. 
+- Fixed an issue with Depth not updating properly when changing to and/or from a Depth-enabled metatype.
+- Fixed the metatype cost label in the sidebar not updating properly when loading characters with non-karma build methods and creating characters in life module build methods.
 
 Data Changes:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -49,6 +49,10 @@ Data Changes:
 - Peak-Discharge Battery Packs no longer appear in the list of available accessories for weapons that cannot use them.
 - Added an item for an Optical Imaging Scope, just like how there is one for Optical Binoculars in the gear section.
 - Improved Range Finder now properly requires a Smartgun accessory.
+- Corrected Ammo Drone to come standard with a rating 2 Maneuvering Autosoft.
+- Added a vehicle mod for the illegal Reloading Drone autosoft for reloading forbidden weapons that costs 250.
+- Added an entry for a Smart Wig with an integrated Trode Net that costs 100 extra.
+- Added an improvement for the Intimidation limit bonus for Voice Warper.
 
 Custom Content Additions:
 

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -366,6 +366,9 @@
 			<allowsubsystems>
 				<category>Eyeware</category>
 			</allowsubsystems>
+			<subsystems>
+				<subsystem>Image Link</subsystem>
+			</subsystems>
 			<source>SR5</source>
 			<page>453</page>
 		</cyberware>
@@ -493,6 +496,9 @@
 			<allowsubsystems>
 				<category>Earware</category>
 			</allowsubsystems>
+			<subsystems>
+				<subsystem>Sound Link</subsystem>
+			</subsystems>
 			<source>SR5</source>
 			<page>453</page>
 		</cyberware>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -3649,6 +3649,13 @@
 			<armorcapacity>[1]</armorcapacity>
 			<avail>8R</avail>
 			<cost>Rating * 250</cost>
+			<bonus>
+				<limitmodifier>
+					<limit>Social</limit>
+					<value>1</value>
+					<condition>Only for intimidation</condition>
+				</limitmodifier>
+			</bonus>
 			<source>HT</source>
 			<page>187</page>
 		</gear>
@@ -4785,6 +4792,16 @@
 			<rating>0</rating>
 			<avail>8</avail>
 			<cost>1200</cost>
+			<source>HT</source>
+			<page>188</page>
+		</gear>
+		<gear>
+			<id>176c8189-e839-4860-82e9-adafaddc5577</id>
+			<name>Smart Wig w/ Trode Net</name>
+			<category>Tools of the Trade</category>
+			<rating>0</rating>
+			<avail>8</avail>
+			<cost>1300</cost>
 			<source>HT</source>
 			<page>188</page>
 		</gear>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -11645,8 +11645,12 @@
 			<name>Empathic Listener</name>
 			<karma>10</karma>
 			<category>Positive</category>
-			<bonus />
-			<!-- TODO: Implement SwapSkillAttribute for specific skills -->
+			<bonus>
+				<swapskillattribute>
+					<attribute>INT</attribute>
+					<limittoskill>Etiquette</limittoskill>
+				</swapskillattribute>
+			</bonus>
 			<source>CA</source>
 			<page>150</page>
 		</quality>
@@ -11693,8 +11697,13 @@
 			<name>Master Debater</name>
 			<karma>10</karma>
 			<category>Positive</category>
-			<bonus />
-			<!-- TODO: Implement SwapSkillAttribute for specific skills -->
+			<bonus>
+				<swapskillspecattribute>
+					<attribute>LOG</attribute>
+					<limittoskill>Negotiation</limittoskill>
+					<spec>Diplomacy</spec>
+				</swapskillspecattribute>
+			</bonus>
 			<source>CA</source>
 			<page>151</page>
 		</quality>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -5677,6 +5677,7 @@
 			<sensor>2</sensor>
 			<gears>
 				<gear rating="2" maxrating="3">Sensor Array</gear>
+				<gear rating="2" select="Ammo Drone">[Model] Maneuvering Autosoft</gear>
 			</gears>
 			<avail>5</avail>
 			<cost>3000</cost>
@@ -6023,6 +6024,22 @@
 			</required>
 			<source>BB</source>
 			<page>23</page>
+		</mod>
+		<mod>
+			<id>75d9f461-f30a-4d50-8700-6e9fa87da8bb</id>
+			<name>Reloading Drone Forbidden Weapon Reloading Autosoft</name>
+			<category>Model-Specific</category>
+			<rating>0</rating>
+			<slots>0</slots>
+			<avail>0F</avail>
+			<cost>250</cost>
+			<required>
+				<vehicledetails>
+					<name operation="contains">Reloading Drone</name>
+				</vehicledetails>
+			</required>
+			<source>HT</source>
+			<page>189</page>
 		</mod>
 		<!-- End Region -->
 		<!-- Region Powertrain-->

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -9152,7 +9152,6 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
-					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9238,7 +9237,6 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
-					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9263,7 +9261,6 @@
 					<accessory>Advanced Safety System, Basic</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
-					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9288,7 +9285,6 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Basic</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
-					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9313,7 +9309,6 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Basic</accessory>
-					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9487,11 +9482,6 @@
 			<id>9a27efa9-f3f4-4e47-9165-76e8adbad4ba</id>
 			<name>Guncam</name>
 			<mount>Top/Under/Barrel/Side/Internal</mount>
-			<forbidden>
-				<oneof>
-					<accessory>Vintage</accessory>
-				</oneof>
-			</forbidden>
 			<rating>0</rating>
 			<avail>4</avail>
 			<cost>350</cost>
@@ -9520,11 +9510,6 @@
 					<accessory>Smartgun System, Internal</accessory>
 				</oneof>
 			</required>
-			<forbidden>
-				<oneof>
-					<accessory>Vintage</accessory>
-				</oneof>
-			</forbidden>
 			<rating>0</rating>
 			<avail>6</avail>
 			<cost>2000</cost>
@@ -9809,15 +9794,9 @@
 			<mount/>
 			<forbidden>
 				<oneof>
-					<accessory>Advanced Safety System, Basic</accessory>
-					<accessory>Advanced Safety System, Immobilization</accessory>
-					<accessory>Advanced Safety System, Self Destruct</accessory>
-					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
-					<accessory>Advanced Safety System, Electro Shocker</accessory>
 					<accessory>Weapon Personality</accessory>
 					<accessory>Weapon Commlink</accessory>
 					<accessory>Safe Target System, Base</accessory>
-					<accessory>Improved Range Finder</accessory>
 					<accessory>Smartgun System, External</accessory>
 					<accessory>Smartgun System, Internal</accessory>
 					<accessory>Smart Firing Platform</accessory>
@@ -9827,8 +9806,7 @@
 					<accessory>Chameleon Coating (Rifle)</accessory>
 					<accessory>Easy Breakdown (Powered)</accessory>
 					<accessory>Electronic Firing</accessory>
-					<accessory>Retractable Bayonet</accessory>
-					<accessory>Guncam</accessory>
+					<accessory>Trigger Removal</accessory>
 				</oneof>
 			</forbidden>
 			<accessorycostmultiplier>2</accessorycostmultiplier>
@@ -10299,6 +10277,9 @@
 			<avail>2</avail>
 			<cost>50</cost>
 			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
 				<weapondetails>
 					<OR>
 						<category>Bows</category>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -8760,6 +8760,11 @@
 			<rating>0</rating>
 			<avail>6R</avail>
 			<cost>600</cost>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<required>
 				<weapondetails>
 					<OR>
@@ -8880,6 +8885,19 @@
 			<allowgear>
 				<gearcategory>Vision Enhancements</gearcategory>
 			</allowgear>
+			<source>SR5</source>
+			<page>432</page>
+		</accessory>
+		<accessory>
+			<id>036742ce-95d8-4510-b25f-5c380ef1076e</id>
+			<name>Imaging Scope (Optical)</name>
+			<mount>Top</mount>
+			<rating>0</rating>
+			<avail>2</avail>
+			<cost>300</cost>
+			<gears>
+				<usegear>Vision Magnification</usegear>
+			</gears>
 			<source>SR5</source>
 			<page>432</page>
 		</accessory>
@@ -9007,6 +9025,11 @@
 			<id>7e25eb59-3ce1-44d8-8367-527fd8c8bc1d</id>
 			<name>Smart Firing Platform</name>
 			<mount>Under</mount>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>12F</avail>
 			<cost>2000</cost>
@@ -9021,6 +9044,7 @@
 				<oneof>
 					<accessory>Ceramic/Plasteel Components</accessory>
 					<accessory>Collapsible Traditional Bow</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 				<weapondetails>
 					<type>Melee</type>
@@ -9045,6 +9069,7 @@
 				<oneof>
 					<accessory>Ceramic/Plasteel Components</accessory>
 					<accessory>Collapsible Traditional Bow</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 				<weapondetails>
 					<type>Melee</type>
@@ -9127,6 +9152,7 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9212,6 +9238,7 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9236,6 +9263,7 @@
 					<accessory>Advanced Safety System, Basic</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9260,6 +9288,7 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Basic</accessory>
 					<accessory>Advanced Safety System, Electro Shocker</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9284,6 +9313,7 @@
 					<accessory>Advanced Safety System, Self Destruct</accessory>
 					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
 					<accessory>Advanced Safety System, Basic</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<rating>0</rating>
@@ -9457,6 +9487,11 @@
 			<id>9a27efa9-f3f4-4e47-9165-76e8adbad4ba</id>
 			<name>Guncam</name>
 			<mount>Top/Under/Barrel/Side/Internal</mount>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>4</avail>
 			<cost>350</cost>
@@ -9479,6 +9514,17 @@
 			<id>21bc8b85-3fd7-4bde-ac8d-35e1fa099f21</id>
 			<name>Improved Range Finder</name>
 			<mount>Top/Under/Barrel/Side/Internal</mount>
+			<required>
+				<oneof>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+				</oneof>
+			</required>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>6</avail>
 			<cost>2000</cost>
@@ -9491,6 +9537,14 @@
 			<ammoslots>1</ammoslots>
 			<ammoreplace>10</ammoreplace>
 			<mount/>
+			<required>
+				<weapondetails>
+					<OR>
+						<ammo operation="contains">Internal source</ammo>
+						<ammo operation="contains">energy</ammo>
+					</OR>
+				</weapondetails>
+			</required>
 			<rating>0</rating>
 			<avail>14F</avail>
 			<cost>400</cost>
@@ -9503,6 +9557,14 @@
 			<ammoslots>1</ammoslots>
 			<ammoreplace>20</ammoreplace>
 			<mount/>
+			<required>
+				<weapondetails>
+					<OR>
+						<ammo operation="contains">Internal source</ammo>
+						<ammo operation="contains">energy</ammo>
+					</OR>
+				</weapondetails>
+			</required>
 			<rating>0</rating>
 			<avail>16F</avail>
 			<cost>900</cost>
@@ -9515,6 +9577,14 @@
 			<ammoslots>1</ammoslots>
 			<ammoreplace>30</ammoreplace>
 			<mount/>
+			<required>
+				<weapondetails>
+					<OR>
+						<ammo operation="contains">Internal source</ammo>
+						<ammo operation="contains">energy</ammo>
+					</OR>
+				</weapondetails>
+			</required>
 			<rating>0</rating>
 			<avail>20F</avail>
 			<cost>2500</cost>
@@ -9525,6 +9595,11 @@
 			<id>51740a3d-4464-4a38-8e2e-8858b3c1481e</id>
 			<name>Safe Target System, Base</name>
 			<mount>Top/Under/Barrel/Side/Internal</mount>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>6</avail>
 			<cost>750</cost>
@@ -9697,6 +9772,11 @@
 			<id>6c703f4e-fade-4045-9d88-ea636e1266f6</id>
 			<name>Weapon Commlink</name>
 			<mount/>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>200</cost>
@@ -9710,6 +9790,11 @@
 			<id>e09095d7-72b5-44ef-b52a-aa2de172da2f</id>
 			<name>Weapon Personality</name>
 			<mount/>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>8</avail>
 			<cost>250</cost>
@@ -9722,6 +9807,31 @@
 			<id>4821b29d-55cd-4cb1-a6e2-c51e9d3a95a1</id>
 			<name>Vintage</name>
 			<mount/>
+			<forbidden>
+				<oneof>
+					<accessory>Advanced Safety System, Basic</accessory>
+					<accessory>Advanced Safety System, Immobilization</accessory>
+					<accessory>Advanced Safety System, Self Destruct</accessory>
+					<accessory>Advanced Safety System, Explosive Self Destruct</accessory>
+					<accessory>Advanced Safety System, Electro Shocker</accessory>
+					<accessory>Weapon Personality</accessory>
+					<accessory>Weapon Commlink</accessory>
+					<accessory>Safe Target System, Base</accessory>
+					<accessory>Improved Range Finder</accessory>
+					<accessory>Smartgun System, External</accessory>
+					<accessory>Smartgun System, Internal</accessory>
+					<accessory>Smart Firing Platform</accessory>
+					<accessory>Airburst Link</accessory>
+					<accessory>Ammo Skip</accessory>
+					<accessory>Chameleon Coating (Pistol)</accessory>
+					<accessory>Chameleon Coating (Rifle)</accessory>
+					<accessory>Easy Breakdown (Powered)</accessory>
+					<accessory>Electronic Firing</accessory>
+					<accessory>Retractable Bayonet</accessory>
+					<accessory>Guncam</accessory>
+				</oneof>
+			</forbidden>
+			<accessorycostmultiplier>2</accessorycostmultiplier>
 			<rating>0</rating>
 			<avail>0</avail>
 			<cost>0</cost>
@@ -9749,6 +9859,11 @@
 			<rating>0</rating>
 			<avail>8R</avail>
 			<cost>250</cost>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<required>
 				<weapondetails>
 					<OR>
@@ -9854,6 +9969,7 @@
 			<forbidden>
 				<oneof>
 					<accessory>Ceramic/Plasteel Components</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<required>
@@ -9875,6 +9991,7 @@
 			<forbidden>
 				<oneof>
 					<accessory>Ceramic/Plasteel Components</accessory>
+					<accessory>Vintage</accessory>
 				</oneof>
 			</forbidden>
 			<required>
@@ -9936,6 +10053,11 @@
 			<id>f27402fa-2845-4314-a97d-2747b3263e0d</id>
 			<name>Easy Breakdown (Powered)</name>
 			<mount>Side</mount>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rating>0</rating>
 			<avail>10R</avail>
 			<cost>1250</cost>
@@ -9946,6 +10068,11 @@
 			<id>2da4f104-cf0c-4e0c-a001-4a6da4c2b46b</id>
 			<name>Electronic Firing</name>
 			<mount>Barrel</mount>
+			<forbidden>
+				<oneof>
+					<accessory>Vintage</accessory>
+				</oneof>
+			</forbidden>
 			<rc>1</rc>
 			<rating>0</rating>
 			<avail>10R</avail>

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -4288,19 +4288,18 @@ namespace Chummer
 			}
 			if (objPowerControl.PowerName == "Improved Ability (skill)")
 			{
-            foreach (Skill objSkill in _objCharacter.SkillsSection.Skills)
-            {
-                foreach (Power objPower in _objCharacter.Powers)
+                foreach (Skill objSkill in _objCharacter.SkillsSection.Skills)
+                {
+                    foreach (Power objPower in _objCharacter.Powers)
                     {
-						if (objPower.Extra == objSkill.Name || (objSkill.IsExoticSkill && objPower.Extra == (objSkill.DisplayName + " (" + objSkill.Specialization +")")))
-							{
-                        double intImprovedAbilityMaximum = objSkill.Rating + (objSkill.Rating / 2);
-                        intImprovedAbilityMaximum = Convert.ToInt32(Math.Ceiling(intImprovedAbilityMaximum));
-                        objPower.MaxLevels = Convert.ToInt32(Math.Ceiling(intImprovedAbilityMaximum));
-                        objPowerControl.nudRating.Maximum = Convert.ToInt32(Math.Ceiling(intImprovedAbilityMaximum));
+                        if (objPower.Extra == objSkill.Name || (objSkill.IsExoticSkill && objPower.Extra == (objSkill.DisplayName + " (" + objSkill.Specialization +")")))
+						{
+                            int intImprovedAbilityMaximum = (3 * objSkill.Rating + 1) / 2;
+                            objPower.MaxLevels = intImprovedAbilityMaximum;
+                            objPowerControl.nudRating.Maximum = intImprovedAbilityMaximum;
+                        }
                     }
-            }
-				}
+			    }
 			}
 
 			UpdateCharacterInfo();
@@ -6413,7 +6412,7 @@ namespace Chummer
                     dblMultiplier -= 0.1;
                 dblMultiplier = Math.Round(dblMultiplier, 2);
 
-                int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+                int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
                 if (intKarmaExpense > _objCharacter.Karma)
                 {
@@ -6489,7 +6488,7 @@ namespace Chummer
                     }
                 }
 
-                int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+                int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
                 string strInitTip = LanguageManager.Instance.GetString("Tip_ImproveInitiateGrade").Replace("{0}", (_objCharacter.InitiateGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
                 tipTooltip.SetToolTip(cmdAddMetamagic, strInitTip);
@@ -6510,7 +6509,7 @@ namespace Chummer
 					dblMultiplier -= 0.1;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
 
-                int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+                int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
                 if (intKarmaExpense > _objCharacter.Karma)
                 {
@@ -6560,7 +6559,7 @@ namespace Chummer
                     }
                 }
 
-                int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+                int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
                 string strInitTip = LanguageManager.Instance.GetString("Tip_ImproveSubmersionGrade").Replace("{0}", (_objCharacter.SubmersionGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
                 tipTooltip.SetToolTip(cmdAddMetamagic, strInitTip);
@@ -18927,7 +18926,7 @@ namespace Chummer
 				double dblMultiplier = 1.0;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
 
-				int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+				int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
 				if (intKarmaExpense > _objCharacter.Karma)
 				{
@@ -18977,7 +18976,7 @@ namespace Chummer
 					}
 				}
 
-				int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+				int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
 				string strInitTip = LanguageManager.Instance.GetString("Tip_ImproveInitiateGrade").Replace("{0}", (_objCharacter.InitiateGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
 				tipTooltip.SetToolTip(cmdAddMetamagic, strInitTip);
@@ -18995,7 +18994,7 @@ namespace Chummer
 				double dblMultiplier = 1.0;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
 
-				int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+				int intKarmaExpense = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
 				if (intKarmaExpense > _objCharacter.Karma)
 				{
@@ -19045,7 +19044,7 @@ namespace Chummer
 					}
 				}
 
-				int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble((10 + ((_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+				int intAmount = Convert.ToInt32(Math.Ceiling(Convert.ToDouble(10 + (_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
 				string strInitTip = LanguageManager.Instance.GetString("Tip_ImproveSubmersionGrade").Replace("{0}", (_objCharacter.SubmersionGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
 				tipTooltip.SetToolTip(cmdAddMetamagic, strInitTip);
@@ -21452,11 +21451,6 @@ namespace Chummer
                     if (_objCharacter.DEPEnabled)
                         intMainAttribute = _objCharacter.DEP.TotalValue;
                     string strPersonaTip = "";
-                    int intFirewall = _objCharacter.WIL.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaFirewall);
-                    int intResponse = _objCharacter.INT.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaResponse);
-                    int intSignal = Convert.ToInt32(Math.Ceiling((Convert.ToDecimal(intMainAttribute, GlobalOptions.Instance.CultureInfo) / 2))) + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSignal);
-                    int intSystem = _objCharacter.LOG.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaSystem);
-                    int intBiofeedback = _objCharacter.CHA.TotalValue + _objImprovementManager.ValueOf(Improvement.ImprovementType.LivingPersonaBiofeedback);
 
                     lblLivingPersonaDeviceRating.Text = intMainAttribute.ToString();
                     strPersonaTip = "RES (" + intMainAttribute.ToString() + ")";
@@ -25550,8 +25544,9 @@ namespace Chummer
 		{
 			double dblMultiplier = 1.0;
 			int intAmount = 0;
+            string strInitTip = "";
 
-			if (_objCharacter.MAGEnabled)
+            if (_objCharacter.MAGEnabled)
 			{
 				if (chkInitiationGroup.Checked)
 					dblMultiplier -= 0.1;
@@ -25560,8 +25555,10 @@ namespace Chummer
 				if (chkInitiationSchooling.Checked)
 					dblMultiplier -= 0.1;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
-				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble((10 + ((_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
-			}
+				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble(10 + (_objCharacter.InitiateGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
+
+                strInitTip = LanguageManager.Instance.GetString("Tip_ImproveInitiateGrade").Replace("{0}", (_objCharacter.InitiateGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
+            }
 			else
 			{
 				if (chkInitiationGroup.Checked)
@@ -25571,14 +25568,10 @@ namespace Chummer
 				if (chkInitiationSchooling.Checked)
 					dblMultiplier -= 0.1;
 				dblMultiplier = Math.Round(dblMultiplier, 2);
-				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble((10 + ((_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation)), GlobalOptions.Instance.CultureInfo) * dblMultiplier));
-			}
+				intAmount = Convert.ToInt32(Math.Floor(Convert.ToDouble(10 + (_objCharacter.SubmersionGrade + 1) * _objOptions.KarmaInitiation, GlobalOptions.Instance.CultureInfo) * dblMultiplier));
 
-			string strInitTip = "";
-			if (_objCharacter.MAGEnabled)
-				strInitTip = LanguageManager.Instance.GetString("Tip_ImproveInitiateGrade").Replace("{0}", (_objCharacter.InitiateGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
-			else
-				strInitTip = LanguageManager.Instance.GetString("Tip_ImproveSubmersionGrade").Replace("{0}", (_objCharacter.SubmersionGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
+                strInitTip = LanguageManager.Instance.GetString("Tip_ImproveSubmersionGrade").Replace("{0}", (_objCharacter.SubmersionGrade + 1).ToString()).Replace("{1}", intAmount.ToString());
+            }
 
 			tipTooltip.SetToolTip(cmdAddMetamagic, strInitTip);
 		}


### PR DESCRIPTION
Nightly Changes:

- Removed Skull cyberlimbs from Cyberlimb Headware Override custom content (because they are identical to the non-overriden entries), added Centaur Full Leg to the list.
- Updated the nodes in Cyberlimb Headware Override custom content to be consistent with the new system that allows for cyberware to come with existing subsystems by default.

Application Changes:

- Fixed an issue with Depth not updating properly when changing to and/or from a Depth-enabled metatype.
- Fixed the metatype cost label in the sidebar not updating properly when loading characters with non-karma build methods and creating characters in life module build methods.
- Fixed an issue with some Depth-linked improvements not being handled properly.
- Improvements now have a "target" member string.
- Optimized the improvement removal code for size, readability, and portability.
- Fixed the improvement for swapping the attributes of a skill. The results of such an improvement show up in the skill's dice tooltip.
- Added an improvement for the swapping of attributes of a skill for a particular specialization. The results of such an improvement show up in the skill's dice tooltip.
- Corrected the Condition Monitors of vehicles to use modified values for Body and Device Rating instead of only base values.
- Corrected the Speed and Handling of vehicles to use modified values for Body instead of only base values.
- Corrected the Device Rating of vehicles to be generated from Pilot rating instead of a base value of 3.
- Optimized away some leftovers from SR4a that were taking up CPU time and lines.
- Performed minor speed optimizations related to rounding of integer division results.
- Fixed a crash when creating a piece of cyberware at a rating above its maximum or below its minimum.

Data Changes:

- Vintage quality now properly doubles accessory cost and is mutually exclusive with electronic accessories.
- Peak-Discharge Battery Packs no longer appear in the list of available accessories for weapons that cannot use them.
- Added an item for an Optical Imaging Scope, just like how there is one for Optical Binoculars in the gear section.
- Improved Range Finder now properly requires a Smartgun accessory.
- Corrected Ammo Drone to come standard with a rating 2 Maneuvering Autosoft.
- Added a vehicle mod for the illegal Reloading Drone autosoft for reloading forbidden weapons that costs 250.
- Added an entry for a Smart Wig with an integrated Trode Net that costs 100 extra.
- Added an improvement for the Intimidation limit bonus for Voice Warper.
- Master Debater and Empathic Listener now have their effects represented in skill dice pool tooltips.
- Cybereyes and cyberears now come standard with Image Link and Sound Link respectively.