### PR TITLE
Small character sheet fixes

### DIFF
--- a/Chummer/sheets/Game Master Summary set.xslt
+++ b/Chummer/sheets/Game Master Summary set.xslt
@@ -251,7 +251,7 @@
 											<tr>
 												<td><strong><xsl:value-of select="$lang.Weapon"/></strong></td>
 												<td align="center"><strong><xsl:value-of select="$lang.Pool"/></strong></td>
-												<td align="center"><strong><xsl:value-of select="$lang.Pool"/></strong></td>
+												<td align="center"><strong><xsl:value-of select="$lang.Accuracy"/></strong></td>
 												<td align="center"><strong><xsl:value-of select="$lang.Damage"/></strong></td>
 												<td align="center"><strong><xsl:value-of select="$lang.AP"/></strong></td>
 												<td align="center"><strong><xsl:value-of select="$lang.Mode"/></strong></td>

--- a/Chummer/sheets/Vehicles set.xslt
+++ b/Chummer/sheets/Vehicles set.xslt
@@ -131,7 +131,7 @@
 									</tr>
 									<tr><td colspan="100%" class="hseparator"></td></tr>
 									<tr>
-										<td class="AttribName"><xsl:value-of select="$lang.Body"/></td>
+										<td class="AttribName"><xsl:value-of select="$lang.VehicleBody"/></td>
 										<td class="AttribValue"><xsl:value-of select="body"/></td>
 									</tr>
 									<tr>

--- a/Chummer/sheets/Vehicles.xsl
+++ b/Chummer/sheets/Vehicles.xsl
@@ -17,4 +17,5 @@
 
 	<!-- Set global variables -->
 	<xsl:variable name="lang" select="'en'"/>
+	<xsl:variable name="ProduceNotes" select="true()"/>
 </xsl:stylesheet>

--- a/Chummer/sheets/de/Fahrzeuge.xsl
+++ b/Chummer/sheets/de/Fahrzeuge.xsl
@@ -17,4 +17,5 @@
 
 	<!-- Set global variables -->
 	<xsl:variable name="lang" select="'de'"/>
+	<xsl:variable name="ProduceNotes" select="true()"/>
 </xsl:stylesheet>

--- a/Chummer/sheets/de/xz.de.xslt
+++ b/Chummer/sheets/de/xz.de.xslt
@@ -137,6 +137,7 @@
 	<xsl:variable name="lang.Notoriety"		select="'Schlechter Ruf'"/>
 	<xsl:variable name="lang.Nuyen"			select="'Nuyen'"/>
 	<xsl:variable name="lang.Other"			select="'Andere'"/>
+	<xsl:variable name="lang.OVR"			select="'ÜbS'"/>
 	<xsl:variable name="lang.Permanent"		select="'Permanent'"/>
 	<xsl:variable name="lang.Persona"		select="'Persona'"/>
 	<xsl:variable name="lang.Physical"		select="'Körperlich'"/>

--- a/Chummer/sheets/fr/Véhicules.xsl
+++ b/Chummer/sheets/fr/Véhicules.xsl
@@ -17,4 +17,5 @@
 
 	<!-- Set global variables -->
 	<xsl:variable name="lang" select="'fr'"/>
+	<xsl:variable name="ProduceNotes" select="true()"/>
 </xsl:stylesheet>

--- a/Chummer/sheets/fr/xz.fr.xslt
+++ b/Chummer/sheets/fr/xz.fr.xslt
@@ -137,6 +137,7 @@
 	<xsl:variable name="lang.Notoriety"		select="'Rumeur'"/>
 	<xsl:variable name="lang.Nuyen"			select="'Nuyen'"/>
 	<xsl:variable name="lang.Other"			select="'Autre'"/>
+	<xsl:variable name="lang.OVR"			select="'OVR'"/>
 	<xsl:variable name="lang.Permanent"		select="'Permanent'"/>
 	<xsl:variable name="lang.Persona"		select="'Persona'"/>
 	<xsl:variable name="lang.Physical"		select="'Physique'"/>

--- a/Chummer/sheets/jp/Vehicles.xsl
+++ b/Chummer/sheets/jp/Vehicles.xsl
@@ -17,4 +17,5 @@
 
 	<!-- Set global variables -->
 	<xsl:variable name="lang" select="'jp'"/>
+	<xsl:variable name="ProduceNotes" select="true()"/>
 </xsl:stylesheet>

--- a/Chummer/sheets/jp/xz.jp.xslt
+++ b/Chummer/sheets/jp/xz.jp.xslt
@@ -137,6 +137,7 @@
 	<xsl:variable name="lang.Notoriety"		select="'Notoriety'"/>
 	<xsl:variable name="lang.Nuyen"			select="'Nuyen'"/>
 	<xsl:variable name="lang.Other"			select="'Other'"/>
+	<xsl:variable name="lang.OVR"			select="'OVR'"/>
 	<xsl:variable name="lang.Permanent"		select="'Permanent'"/>
 	<xsl:variable name="lang.Persona"		select="'Persona'"/>
 	<xsl:variable name="lang.Physical"		select="'Physical'"/>

--- a/Chummer/sheets/xt.ConditionMonitor.xslt
+++ b/Chummer/sheets/xt.ConditionMonitor.xslt
@@ -167,11 +167,11 @@
 				<xsl:when test="$LowBox &gt; ($TotalBoxes + $OverFlow)">&#160;</xsl:when>
 				<!-- Last Box of OverFlow needs DEAD -->
 				<xsl:when test="$LowBox = ($TotalBoxes + $OverFlow) and $OverFlow &gt; 0">
-					<text><br/>DEAD</text>
+					<text><br/><xsl:value-of select="$lang.Dead"/></text>
 				</xsl:when>
 				<!-- Boxes of OverFlow are Marked OVR -->
 				<xsl:when test="$LowBox &gt; $TotalBoxes">
-					<text><br/>OVR&#160;</text>
+					<text><br/><xsl:value-of select="$lang.OVR"/></text>
 				</xsl:when>
 				<!-- Last Normal Box -->
 				<xsl:when test="$LowBox = $TotalBoxes">

--- a/Chummer/sheets/xz.en-us.xslt
+++ b/Chummer/sheets/xz.en-us.xslt
@@ -137,6 +137,7 @@
 	<xsl:variable name="lang.Notoriety"		select="'Notoriety'"/>
 	<xsl:variable name="lang.Nuyen"			select="'Nuyen'"/>
 	<xsl:variable name="lang.Other"			select="'Other'"/>
+	<xsl:variable name="lang.OVR"			select="'OVR'"/>
 	<xsl:variable name="lang.Permanent"		select="'Permanent'"/>
 	<xsl:variable name="lang.Persona"		select="'Persona'"/>
 	<xsl:variable name="lang.Physical"		select="'Physical'"/>


### PR DESCRIPTION
- Changed condition monitor to use translated strings for "DEAD" and "OVR". New variable "lang.OVR" has been added for that.
- Fixed used label in game master summary weapon table (was Pool instead of Accuracy).
- Fixed used body label in vehicle sheet (different terms in other languages).
- Added "ProduceNotes" variable to vehicle sheets (all languages). I broke that sheet when I re-added notes to ranged weapons.