### PR TITLE
Small character sheet fixes

### DIFF
--- a/Chummer/lang/de_data.xml
+++ b/Chummer/lang/de_data.xml
@@ -2627,31 +2627,31 @@
 			<metatype>
 				<id>47428a29-890f-4b3a-9d18-d8c2e581f1b4</id>
 				<name>Dog</name>
-				<page>404</page>
+				<page>343</page>
 				<translate>Hund</translate>
 			</metatype>
 			<metatype>
 				<id>7983859b-5c38-47b7-b127-2649f0c8c1b0</id>
 				<name>Great Cat</name>
-				<page>404</page>
+				<page>343</page>
 				<translate>Großkatze</translate>
 			</metatype>
 			<metatype>
 				<id>d4a66987-de45-4bd1-a1f3-c8573ba6d8cf</id>
 				<name>Horse</name>
-				<page>404</page>
+				<page>343</page>
 				<translate>Pferd</translate>
 			</metatype>
 			<metatype>
 				<id>a38329e9-cdfb-441f-9594-1ecf5fcdd787</id>
 				<name>Shark</name>
-				<page>404</page>
+				<page>343</page>
 				<translate>Hai</translate>
 			</metatype>
 			<metatype translated="True">
 				<id>d6da129f-65b2-4fb4-aae3-a73e6937a2a6</id>
 				<name>Wolf</name>
-				<page>404</page>
+				<page>343</page>
 				<translate>Wolf</translate>
 			</metatype>
 			<metatype>
@@ -3869,25 +3869,25 @@
 			<metatype translated="True">
 				<id>f03dcf11-8a65-4452-912b-d42bc78e3e93</id>
 				<name>Barghest</name>
-				<page>404</page>
+				<page>299</page>
 				<translate>Barghest</translate>
 			</metatype>
 			<metatype>
 				<id>6fb20284-a25b-4eb7-82d5-e20f79d345e3</id>
 				<name>Devil Rat</name>
-				<page>407</page>
-				<translate>Teufelsratte</translate>
+				<page>299</page>
+				<translate>Riesenratte</translate>
 			</metatype>
 			<metatype>
 				<id>d3a7e0fe-46bc-4c30-a287-b159eb53f0f8</id>
 				<name>Ghoul</name>
-				<page>406</page>
+				<page>299</page>
 				<translate>Ghul</translate>
 			</metatype>
 			<metatype>
 				<id>2403521d-8a3b-4e73-8562-2a5978841478</id>
 				<name>Hell Hound</name>
-				<page>406</page>
+				<page>300</page>
 				<translate>Höllenhund</translate>
 			</metatype>
 			<metatype translated="True">
@@ -3905,7 +3905,7 @@
 			<metatype translated="True">
 				<id>6d15c952-542a-429d-9b56-51fc21ebb138</id>
 				<name>Sasquatch</name>
-				<page>406</page>
+				<page>300</page>
 				<translate>Sasquatch</translate>
 			</metatype>
 			<metatype>
@@ -3917,7 +3917,7 @@
 			<metatype>
 				<id>c901c62b-30cb-4a55-89cc-95af3321c297</id>
 				<name>Vampire</name>
-				<page>407</page>
+				<page>301</page>
 				<translate>Vampir</translate>
 			</metatype>
 			<metatype translated="True">
@@ -4139,7 +4139,7 @@
 			<metatype>
 				<id>f023c6db-03f3-4dba-b7ee-7e64f71f7d5b</id>
 				<name>Cockatrice</name>
-				<page>407</page>
+				<page>129</page>
 				<translate>Schreckhahn</translate>
 			</metatype>
 			<metatype>
@@ -4373,7 +4373,7 @@
 			<metatype translated="True">
 				<id>49434a88-ced1-46e3-b650-b0bd12ddd480</id>
 				<name>Basilisk</name>
-				<page>405</page>
+				<page>148</page>
 				<translate>Basilisk</translate>
 			</metatype>
 			<metatype>
@@ -4607,7 +4607,7 @@
 			<metatype>
 				<id>7f0f9028-4351-4729-a363-ff8533895d1c</id>
 				<name>Spirit of Air</name>
