### PR TITLE
Minor Bioware.xml Fixes - Biosculpting Essence & Availability

### DIFF
--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -923,7 +923,7 @@
 			<id>a4ca355b-6188-42c1-88c7-93947f233314</id>
 			<name>Severe Biosculpting Modification</name>
 			<category>Biosculpting</category>
-			<ess>0</ess>
+			<ess>0.25</ess>
 			<capacity>0</capacity>
 			<avail>2</avail>
 			<cost>Variable(2000-10000)</cost>

--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -911,7 +911,7 @@
 			<category>Biosculpting</category>
 			<ess>0.1</ess>
 			<capacity>0</capacity>
-			<avail>2</avail>
+			<avail>4</avail>
 			<cost>Variable(500-2000)</cost>
 			<bonus>
 				<selecttext />
@@ -925,7 +925,7 @@
 			<category>Biosculpting</category>
 			<ess>0.25</ess>
 			<capacity>0</capacity>
-			<avail>2</avail>
+			<avail>8</avail>
 			<cost>Variable(2000-10000)</cost>
 			<bonus>
 				<selecttext />


### PR DESCRIPTION
Simple typo fixes. This would change the Essence cost of Severe Biosculpting Modification from 0 to 0.25, and would change the Availability of Moderate and Severe Biosculpting to 4 and 8 respectively, from 2.

(SR5 page reference: Chrome Flesh, pg 108. The Essence cost for Severe is listed as "0.25-0.5" in the book, and the Availability for Severe is listed as "8-12", but unless that is accomplished done by using a Rating, this seems to make the most sense.)