### PR TITLE
Fixes an issue with localized spirit names in custom traditions.

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -12171,8 +12171,10 @@ namespace Chummer
         {
             if (cboSpiritCombat.IsInitalized(_blnLoading))
                 return;
+            if (cboSpiritCombat.SelectedValue == null)
+                return;
 
-            _objCharacter.SpiritCombat = cboSpiritCombat.Text;
+            _objCharacter.SpiritCombat = cboSpiritCombat.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -12185,8 +12187,10 @@ namespace Chummer
         {
             if (cboSpiritDetection.IsInitalized(_blnLoading))
                 return;
+            if (cboSpiritDetection.SelectedValue == null)
+                return;
 
-            _objCharacter.SpiritDetection = cboSpiritDetection.Text;
+            _objCharacter.SpiritDetection = cboSpiritDetection.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -12199,8 +12203,10 @@ namespace Chummer
         {
             if (cboSpiritHealth.IsInitalized(_blnLoading))
                 return;
+            if (cboSpiritHealth.SelectedValue == null)
+                return;
 
-            _objCharacter.SpiritHealth = cboSpiritHealth.Text;
+            _objCharacter.SpiritHealth = cboSpiritHealth.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -12213,8 +12219,9 @@ namespace Chummer
         {
             if (cboSpiritIllusion.IsInitalized(_blnLoading))
                 return;
-
-            _objCharacter.SpiritIllusion = cboSpiritIllusion.Text;
+            if (cboSpiritIllusion.SelectedValue == null)
+                return;
+            _objCharacter.SpiritIllusion = cboSpiritIllusion.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -12227,8 +12234,10 @@ namespace Chummer
         {
             if (cboSpiritManipulation.IsInitalized(_blnLoading))
                 return;
+            if (cboSpiritManipulation.SelectedValue == null)
+                return;
 
-            _objCharacter.SpiritManipulation = cboSpiritManipulation.Text;
+            _objCharacter.SpiritManipulation = cboSpiritManipulation.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -26278,10 +26278,12 @@ namespace Chummer
 
         private void cboSpiritCombat_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if (cboSpiritCombat.SelectedValue == null)
+                return;
             if (_blnLoading || string.IsNullOrEmpty(cboSpiritCombat.SelectedValue.ToString()))
                 return;
 
-            _objCharacter.SpiritCombat = cboSpiritCombat.Text;
+            _objCharacter.SpiritCombat = cboSpiritCombat.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -26292,10 +26294,12 @@ namespace Chummer
 
         private void cboSpiritDetection_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if (cboSpiritDetection.SelectedValue == null)
+                return;
             if (_blnLoading || string.IsNullOrEmpty(cboSpiritDetection.SelectedValue.ToString()))
                 return;
 
-            _objCharacter.SpiritDetection = cboSpiritDetection.Text;
+            _objCharacter.SpiritDetection = cboSpiritDetection.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -26306,10 +26310,12 @@ namespace Chummer
 
         private void cboSpiritHealth_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if (cboSpiritHealth.SelectedValue == null)
+                return;
             if (_blnLoading || string.IsNullOrEmpty(cboSpiritHealth.SelectedValue.ToString()))
                 return;
 
-            _objCharacter.SpiritHealth = cboSpiritHealth.Text;
+            _objCharacter.SpiritHealth = cboSpiritHealth.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -26320,10 +26326,12 @@ namespace Chummer
 
         private void cboSpiritIllusion_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if (cboSpiritIllusion.SelectedValue == null)
+                return;
             if (_blnLoading || string.IsNullOrEmpty(cboSpiritIllusion.SelectedValue.ToString()))
                 return;
 
-            _objCharacter.SpiritIllusion = cboSpiritIllusion.Text;
+            _objCharacter.SpiritIllusion = cboSpiritIllusion.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 
@@ -26334,10 +26342,12 @@ namespace Chummer
 
         private void cboSpiritManipulation_SelectedIndexChanged(object sender, EventArgs e)
         {
+            if (cboSpiritManipulation.SelectedValue == null)
+                return;
             if (_blnLoading || string.IsNullOrEmpty(cboSpiritManipulation.SelectedValue.ToString()))
                 return;
 
-            _objCharacter.SpiritManipulation = cboSpiritManipulation.Text;
+            _objCharacter.SpiritManipulation = cboSpiritManipulation.SelectedValue.ToString();
             foreach (SpiritControl objSpiritControl in panSpirits.Controls)
                 objSpiritControl.RebuildSpiritList(cboTradition.SelectedValue.ToString());
 


### PR DESCRIPTION
When moving mages with custom traditions into carrer mode, localized spirit name lead to crashes.
This commit fixes this behaviour by storing the value of the spirit instead of its name.
Also it provides a bit more error checking, to allow loading of such character files without crashing Chummer. (You still need to set your spirits once after opening your character sheet)