-				<page>303</page>
+				<page>302</page>
 				<translate>Luftgeist</translate>
 			</metatype>
 			<metatype>
@@ -4619,7 +4619,7 @@
 			<metatype>
 				<id>4a80bfc5-da03-4896-9722-2a785d32095e</id>
 				<name>Spirit of Beasts</name>
-				<page>303</page>
+				<page>302</page>
 				<translate>Geist des Tieres</translate>
 			</metatype>
 			<metatype>
@@ -4631,7 +4631,7 @@
 			<metatype>
 				<id>285885ed-d2cb-4c02-976c-a8f81efa67cb</id>
 				<name>Spirit of Earth</name>
-				<page>302</page>
+				<page>303</page>
 				<translate>Erdgeist</translate>
 			</metatype>
 			<metatype>
@@ -4643,7 +4643,7 @@
 			<metatype>
 				<id>3232c4f1-0b22-4799-8c80-392392f9af38</id>
 				<name>Spirit of Fire</name>
-				<page>302</page>
+				<page>303</page>
 				<translate>Feuergeist</translate>
 			</metatype>
 			<metatype>
@@ -5045,13 +5045,13 @@
 			<metatype>
 				<id>805e79e4-4a6c-4877-b764-b07566414180</id>
 				<name>Eastern Dragon</name>
-				<page>409</page>
+				<page>303</page>
 				<translate>Östlicher Drache</translate>
 			</metatype>
 			<metatype>
 				<id>b6997b8d-b524-4d7d-a35c-8502e71fc9b6</id>
 				<name>Feathered Serpent</name>
-				<page>408</page>
+				<page>304</page>
 				<translate>Gefiederte Schlange</translate>
 			</metatype>
 			<metatype translated="True">
@@ -5063,7 +5063,7 @@
 			<metatype>
 				<id>26781a84-eab5-4617-962b-3c1ea14e8f7c</id>
 				<name>Western Dragon</name>
-				<page>409</page>
+				<page>303</page>
 				<translate>Westlicher Drache</translate>
 			</metatype>
 			<metatype>
@@ -5399,31 +5399,31 @@
 			<metatype>
 				<id>8db4f865-57b6-4363-8d1d-d2979df47cac</id>
 				<name>Courier Sprite</name>
-				<page>256</page>
+				<page>242</page>
 				<translate>Kurier-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>1eabd4d6-b759-4e89-8478-1d327e2755c3</id>
 				<name>Crack Sprite</name>
-				<page>255</page>
+				<page>242</page>
 				<translate>Infiltrator-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>4742c36a-baa9-467b-b2c1-9dc6889a46e2</id>
 				<name>Data Sprite</name>
-				<page>255</page>
+				<page>242</page>
 				<translate>Daten-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>72b6f335-4351-4af7-b103-350cb15d2bca</id>
 				<name>Fault Sprite</name>
-				<page>256</page>
+				<page>242</page>
 				<translate>Stör-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>1a34d4b2-2055-47e7-b750-39aa724ce19c</id>
 				<name>Machine Sprite</name>
-				<page>256</page>
+				<page>242</page>
 				<translate>Maschinen-Sprite</translate>
 			</metatype>
 			<metatype>
@@ -5554,7 +5554,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Air</name>
-				<page>303</page>
+				<page>348</page>
 				<translate>Luftgeist</translate>
 			</metatype>
 			<metatype>
@@ -5564,7 +5564,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Beasts</name>
-				<page>303</page>
+				<page>348</page>
 				<translate>Geist des Tieres</translate>
 			</metatype>
 			<metatype>
@@ -5574,7 +5574,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Earth</name>
-				<page>302</page>
+				<page>347</page>
 				<translate>Erdgeist</translate>
 			</metatype>
 			<metatype>
@@ -5584,7 +5584,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Fire</name>
-				<page>302</page>
+				<page>347</page>
 				<translate>Feuergeist</translate>
 			</metatype>
 			<metatype>
@@ -5594,7 +5594,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Man</name>
-				<page>303</page>
+				<page>348</page>
 				<translate>Geist des Menschen</translate>
 			</metatype>
 			<metatype>
