### PR TITLE
Added 'specific' skill selection type to Talent selector in priogen, allowing specific skills to be listed for Explorer & Aware. Fixed prio entry for Explorer. Fixes #1761

### DIFF
--- a/Chummer/Backend/Attributes/Attribute.Core.cs
+++ b/Chummer/Backend/Attributes/Attribute.Core.cs
@@ -333,15 +333,17 @@ namespace Chummer.Backend.Attributes
                         else
                         {
 							if (objImprovement.ImproveType == Improvement.ImprovementType.Attribute && objImprovement.ImprovedName == _strAbbrev)
-							if (objImprovement.SourceName == "Essence Loss")
 							{
 								if ((Abbrev == "MAG" || Abbrev == "DEP" || Abbrev == "RES") &&
-									_objCharacter.Options.ESSLossReducesMaximumOnly && _objCharacter.EssencePenalty > 0)
+                                     objImprovement.SourceName == "Essence Loss" &&
+                                    _objCharacter.Options.ESSLossReducesMaximumOnly && _objCharacter.EssencePenalty > 0)
 								{
-									break;
-								}
+									// Do Nothing
+								} else
+                                {
+                                    intModifier += objImprovement.Augmented * objImprovement.Rating;
+                                }
 							}
-							intModifier += objImprovement.Augmented * objImprovement.Rating;
                         }
                     }
                 }

--- a/Chummer/Character Creation/frmPriorityMetatype.cs
+++ b/Chummer/Character Creation/frmPriorityMetatype.cs
@@ -596,7 +596,8 @@ namespace Chummer
 					string strSkillVal = (objTalentsNode.SelectSingleNode("skillval")?.InnerText ??
 										  objTalentsNode.SelectSingleNode("skillgroupval")?.InnerText);
 					XmlNodeList objNodeList = (objTalentsNode.SelectNodes("skillgroupchoices/skillgroup"));
-					string strLabel = LanguageManager.Instance.GetString("String_MetamagicSkillBase");
+                    XmlNodeList skillNodeList = (objTalentsNode.SelectNodes("skillchoices/skill"));
+                    string strLabel = LanguageManager.Instance.GetString("String_MetamagicSkillBase");
 					strLabel = string.Format(strLabel, LanguageManager.Instance.GetString("String_MetamagicSkills"));
 					strLabel = string.Format(strLabel, strSkillCount, strSkillType, strSkillVal);
 					lblMetatypeSkillSelection.Text = strLabel;
@@ -622,8 +623,13 @@ namespace Chummer
 							{
 								objXmlSkillsList = BuildSkillCategoryList(objNodeList);
 								break;
-							}
-						default:
+                            }
+                        case "specific":
+                            {
+                                objXmlSkillsList = BuildSkillList(skillNodeList);
+                                break;
+                            }
+                        default:
 							{
 								objXmlSkillsList = GetActiveSkillList();
 								break;
@@ -2118,7 +2124,20 @@ namespace Chummer
 			return objXmlSkillList;
 		}
 
-		private void chkPossessionBased_CheckedChanged(object sender, EventArgs e)
+        private XmlNodeList BuildSkillList(XmlNodeList objSkillList)
+        {
+            XmlDocument objXmlSkillsDocument = XmlManager.Instance.Load("skills.xml");
+            string strGroups = "/chummer/skills/skill[name = \"" + objSkillList[0].InnerText + "\"";
+            for (int i = 1; i < objSkillList.Count; i++)
+            {
+                strGroups += " or name = \"" + objSkillList[i].InnerText + "\"";
+            }
+            strGroups += "]";
+            var objXmlSkillList = objXmlSkillsDocument.SelectNodes(strGroups);
+            return objXmlSkillList;
+        }
+
+        private void chkPossessionBased_CheckedChanged(object sender, EventArgs e)
 		{
 			cboPossessionMethod.Enabled = chkPossessionBased.Checked;
 		}

--- a/Chummer/data/priorities.xml
+++ b/Chummer/data/priorities.xml
@@ -981,13 +981,15 @@
 					<qualities>
 						<quality>Aspected Magician</quality>
 					</qualities>
-					<skillgroupchoices>
-						<skillgroup>Enchanting</skillgroup>
-					</skillgroupchoices>
+          <skillchoices>
+            <skill>Arcana</skill>
+            <skill>Assensing</skill>
+            <skill>Astral Combat</skill>
+          </skillchoices>
 					<magic>5</magic>
-					<skillqty>1</skillqty>
-					<skillval>2</skillval>
-					<skilltype>magic</skilltype>
+          <skillqty>2</skillqty>
+          <skillval>6</skillval>
+          <skilltype>specific</skilltype>
 					<forbidden>
 						<oneof>
 							<metatype>A.I.</metatype>
@@ -1093,10 +1095,15 @@
 					<qualities>
 						<quality>Aware</quality>
 					</qualities>
+          <skillchoices>
+            <skill>Arcana</skill>
+            <skill>Assensing</skill>
+            <skill>Astral Combat</skill>
+          </skillchoices>
 					<magic>3</magic>
 					<skillqty>1</skillqty>
 					<skillval>4</skillval>
-					<skilltype>magic</skilltype>
+					<skilltype>specific</skilltype>
 					<forbidden>
 						<oneof>
 							<metatype>A.I.</metatype>

--- a/Chummer/data/priorities.xsd
+++ b/Chummer/data/priorities.xsd
@@ -49,6 +49,13 @@
                                       </xs:sequence>
                                     </xs:complexType>
                                   </xs:element>
+                                  <xs:element minOccurs="0" name="skillchoices">
+                                    <xs:complexType>
+                                      <xs:sequence>
+                                        <xs:element maxOccurs="unbounded" name="skill" type="xs:string" />
+                                      </xs:sequence>
+                                    </xs:complexType>
+                                  </xs:element>
                                   <xs:element minOccurs="0" name="resonance" type="xs:unsignedByte" />
                                   <xs:element minOccurs="0" name="cfp" type="xs:unsignedByte" />
                                   <xs:element minOccurs="0" name="magic" type="xs:unsignedByte" />


### PR DESCRIPTION
Added 'specific' skill selection type to Talent selector in priogen, allowing specific skills to be listed for Explorer & Aware. Fixed prio entry for Explorer.
Fixes #1761

It is a bit messy but I didn't want to change too much.

Due to the addition of the Aspected Magician quality, it will still prompt the user for their Aspect, but fixing that would require a potentially breaking change.