### PR TITLE
Fixed #1377

### DIFF
--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
@@ -255,17 +255,17 @@ namespace Chummer
 				lblRC.Visible = false;
 				lblRCLabel.Visible = false;
 			}
-		    int intMaxRating;
+		  int intMaxRating;
 			if (int.TryParse(objXmlAccessory["rating"]?.InnerText, out intMaxRating) && intMaxRating > 1)
 			{
 				nudRating.Enabled = true;
 				nudRating.Visible = true;
 				lblRatingLabel.Visible = true;
 				nudRating.Maximum = intMaxRating;
-            }
+      }
 			else
 			{
-				nudRating.Value = intMaxRating;
+			  nudRating.Enabled = false;
 				nudRating.Visible = false;
 				lblRatingLabel.Visible = false;
 			}
@@ -477,7 +477,15 @@ namespace Chummer
 		{
 			get
 			{
-				return nudRating.Value.ToString(GlobalOptions.CultureInfo);
+			  if (nudRating.Enabled)
+			  {
+			    return nudRating.Value.ToString(GlobalOptions.CultureInfo);
+			  }
+			  else
+			  {
+          // Display Rating for items without one as 0
+			    return 0.ToString(GlobalOptions.CultureInfo);
+			  }
 			}
 		}
 

--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
@@ -255,17 +255,17 @@ namespace Chummer
 				lblRC.Visible = false;
 				lblRCLabel.Visible = false;
 			}
-		  int intMaxRating;
+			int intMaxRating;
 			if (int.TryParse(objXmlAccessory["rating"]?.InnerText, out intMaxRating) && intMaxRating > 1)
 			{
 				nudRating.Enabled = true;
 				nudRating.Visible = true;
 				lblRatingLabel.Visible = true;
 				nudRating.Maximum = intMaxRating;
-      }
+			}
 			else
 			{
-			  nudRating.Enabled = false;
+				nudRating.Enabled = false;
 				nudRating.Visible = false;
 				lblRatingLabel.Visible = false;
 			}
@@ -477,15 +477,15 @@ namespace Chummer
 		{
 			get
 			{
-			  if (nudRating.Enabled)
-			  {
-			    return nudRating.Value.ToString(GlobalOptions.CultureInfo);
-			  }
-			  else
-			  {
-          // Display Rating for items without one as 0
-			    return 0.ToString(GlobalOptions.CultureInfo);
-			  }
+				if (nudRating.Enabled)
+				{
+					return nudRating.Value.ToString(GlobalOptions.CultureInfo);
+				}
+				else
+				{
+					// Display Rating for items without one as 0
+					return 0.ToString(GlobalOptions.CultureInfo);
+				}
 			}
 		}
 

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -8747,8 +8747,8 @@ namespace Chummer
 
 		private void tsWeaponAddAccessory_Click(object sender, EventArgs e)
 		{
-            // Make sure a parent item is selected, then open the Select Accessory window.
-            if (treCyberware.SelectedNode == null || treCyberware.SelectedNode.Level <= 0)
+      // Make sure a parent item is selected, then open the Select Accessory window.
+      if (treWeapons.SelectedNode == null || treWeapons.SelectedNode.Level <= 0)
 			{
 				MessageBox.Show(LanguageManager.Instance.GetString("Message_SelectWeaponAccessory"), LanguageManager.Instance.GetString("MessageTitle_SelectWeapon"), MessageBoxButtons.OK, MessageBoxIcon.Information);
 				return;

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -8747,8 +8747,8 @@ namespace Chummer
 
 		private void tsWeaponAddAccessory_Click(object sender, EventArgs e)
 		{
-      // Make sure a parent item is selected, then open the Select Accessory window.
-      if (treWeapons.SelectedNode == null || treWeapons.SelectedNode.Level <= 0)
+      		// Make sure a parent item is selected, then open the Select Accessory window.
+      		if (treWeapons.SelectedNode == null || treWeapons.SelectedNode.Level <= 0)
 			{
 				MessageBox.Show(LanguageManager.Instance.GetString("Message_SelectWeaponAccessory"), LanguageManager.Instance.GetString("MessageTitle_SelectWeapon"), MessageBoxButtons.OK, MessageBoxIcon.Information);
 				return;


### PR DESCRIPTION
 - Now properly checks for the Weapon tree node instead of the Cyberware tree node.
 - Accessories without rating now get displayed with rating 0 instead of 1 as probably intended