@@ -5604,7 +5604,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Water</name>
-				<page>303</page>
+				<page>348</page>
 				<translate>Wassergeist</translate>
 			</metatype>
 			<metatype>
@@ -5619,12 +5619,12 @@
 			</metatype>
 			<metatype>
 				<name>Eastern Dragon</name>
-				<page>409</page>
+				<page>350</page>
 				<translate>Östlicher Drache</translate>
 			</metatype>
 			<metatype>
 				<name>Feathered Serpent</name>
-				<page>408</page>
+				<page>348</page>
 				<translate>Gefiederte Schlange</translate>
 			</metatype>
 			<metatype>
@@ -5634,7 +5634,7 @@
 			</metatype>
 			<metatype>
 				<name>Western Dragon</name>
-				<page>409</page>
+				<page>350</page>
 				<translate>Westlicher Drache</translate>
 			</metatype>
 			<metatype>
@@ -5659,27 +5659,27 @@
 			</metatype>
 			<metatype>
 				<name>Courier Sprite</name>
-				<page>256</page>
+				<page>282</page>
 				<translate>Kurier-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Crack Sprite</name>
-				<page>255</page>
+				<page>282</page>
 				<translate>Infiltrator-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Data Sprite</name>
-				<page>255</page>
+				<page>282</page>
 				<translate>Daten-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Fault Sprite</name>
-				<page>256</page>
+				<page>282</page>
 				<translate>Stör-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Machine Sprite</name>
-				<page>256</page>
+				<page>282</page>
 				<translate>Maschinen-Sprite</translate>
 			</metatype>
 			<metatype translated="True">

--- a/Chummer/lang/de_data.xml
+++ b/Chummer/lang/de_data.xml
@@ -2627,31 +2627,31 @@
 			<metatype>
 				<id>47428a29-890f-4b3a-9d18-d8c2e581f1b4</id>
 				<name>Dog</name>
-				<page>343</page>
+				<page>404</page>
 				<translate>Hund</translate>
 			</metatype>
 			<metatype>
 				<id>7983859b-5c38-47b7-b127-2649f0c8c1b0</id>
 				<name>Great Cat</name>
-				<page>343</page>
+				<page>404</page>
 				<translate>Großkatze</translate>
 			</metatype>
 			<metatype>
 				<id>d4a66987-de45-4bd1-a1f3-c8573ba6d8cf</id>
 				<name>Horse</name>
-				<page>343</page>
+				<page>404</page>
 				<translate>Pferd</translate>
 			</metatype>
 			<metatype>
 				<id>a38329e9-cdfb-441f-9594-1ecf5fcdd787</id>
 				<name>Shark</name>
-				<page>343</page>
+				<page>404</page>
 				<translate>Hai</translate>
 			</metatype>
 			<metatype translated="True">
 				<id>d6da129f-65b2-4fb4-aae3-a73e6937a2a6</id>
 				<name>Wolf</name>
-				<page>343</page>
+				<page>404</page>
 				<translate>Wolf</translate>
 			</metatype>
 			<metatype>
@@ -3869,25 +3869,25 @@
 			<metatype translated="True">
 				<id>f03dcf11-8a65-4452-912b-d42bc78e3e93</id>
 				<name>Barghest</name>
-				<page>299</page>
+				<page>404</page>
 				<translate>Barghest</translate>
 			</metatype>
 			<metatype>
 				<id>6fb20284-a25b-4eb7-82d5-e20f79d345e3</id>
 				<name>Devil Rat</name>
-				<page>299</page>
-				<translate>Riesenratte</translate>
+				<page>407</page>
+				<translate>Teufelsratte</translate>
 			</metatype>
 			<metatype>
 				<id>d3a7e0fe-46bc-4c30-a287-b159eb53f0f8</id>
 				<name>Ghoul</name>
-				<page>299</page>
+				<page>406</page>
 				<translate>Ghul</translate>
 			</metatype>
 			<metatype>
 				<id>2403521d-8a3b-4e73-8562-2a5978841478</id>
 				<name>Hell Hound</name>
-				<page>300</page>
+				<page>406</page>
 				<translate>Höllenhund</translate>
 			</metatype>
 			<metatype translated="True">
