### PR TITLE
Small character sheet fixes

### DIFF
--- a/Chummer/sheets/Shadowrun 5 Base.xslt
+++ b/Chummer/sheets/Shadowrun 5 Base.xslt
@@ -634,9 +634,9 @@
 				</div>
 
 				<div class="block" id="LimitsBlock">
-					<table width="100%" cellspacing="0" cellpadding="0" class="tableborder">
+					<table width="100%" cellspacing="0" cellpadding="0">
 						<tr>
-							<td width="100%">
+							<td width="100%" class="tableborder">
 								<table width="100%" cellspacing="0" cellpadding="0" border="0">
 									<tr>
 										<td width="25%" style="text-align:center;" valign="top">
@@ -1565,10 +1565,10 @@
                       <td class="rowsummary" colspan="3">
                         AI PROGRAMS AND ADVANCED PROGRAMS<span
 												class="rowsummarybutton"
-												onClick="showhide(this,'ProgramBlock');"
+												onClick="showhide(this,'AIProgramBlock');"
 												colspan="1">Show: YES</span>
                         <span class="rowsummarybutton"
-												onClick="zalomit(this,'ProgramBlock');"
+												onClick="zalomit(this,'AIProgramBlock');"
 												colspan="1">Page Break: NO</span>
                       </td>
                     </tr>

--- a/Chummer/sheets/de/Shadowrun 5 Base.xslt
+++ b/Chummer/sheets/de/Shadowrun 5 Base.xslt
@@ -549,8 +549,8 @@
 				<div class="block" id="LimitsBlock">
 					<table width="100%" cellspacing="0" cellpadding="0" border="0">
 						<tr>
-							<td width="100%">
-								<table width="100%" cellspacing="0" cellpadding="0" border="0" class="tableborder">
+							<td width="100%" class="tableborder">
+								<table width="100%" cellspacing="0" cellpadding="0" border="0">
 									<tr>
 										<td width="25%" style="text-align:center;" valign="top">
 											<strong>Körperliches Limit: <xsl:value-of
@@ -1317,8 +1317,8 @@
                     <tr>
                       <td class="rowsummary" colspan="3">
                         KI Programme und fortgeschrittene Programme
-                        <span class="rowsummarybutton" onClick="showhide(this,'ProgramBlock');" colspan="1">Zeigen: Ja</span>
-                        <span class="rowsummarybutton" onClick="zalomit(this,'ProgramBlock');" colspan="1">Seitenumbruch: Nein</span>
+                        <span class="rowsummarybutton" onClick="showhide(this,'AIProgramBlock');" colspan="1">Zeigen: Ja</span>
+                        <span class="rowsummarybutton" onClick="zalomit(this,'AIProgramBlock');" colspan="1">Seitenumbruch: Nein</span>
                       </td>
                     </tr>
                   </table>


### PR DESCRIPTION
- Moved table="tableborder" attribute of LimitBlock so that the
horizontal spacer is after the block and not inside of it.
- Corrected block id (AIProgramBlock instead of ProgramBlock) for show
and page break switching of the AIProgramBlock.