### PR TITLE
Fixes #1209 calculation is incorrect if Karma cost to improve active skills is changed

### DIFF
--- a/Chummer/Backend/Skills/Skill.core.cs
+++ b/Chummer/Backend/Skills/Skill.core.cs
@@ -366,9 +366,6 @@ namespace Chummer.Skills
 				cost = RangeCost(lower, LearnedRating);
 			}
 
-			cost /= 2;
-			cost *= CharacterObject.Options.KarmaImproveActiveSkill;
-
 			//Don't think this is going to happen, but if it happens i want to know
 			if (cost < 0 && Debugger.IsAttached)
 				Debugger.Break();


### PR DESCRIPTION
Fixes #1209 
Fixed issue where  if the karma cost of increasing active skills is modified, the calculation is incorrect.
The problem is that the 2 deleted lines appear in RangeCost() and then again right afterwards
These lines cancel themselves out if KarmaImproveActiveSkill is 2, but if it's anything else it squares the difference (so for example if you set it to 1, it halves twice instead of once). Deleting these lines takes care of the issue.