@@ -3905,7 +3905,7 @@
 			<metatype translated="True">
 				<id>6d15c952-542a-429d-9b56-51fc21ebb138</id>
 				<name>Sasquatch</name>
-				<page>300</page>
+				<page>406</page>
 				<translate>Sasquatch</translate>
 			</metatype>
 			<metatype>
@@ -3917,7 +3917,7 @@
 			<metatype>
 				<id>c901c62b-30cb-4a55-89cc-95af3321c297</id>
 				<name>Vampire</name>
-				<page>301</page>
+				<page>407</page>
 				<translate>Vampir</translate>
 			</metatype>
 			<metatype translated="True">
@@ -4139,7 +4139,7 @@
 			<metatype>
 				<id>f023c6db-03f3-4dba-b7ee-7e64f71f7d5b</id>
 				<name>Cockatrice</name>
-				<page>129</page>
+				<page>407</page>
 				<translate>Schreckhahn</translate>
 			</metatype>
 			<metatype>
@@ -4373,7 +4373,7 @@
 			<metatype translated="True">
 				<id>49434a88-ced1-46e3-b650-b0bd12ddd480</id>
 				<name>Basilisk</name>
-				<page>148</page>
+				<page>405</page>
 				<translate>Basilisk</translate>
 			</metatype>
 			<metatype>
@@ -4607,7 +4607,7 @@
 			<metatype>
 				<id>7f0f9028-4351-4729-a363-ff8533895d1c</id>
 				<name>Spirit of Air</name>
-				<page>302</page>
+				<page>303</page>
 				<translate>Luftgeist</translate>
 			</metatype>
 			<metatype>
@@ -4619,7 +4619,7 @@
 			<metatype>
 				<id>4a80bfc5-da03-4896-9722-2a785d32095e</id>
 				<name>Spirit of Beasts</name>
-				<page>302</page>
+				<page>303</page>
 				<translate>Geist des Tieres</translate>
 			</metatype>
 			<metatype>
@@ -4631,7 +4631,7 @@
 			<metatype>
 				<id>285885ed-d2cb-4c02-976c-a8f81efa67cb</id>
 				<name>Spirit of Earth</name>
-				<page>303</page>
+				<page>302</page>
 				<translate>Erdgeist</translate>
 			</metatype>
 			<metatype>
@@ -4643,7 +4643,7 @@
 			<metatype>
 				<id>3232c4f1-0b22-4799-8c80-392392f9af38</id>
 				<name>Spirit of Fire</name>
-				<page>303</page>
+				<page>302</page>
 				<translate>Feuergeist</translate>
 			</metatype>
 			<metatype>
@@ -5045,13 +5045,13 @@
 			<metatype>
 				<id>805e79e4-4a6c-4877-b764-b07566414180</id>
 				<name>Eastern Dragon</name>
-				<page>303</page>
+				<page>409</page>
 				<translate>Östlicher Drache</translate>
 			</metatype>
 			<metatype>
 				<id>b6997b8d-b524-4d7d-a35c-8502e71fc9b6</id>
 				<name>Feathered Serpent</name>
-				<page>304</page>
+				<page>408</page>
 				<translate>Gefiederte Schlange</translate>
 			</metatype>
 			<metatype translated="True">
@@ -5063,7 +5063,7 @@
 			<metatype>
 				<id>26781a84-eab5-4617-962b-3c1ea14e8f7c</id>
 				<name>Western Dragon</name>
-				<page>303</page>
+				<page>409</page>
 				<translate>Westlicher Drache</translate>
 			</metatype>
 			<metatype>
@@ -5399,31 +5399,31 @@
 			<metatype>
 				<id>8db4f865-57b6-4363-8d1d-d2979df47cac</id>
 				<name>Courier Sprite</name>
-				<page>242</page>
+				<page>256</page>
 				<translate>Kurier-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>1eabd4d6-b759-4e89-8478-1d327e2755c3</id>
 				<name>Crack Sprite</name>
-				<page>242</page>
+				<page>255</page>
 				<translate>Infiltrator-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>4742c36a-baa9-467b-b2c1-9dc6889a46e2</id>
 				<name>Data Sprite</name>
