### PR TITLE
Various data-fixes

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -3853,6 +3853,17 @@
 			<source>SR5</source>
 			<page>439</page>
 		</gear>
+		<gear>
+			<id>a14a00c5-439f-45d1-9703-55bf5525e7f8</id>
+			<name>SmartSafety Bracelet</name>
+			<category>Electronics Accessories</category>
+			<rating>0</rating>
+			<armorcapacity>[0]</armorcapacity>
+			<avail>0</avail>
+			<cost>50</cost>
+			<source>R5</source>
+			<page>133</page>
+		</gear>
 		<!-- End Region -->
 		<!-- Region RFID Tags -->
 		<gear>
@@ -8316,6 +8327,17 @@
 			<cost>175</cost>
 			<source>SR5</source>
 			<page>432</page>
+		</gear>
+		<gear>
+			<id>82334694-a630-42c4-95d6-eb1345e4ed82</id>
+			<name>Concealed Quick-Draw Holster</name>
+			<category>Armor Enhancements</category>
+			<rating>0</rating>
+			<armorcapacity>[4]</armorcapacity>
+			<avail>6</avail>
+			<cost>275</cost>
+			<source>RG</source>
+			<page>51</page>
 		</gear>
 		<gear>
 			<id>f77fc093-d5cf-4be6-bfeb-311653ecd64e</id>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -3218,6 +3218,10 @@
 				<gear rating="2" maxrating="3">Sensor Array</gear>
 				<gear rating="3">[Weapon] Targeting Autosoft</gear>
 				<gear>Smartsoft</gear>
+				<gear>SmartSafety Bracelet</gear>
+				<gear>SmartSafety Bracelet</gear>
+				<gear>SmartSafety Bracelet</gear>
+				<gear>SmartSafety Bracelet</gear>
 			</gears>
 			<mods>
 				<name>Small Weapon Mount (Drone)</name>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -8067,7 +8067,7 @@
 			<reach>0</reach>
 			<damage>8P</damage>
 			<ap>-1</ap>
-			<mode>SA</mode>
+			<mode>SS</mode>
 			<rc>0</rc>
 			<ammo>9(cy)</ammo>
 			<avail>8R</avail>
@@ -8097,7 +8097,7 @@
 			<hide>yes</hide>
 			<type>Ranged</type>
 			<conceal>0</conceal>
-			<spec>Semi-Automatics</spec>
+			<spec>Revolvers</spec>
 			<accuracy>5</accuracy>
 			<reach>0</reach>
 			<damage>10P(f)</damage>


### PR DESCRIPTION
Fixes #1644

Gear:
* Concealable Quick-Draw Holster (RG 51):
  * Item missing (no clearly defined armor capacity, should be 4 or 5)
* SmartSafety bracelet (R5 133):
  * Item missing (Accessory for Lone Star Castle Guard)

Vehicles:
* Lone Star Castle Guard (R5 133):
  * cost 8000 -> 10000
  * avail 10R -> 8R
  * Missing included item -> 4x SmartSafety bracelet

Weapons:
* Lemat 2072 (HT 178):
  * Mode SA -> SS
* Lemat 2072 (Shotgun Barrel) (HT 178):
  * Spec Semi-automatics -> Revolvers