-				<page>242</page>
+				<page>255</page>
 				<translate>Daten-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>72b6f335-4351-4af7-b103-350cb15d2bca</id>
 				<name>Fault Sprite</name>
-				<page>242</page>
+				<page>256</page>
 				<translate>Stör-Sprite</translate>
 			</metatype>
 			<metatype>
 				<id>1a34d4b2-2055-47e7-b750-39aa724ce19c</id>
 				<name>Machine Sprite</name>
-				<page>242</page>
+				<page>256</page>
 				<translate>Maschinen-Sprite</translate>
 			</metatype>
 			<metatype>
@@ -5554,7 +5554,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Air</name>
-				<page>348</page>
+				<page>303</page>
 				<translate>Luftgeist</translate>
 			</metatype>
 			<metatype>
@@ -5564,7 +5564,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Beasts</name>
-				<page>348</page>
+				<page>303</page>
 				<translate>Geist des Tieres</translate>
 			</metatype>
 			<metatype>
@@ -5574,7 +5574,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Earth</name>
-				<page>347</page>
+				<page>302</page>
 				<translate>Erdgeist</translate>
 			</metatype>
 			<metatype>
@@ -5584,7 +5584,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Fire</name>
-				<page>347</page>
+				<page>302</page>
 				<translate>Feuergeist</translate>
 			</metatype>
 			<metatype>
@@ -5594,7 +5594,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Man</name>
-				<page>348</page>
+				<page>303</page>
 				<translate>Geist des Menschen</translate>
 			</metatype>
 			<metatype>
@@ -5604,7 +5604,7 @@
 			</metatype>
 			<metatype>
 				<name>Spirit of Water</name>
-				<page>348</page>
+				<page>303</page>
 				<translate>Wassergeist</translate>
 			</metatype>
 			<metatype>
@@ -5619,12 +5619,12 @@
 			</metatype>
 			<metatype>
 				<name>Eastern Dragon</name>
-				<page>350</page>
+				<page>409</page>
 				<translate>Östlicher Drache</translate>
 			</metatype>
 			<metatype>
 				<name>Feathered Serpent</name>
-				<page>348</page>
+				<page>408</page>
 				<translate>Gefiederte Schlange</translate>
 			</metatype>
 			<metatype>
@@ -5634,7 +5634,7 @@
 			</metatype>
 			<metatype>
 				<name>Western Dragon</name>
-				<page>350</page>
+				<page>409</page>
 				<translate>Westlicher Drache</translate>
 			</metatype>
 			<metatype>
@@ -5659,27 +5659,27 @@
 			</metatype>
 			<metatype>
 				<name>Courier Sprite</name>
-				<page>282</page>
+				<page>256</page>
 				<translate>Kurier-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Crack Sprite</name>
-				<page>282</page>
+				<page>255</page>
 				<translate>Infiltrator-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Data Sprite</name>
-				<page>282</page>
+				<page>255</page>
 				<translate>Daten-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Fault Sprite</name>
-				<page>282</page>
+				<page>256</page>
 				<translate>Stör-Sprite</translate>
 			</metatype>
 			<metatype>
 				<name>Machine Sprite</name>
-				<page>282</page>
+				<page>256</page>
 				<translate>Maschinen-Sprite</translate>
 			</metatype>
 			<metatype translated="True">

--- a/Chummer/sheets/Game Master Summary set.xslt
+++ b/Chummer/sheets/Game Master Summary set.xslt
@@ -64,7 +64,7 @@
 									<td width="9%" align="center"><strong><xsl:value-of select="$lang.INT"/></strong></td>
 									<td width="9%" align="center"><strong><xsl:value-of select="$lang.LOG"/></strong></td>
 									<td width="9%" align="center"><strong><xsl:value-of select="$lang.WIL"/></strong></td>
-									<td width="9%" align="center"><strong><xsl:value-of select="$lang.ESS"/></strong></td>
+									<td width="9%" align="center"><strong><xsl:value-of select="$lang.EDG"/></strong></td>
 									<xsl:if test="magenabled = 'True'">
 										<td width="9%" align="center"><strong><xsl:value-of select="$lang.MAG"/></strong></td>
 									</xsl:if>
@@ -488,7 +488,7 @@
 								<xsl:for-each select="cyberwares/cyberware">
 									<xsl:sort select="name" />
 									<xsl:value-of select="name" />
-									<xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/> <xsl:value-of select="rating" /></xsl:if>
+									<xsl:if test="rating != 0"><xsl:text> </xsl:text><xsl:value-of select="$lang.Rating"/><xsl:text> </xsl:text><xsl:value-of select="rating" /></xsl:if>
 									<xsl:if test="children/cyberware">
 										(<xsl:for-each select="children/cyberware">
 											<xsl:value-of select="name" />

--- a/Chummer/sheets/Shadowrun 5 set.xslt
+++ b/Chummer/sheets/Shadowrun 5 set.xslt
@@ -583,16 +583,20 @@
 												<xsl:value-of select="$lang.PhysicalTrack1"/>
 											</th>
 											<th width="3%"/>
-											<th width="46%">
+											<th width="46%" style="text-align: left">
 												<xsl:value-of select="$lang.StunTrack1"/>
 											</th>
 											<th width="2mm"/>
 										</tr>
 										<tr class="title">
 											<th/>
-											<th><xsl:value-of select="$lang.PhysicalTrack2"/></th>
+											<th style="text-align: left">
+												<xsl:value-of select="$lang.PhysicalTrack2"/>
+											</th>
 											<th/>
-											<th><xsl:value-of select="$lang.StunTrack2"/></th>
+											<th style="text-align: left">
+												<xsl:value-of select="$lang.StunTrack2"/>
+											</th>
 											<th/>
 										</tr>
 										<tr>

--- a/Chummer/sheets/xt.Expenses.xslt
+++ b/Chummer/sheets/xt.Expenses.xslt
@@ -8,7 +8,6 @@
 			<xsl:param name="sfx" select="''"/>
 
 		<xsl:for-each select="expenses/expense[type = $type]">
-			<xsl:sort select="date"/>
 			<tr>
 				<xsl:if test="position() mod 2 != 1">
 					<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>

--- a/Chummer/sheets/xt.Notes.xslt
+++ b/Chummer/sheets/xt.Notes.xslt
@@ -5,11 +5,11 @@
 	<xsl:template name="notes">
 
 		<xsl:if test="notes != '' or gamenotes != ''">
-			<table><tr><td/></tr></table>
-			<xsl:call-template name="TableTitle">
-				<xsl:with-param name="name" select="$lang.Notes"/>
-			</xsl:call-template>
 			<div class="block" id="NotesBlock">
+				<table><tr><td/></tr></table>
+				<xsl:call-template name="TableTitle">
+					<xsl:with-param name="name" select="$lang.Notes"/>
+				</xsl:call-template>
 				<table class="tablestyle">
 					<tr><td colspan="100%" style="text-align: justify">
 						<xsl:call-template name="PreserveLineBreaks">
@@ -47,11 +47,11 @@
 		</xsl:if>
 
 		<xsl:if test="concept != ''">
-			<table><tr><td/></tr></table>
-			<xsl:call-template name="TableTitle">
-				<xsl:with-param name="name" select="$lang.Concept"/>
-			</xsl:call-template>
 			<div class="block" id="ConceptBlock">
+				<table><tr><td/></tr></table>
+				<xsl:call-template name="TableTitle">
+					<xsl:with-param name="name" select="$lang.Concept"/>
+				</xsl:call-template>
 				<table class="tablestyle">
 					<tr><td colspan="100%" style="text-align: justify">
 						<xsl:call-template name="PreserveLineBreaks">
@@ -67,11 +67,11 @@
 		</xsl:if>
 
 		<xsl:if test="description != ''">
-			<table><tr><td/></tr></table>
-			<xsl:call-template name="TableTitle">
-				<xsl:with-param name="name" select="$lang.Description"/>
-			</xsl:call-template>
 			<div class="block" id="DescriptionBlock">
+				<table><tr><td/></tr></table>
+				<xsl:call-template name="TableTitle">
+					<xsl:with-param name="name" select="$lang.Description"/>
+				</xsl:call-template>
 				<table class="tablestyle">
 					<tr><td colspan="100%" style="text-align: justify">
 						<xsl:call-template name="PreserveLineBreaks">
@@ -87,11 +87,11 @@
 		</xsl:if>
 
 		<xsl:if test="background != ''">
-			<table><tr><td/></tr></table>
-			<xsl:call-template name="TableTitle">
-				<xsl:with-param name="name" select="$lang.Background"/>
-			</xsl:call-template>
 			<div class="block" id="BackgroundBlock">
+				<table><tr><td/></tr></table>
+				<xsl:call-template name="TableTitle">
+					<xsl:with-param name="name" select="$lang.Background"/>
+				</xsl:call-template>
 				<table class="tablestyle">
 					<tr><td colspan="100%" style="text-align: justify">
 						<xsl:call-template name="PreserveLineBreaks">
@@ -105,6 +105,5 @@
 				<xsl:with-param name="bnme" select="'BackgroundBlock'"/>
 			</xsl:call-template>
 		</xsl:if>
-
 	</xsl:template>
 </xsl:stylesheet>

--- a/Chummer/sheets/xt.RangedWeapons.xslt
+++ b/Chummer/sheets/xt.RangedWeapons.xslt
@@ -177,26 +177,6 @@
 						<xsl:value-of select="page"/>
 					</td>
 				</tr>
-				<xsl:if test="accessories/accessory">
-					<tr>
-						<xsl:if test="position() mod 2 != 1">
-							<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-						</xsl:if>
-						<td colspan="100%" class="indent">
-							<xsl:for-each select="accessories/accessory">
-								<xsl:sort select="name"/>
-								<xsl:value-of select="name"/>
-								<xsl:if test="last() &gt; 1">; </xsl:if>
-							</xsl:for-each>
-							<xsl:for-each select="mods/weaponmod">
-								<xsl:sort select="name"/>
-								<xsl:value-of select="name"/>
-								<xsl:if test="rating > 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
-								<xsl:if test="last() &gt; 1">; </xsl:if>
-							</xsl:for-each>
-						</td>
-					</tr>
-				</xsl:if>
 				<xsl:if test="ranges/short != ''">
 					<tr style="text-align: center">
 						<xsl:if test="position() mod 2 != 1">
@@ -220,6 +200,26 @@
 							<xsl:value-of select="ranges/extreme"/>
 						</td>
 						<td colspan="5"/>
+					</tr>
+				</xsl:if>
+				<xsl:if test="accessories/accessory">
+					<tr>
+						<xsl:if test="position() mod 2 != 1">
+							<xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+						</xsl:if>
+						<td colspan="100%" class="indent">
+							<xsl:for-each select="accessories/accessory">
+								<xsl:sort select="name"/>
+								<xsl:value-of select="name"/>
+								<xsl:if test="last() &gt; 1">; </xsl:if>
+							</xsl:for-each>
+							<xsl:for-each select="mods/weaponmod">
+								<xsl:sort select="name"/>
+								<xsl:value-of select="name"/>
+								<xsl:if test="rating > 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+								<xsl:if test="last() &gt; 1">; </xsl:if>
+							</xsl:for-each>
+						</td>
 					</tr>
 				</xsl:if>
 			</xsl:for-each>


### PR DESCRIPTION
A set of small fixes on the character sheets.

- Expenses (karma and nuyen) sorting removed from xslt. Due to date format (mm/dd/yyyy) that sort destroyed the ordering of the entries. Sorting is already done in the program.

- Swapped order of "ranges" and "accessories" fragments for under barrel weapons of ranged weapons. Now its order matches the order of that fragments for the weapon itself.

- Move "TableTitle" of the divs for notes,  background, concept and description from before the div into the div. Otherwise the table title remains visible if the block is hidden via the javascript "show" option.

- Left aligned header for physical and stun damage track. So far, only the first line of the physical track was left aligned. That looked strange in german (the second line is longer than the first one).

- Fixed attribute title for edge in the Game Master Summary. Was ESS instead of EDG.

- Added intended spaces around rating of cyberware in the Game Master Summary. Replaced a simple space character by <xsl:text> </xsl:text> to retain the space in the output.