### PR TITLE
Chakram, BoomerEye added, Minor Fixes, Wireless Bonus Backend

### DIFF
--- a/Chummer/Backend/Equipment/Armor.cs
+++ b/Chummer/Backend/Equipment/Armor.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Globalization;
@@ -38,6 +38,8 @@ namespace Chummer.Backend.Equipment
         private string _strNotes = string.Empty;
         protected string _strLocation = string.Empty;
         private XmlNode _nodBonus;
+        private XmlNode _nodWirelessBonus;
+        private bool _blnWirelessOn = true;
         private string _strAltName = string.Empty;
         private string _strAltCategory = string.Empty;
         private string _strAltPage = string.Empty;
@@ -74,6 +76,8 @@ namespace Chummer.Backend.Equipment
             objXmlArmorNode.TryGetStringFieldQuickly("source", ref _strSource);
             objXmlArmorNode.TryGetStringFieldQuickly("page", ref _strPage);
             _nodBonus = objXmlArmorNode["bonus"];
+            _nodWirelessBonus = objXmlArmorNode["wirelessbonus"];
+            _blnWirelessOn = _nodWirelessBonus != null;
 
             if (GlobalOptions.Instance.Language != "en-us")
             {
@@ -358,6 +362,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("page", _strPage);
             objWriter.WriteElementString("armorname", _strArmorName);
             objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("extra", _strExtra);
             objWriter.WriteElementString("damage", _intDamage.ToString(CultureInfo.InvariantCulture));
             objWriter.WriteElementString("rating", _intRating.ToString(CultureInfo.InvariantCulture));
@@ -390,6 +395,10 @@ namespace Chummer.Backend.Equipment
                 objWriter.WriteRaw(_nodBonus.OuterXml);
             else
                 objWriter.WriteElementString("bonus", string.Empty);
+            if (_nodWirelessBonus != null)
+                objWriter.WriteRaw(_nodWirelessBonus.OuterXml);
+            else
+                objWriter.WriteElementString("wirelessbonus", string.Empty);
             objWriter.WriteElementString("location", _strLocation);
             objWriter.WriteElementString("notes", _strNotes);
             objWriter.WriteElementString("discountedcost", DiscountCost.ToString());
@@ -448,6 +457,9 @@ namespace Chummer.Backend.Equipment
             objNode.TryGetStringFieldQuickly("notes", ref _strNotes);
             objNode.TryGetBoolFieldQuickly("discountedcost", ref _blnDiscountCost);
             _nodBonus = objNode["bonus"];
+            _nodWirelessBonus = objNode["wirelessbonus"];
+            if (!objNode.TryGetBoolFieldQuickly("wirelesson", ref _blnWirelessOn))
+                _blnWirelessOn = _nodWirelessBonus != null;
             if (objNode.InnerXml.Contains("armormods"))
             {
                 XmlNodeList nodMods = objNode.SelectNodes("armormods/armormod");
@@ -517,6 +529,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("page", Page);
             objWriter.WriteElementString("armorname", _strArmorName);
             objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteStartElement("armormods");
             foreach (ArmorMod objMod in _lstArmorMods)
             {
@@ -585,6 +598,21 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _nodBonus = value;
+            }
+        }
+
+        /// <summary>
+        /// Wireless Bonus node from the XML file.
+        /// </summary>
+        public XmlNode WirelessBonus
+        {
+            get
+            {
+                return _nodWirelessBonus;
+            }
+            set
+            {
+                _nodWirelessBonus = value;
             }
         }
 
@@ -870,6 +898,21 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _blnEquipped = value;
+            }
+        }
+
+        /// <summary>
+        /// Whether or not Wireless is turned on for this armor
+        /// </summary>
+        public bool WirelessOn
+        {
+            get
+            {
+                return _blnWirelessOn;
+            }
+            set
+            {
+                _blnWirelessOn = value;
             }
         }
 
@@ -1255,6 +1298,10 @@ namespace Chummer.Backend.Equipment
                         if (objMod.Bonus != null)
                         {
                             blnSoftweave = objMod.Bonus.SelectSingleNode("softweave") != null;
+                        }
+                        if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                        {
+                            blnSoftweave = objMod.WirelessBonus.SelectSingleNode("softweave") != null;
                         }
                         if (blnSoftweave) continue;
                         string strCapacity = objMod.CalculatedCapacity;

--- a/Chummer/Backend/Equipment/ArmorMod.cs
+++ b/Chummer/Backend/Equipment/ArmorMod.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -49,6 +49,8 @@ namespace Chummer.Backend.Equipment
         private string _strExtra = string.Empty;
         private Guid _guiWeaponID = new Guid();
         private XmlNode _nodBonus;
+        private XmlNode _nodWirelessBonus;
+        private bool _blnWirelessOn = true;
         private readonly Character _objCharacter;
         private string _strNotes = string.Empty;
         private string _strAltName = string.Empty;
@@ -84,6 +86,8 @@ namespace Chummer.Backend.Equipment
             objXmlArmorNode.TryGetStringFieldQuickly("source", ref _strSource);
             objXmlArmorNode.TryGetStringFieldQuickly("page", ref _strPage);
             _nodBonus = objXmlArmorNode["bonus"];
+            _nodWirelessBonus = objXmlArmorNode["wirelessbonus"];
+            _blnWirelessOn = _nodWirelessBonus != null;
 
             if (GlobalOptions.Instance.Language != "en-us")
             {
@@ -202,6 +206,11 @@ namespace Chummer.Backend.Equipment
                 objWriter.WriteRaw(_nodBonus.OuterXml);
             else
                 objWriter.WriteElementString("bonus", string.Empty);
+            if (_nodWirelessBonus != null)
+                objWriter.WriteRaw(_nodWirelessBonus.OuterXml);
+            else
+                objWriter.WriteElementString("wirelessbonus", string.Empty);
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("source", _strSource);
             objWriter.WriteElementString("page", _strPage);
             objWriter.WriteElementString("included", _blnIncludedInArmor.ToString());
@@ -239,10 +248,13 @@ namespace Chummer.Backend.Equipment
             objNode.TryGetStringFieldQuickly("avail", ref _strAvail);
             objNode.TryGetStringFieldQuickly("cost", ref _strCost);
             _nodBonus = objNode["bonus"];
+            _nodWirelessBonus = objNode["wirelessbonus"];
             objNode.TryGetStringFieldQuickly("source", ref _strSource);
             objNode.TryGetStringFieldQuickly("page", ref _strPage);
             objNode.TryGetBoolFieldQuickly("included", ref _blnIncludedInArmor);
             objNode.TryGetBoolFieldQuickly("equipped", ref _blnEquipped);
+            if (!objNode.TryGetBoolFieldQuickly("wirelesson", ref _blnWirelessOn))
+                _blnWirelessOn = _nodWirelessBonus != null;
             objNode.TryGetStringFieldQuickly("extra", ref _strExtra);
             if (objNode["weaponguid"] != null)
             {
@@ -288,6 +300,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("page", Page);
             objWriter.WriteElementString("included", _blnIncludedInArmor.ToString());
             objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("extra", LanguageManager.Instance.TranslateExtra(_strExtra));
             if (_objCharacter.Options.PrintNotes)
                 objWriter.WriteElementString("notes", _strNotes);
@@ -334,6 +347,21 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _nodBonus = value;
+            }
+        }
+
+        /// <summary>
+        /// Wireless Bonus node from the XML file.
+        /// </summary>
+        public XmlNode WirelessBonus
+        {
+            get
+            {
+                return _nodWirelessBonus;
+            }
+            set
+            {
+                _nodWirelessBonus = value;
             }
         }
 
@@ -563,6 +591,21 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _blnEquipped = value;
+            }
+        }
+
+        /// <summary>
+        /// Whether or not an Armor Mod's wireless bonus is enabled
+        /// </summary>
+        public bool WirelessOn
+        {
+            get
+            {
+                return _blnWirelessOn;
+            }
+            set
+            {
+                _blnWirelessOn = value;
             }
         }
 

--- a/Chummer/Backend/Equipment/Gear.cs
+++ b/Chummer/Backend/Equipment/Gear.cs
@@ -39,8 +39,10 @@ namespace Chummer.Backend.Equipment
         protected string _strExtra = string.Empty;
         protected bool _blnBonded = false;
         protected bool _blnEquipped = true;
+        protected bool _blnWirelessOn = true;
         protected bool _blnHomeNode = false;
         protected XmlNode _nodBonus;
+        protected XmlNode _nodWirelessBonus;
         protected XmlNode _nodWeaponBonus;
         protected Guid _guiWeaponID = new Guid();
         protected List<Gear> _objChildren = new List<Gear>();
@@ -100,6 +102,8 @@ namespace Chummer.Backend.Equipment
             objXmlGear.TryGetStringFieldQuickly("cost6", ref _strCost6);
             objXmlGear.TryGetStringFieldQuickly("cost10", ref _strCost10);
             _nodBonus = objXmlGear["bonus"];
+            _nodWirelessBonus = objXmlGear["wirelessbonus"];
+            _blnWirelessOn = _nodWirelessBonus != null;
             objXmlGear.TryGetInt32FieldQuickly("rating", ref _intMaxRating);
             objXmlGear.TryGetInt32FieldQuickly("minrating", ref _intMinRating);
             _intRating = intRating;
@@ -475,8 +479,10 @@ namespace Chummer.Backend.Equipment
             _strExtra = objGear.Extra;
             _blnBonded = objGear.Bonded;
             _blnEquipped = objGear.Equipped;
+            _blnWirelessOn = objGear.WirelessOn;
             _blnHomeNode = objGear.HomeNode;
             _nodBonus = objGear.Bonus;
+            _nodWirelessBonus = objGear.WirelessBonus;
             _nodWeaponBonus = objGear.WeaponBonus;
             _guiWeaponID = Guid.Parse(objGear.WeaponID);
             _strNotes = objGear.Notes;
@@ -545,6 +551,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("extra", _strExtra);
             objWriter.WriteElementString("bonded", _blnBonded.ToString());
             objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
             if (_guiWeaponID != Guid.Empty)
                 objWriter.WriteElementString("weaponguid", _guiWeaponID.ToString());
@@ -552,6 +559,10 @@ namespace Chummer.Backend.Equipment
                 objWriter.WriteRaw("<bonus>" + _nodBonus.InnerXml + "</bonus>");
             else
                 objWriter.WriteElementString("bonus", string.Empty);
+            if (_nodWirelessBonus != null)
+                objWriter.WriteRaw("<wirelessbonus>" + _nodWirelessBonus.InnerXml + "</wirelessbonus>");
+            else
+                objWriter.WriteElementString("wirelessbonus", string.Empty);
             if (_nodWeaponBonus != null)
                 objWriter.WriteRaw("<weaponbonus>" + _nodWeaponBonus.InnerXml + "</weaponbonus>");
             objWriter.WriteElementString("source", _strSource);
@@ -639,6 +650,9 @@ namespace Chummer.Backend.Equipment
             objNode.TryGetBoolFieldQuickly("equipped", ref _blnEquipped);
             objNode.TryGetBoolFieldQuickly("homenode", ref _blnHomeNode);
             _nodBonus = objNode["bonus"];
+            _nodWirelessBonus = objNode["wirelessbonus"];
+            if (!objNode.TryGetBoolFieldQuickly("wirelesson", ref _blnWirelessOn))
+                _blnWirelessOn = _nodWirelessBonus != null;
             _nodWeaponBonus = objNode["weaponbonus"];
             objNode.TryGetStringFieldQuickly("source", ref _strSource);
             objNode.TryGetStringFieldQuickly("page", ref _strPage);
@@ -723,6 +737,7 @@ namespace Chummer.Backend.Equipment
                             Equipped = false;
                             _objCharacter.ObjImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, InternalId);
                             Bonus = gear["bonus"];
+                            WirelessBonus = gear["wirelessbonus"];
                         }
                     }
                 }
@@ -782,6 +797,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("extra", LanguageManager.Instance.TranslateExtra(_strExtra));
             objWriter.WriteElementString("bonded", _blnBonded.ToString());
             objWriter.WriteElementString("equipped", _blnEquipped.ToString());
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("homenode", _blnHomeNode.ToString());
             objWriter.WriteElementString("location", _strLocation);
             objWriter.WriteElementString("gearname", _strGearName);
@@ -893,6 +909,21 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _nodBonus = value;
+            }
+        }
+
+        /// <summary>
+        /// Wireless bonus node from the XML file.
+        /// </summary>
+        public XmlNode WirelessBonus
+        {
+            get
+            {
+                return _nodWirelessBonus;
+            }
+            set
+            {
+                _nodWirelessBonus = value;
             }
         }
 
@@ -1268,6 +1299,21 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _blnEquipped = value;
+            }
+        }
+
+        /// <summary>
+        /// Whether or not the Gear's wireless bonus is enabled.
+        /// </summary>
+        public bool WirelessOn
+        {
+            get
+            {
+                return _blnWirelessOn;
+            }
+            set
+            {
+                _blnWirelessOn = value;
             }
         }
 

--- a/Chummer/Backend/Equipment/VehicleMod.cs
+++ b/Chummer/Backend/Equipment/VehicleMod.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
@@ -24,6 +24,8 @@ namespace Chummer.Backend.Equipment
         private int _intMarkup;
         private string _strAvail = string.Empty;
         private XmlNode _nodBonus;
+        private XmlNode _nodWirelessBonus;
+        private bool _blnWirelessOn = true;
         private string _strSource = string.Empty;
         private string _strPage = string.Empty;
         private bool _blnIncludeInVehicle;
@@ -137,6 +139,8 @@ namespace Chummer.Backend.Equipment
             objXmlMod.TryGetStringFieldQuickly("source", ref _strSource);
             objXmlMod.TryGetStringFieldQuickly("page", ref _strPage);
             _nodBonus = objXmlMod["bonus"];
+            _nodWirelessBonus = objXmlMod["wirelessbonus"];
+            _blnWirelessOn = _nodWirelessBonus != null;
 
             if (GlobalOptions.Instance.Language != "en-us")
             {
@@ -185,6 +189,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("page", _strPage);
             objWriter.WriteElementString("included", _blnIncludeInVehicle.ToString());
             objWriter.WriteElementString("installed", _blnInstalled.ToString());
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("subsystems", _strSubsystems);
             objWriter.WriteElementString("weaponmountcategories", _strWeaponMountCategories);
             objWriter.WriteStartElement("weapons");
@@ -200,6 +205,8 @@ namespace Chummer.Backend.Equipment
             }
             if (_nodBonus != null)
                 objWriter.WriteRaw(_nodBonus.OuterXml);
+            if (_nodWirelessBonus != null)
+                objWriter.WriteRaw(_nodWirelessBonus.OuterXml);
             objWriter.WriteElementString("notes", _strNotes);
             objWriter.WriteElementString("discountedcost", DiscountCost.ToString());
             objWriter.WriteEndElement();
@@ -269,6 +276,9 @@ namespace Chummer.Backend.Equipment
             }
 
             _nodBonus = objNode["bonus"];
+            _nodWirelessBonus = objNode["wirelessbonus"];
+            if (!objNode.TryGetBoolFieldQuickly("wirelesson", ref _blnWirelessOn))
+                _blnWirelessOn = _nodWirelessBonus != null;
             objNode.TryGetStringFieldQuickly("notes", ref _strNotes);
             objNode.TryGetBoolFieldQuickly("discountedcost", ref _blnDiscountCost);
             objNode.TryGetStringFieldQuickly("extra", ref _strExtra);
@@ -304,6 +314,7 @@ namespace Chummer.Backend.Equipment
             objWriter.WriteElementString("cost", TotalCost.ToString());
             objWriter.WriteElementString("owncost", OwnCost.ToString());
             objWriter.WriteElementString("source", _objCharacter.Options.LanguageBookShort(_strSource));
+            objWriter.WriteElementString("wirelesson", _blnWirelessOn.ToString());
             objWriter.WriteElementString("page", Page);
             objWriter.WriteElementString("included", _blnIncludeInVehicle.ToString());
             objWriter.WriteStartElement("weapons");
@@ -639,6 +650,36 @@ namespace Chummer.Backend.Equipment
             set
             {
                 _nodBonus = value;
+            }
+        }
+
+        /// <summary>
+        /// Wireless Bonus node.
+        /// </summary>
+        public XmlNode WirelessBonus
+        {
+            get
+            {
+                return _nodWirelessBonus;
+            }
+            set
+            {
+                _nodWirelessBonus = value;
+            }
+        }
+
+        /// <summary>
+        /// Whether the vehicle mod's wireless is enabled
+        /// </summary>
+        public bool WirelessOn
+        {
+            get
+            {
+                return _blnWirelessOn;
+            }
+            set
+            {
+                _blnWirelessOn = value;
             }
         }
 

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -5032,12 +5032,9 @@ namespace Chummer
                         return;
 
                     // Check for Improved Sensor bonus.
-                    if (objMod.Bonus != null)
+                    if (objMod.Bonus?["improvesensor"] != null || (objMod.WirelessOn && objMod.WirelessBonus?["improvesensor"] != null))
                     {
-                        if (objMod.Bonus["improvesensor"] != null)
-                        {
-                            ChangeVehicleSensor(objFoundVehicle, false);
-                        }
+                        ChangeVehicleSensor(objFoundVehicle, false);
                     }
 
                     // If this is the Obsolete Mod, the user must select a percentage. This will create an Expense that costs X% of the Vehicle's base cost to remove the special Obsolete Mod.
@@ -6840,17 +6837,29 @@ namespace Chummer
                     // Add the Armor's Improevments to the character.
                     if (objArmor.Bonus != null)
                         _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.Bonus, false, 1, objArmor.DisplayNameShort);
+                    if (objArmor.WirelessOn && objArmor.WirelessBonus != null)
+                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.WirelessBonus, false, 1, objArmor.DisplayNameShort);
                     // Add the Improvements from any Armor Mods in the Armor.
                     foreach (ArmorMod objMod in objArmor.ArmorMods)
                     {
-                        if (objMod.Bonus != null && objMod.Equipped)
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                        if (objMod.Equipped)
+                        {
+                            if (objMod.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
+                        }
                     }
                     // Add the Improvements from any Gear in the Armor.
                     foreach (Gear objGear in objArmor.Gear)
                     {
-                        if (objGear.Bonus != null && objGear.Equipped)
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        if (objGear.Equipped)
+                        {
+                            if (objGear.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        }
                     }
                 }
             }
@@ -6870,18 +6879,18 @@ namespace Chummer
                 {
                     objArmor.Equipped = false;
                     // Remove any Improvements the Armor created.
-                    if (objArmor.Bonus != null)
+                    if (objArmor.Bonus != null || (objArmor.WirelessOn && objArmor.WirelessBonus != null))
                         _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
                     // Remove any Improvements from any Armor Mods in the Armor.
                     foreach (ArmorMod objMod in objArmor.ArmorMods)
                     {
-                        if (objMod.Bonus != null)
+                        if (objMod.Bonus != null || (objMod.WirelessOn && objMod.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                     }
                     // Remove any Improvements from any Gear in the Armor.
                     foreach (Gear objGear in objArmor.Gear)
                     {
-                        if (objGear.Bonus != null)
+                        if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                     }
                 }
@@ -10360,14 +10369,14 @@ namespace Chummer
                     objCyberware.Rating = Convert.ToInt32(nudCyberwareRating.Value);
 
                     // See if a Bonus node exists.
-                    if (objCyberware.Bonus != null)
+                    if ((objCyberware.Bonus != null && objCyberware.Bonus.InnerXml.Contains("Rating")) || (objCyberware.WirelessOn && objCyberware.WirelessBonus != null && objCyberware.WirelessBonus.InnerXml.Contains("Rating")))
                     {
                         // If the Bonus contains "Rating", remove the existing Improvements and create new ones.
-                        if (objCyberware.Bonus.InnerXml.Contains("Rating"))
-                        {
-                            _objImprovementManager.RemoveImprovements(objCyberware.SourceType, objCyberware.InternalId);
+                        _objImprovementManager.RemoveImprovements(objCyberware.SourceType, objCyberware.InternalId);
+                        if (objCyberware.Bonus != null)
                             _objImprovementManager.CreateImprovements(objCyberware.SourceType, objCyberware.InternalId, objCyberware.Bonus, false, objCyberware.Rating, objCyberware.DisplayNameShort);
-                        }
+                        if (objCyberware.WirelessOn && objCyberware.WirelessBonus != null)
+                            _objImprovementManager.CreateImprovements(objCyberware.SourceType, objCyberware.InternalId, objCyberware.WirelessBonus, false, objCyberware.Rating, objCyberware.DisplayNameShort);
                     }
 
                     treCyberware.SelectedNode.Text = objCyberware.DisplayName;
@@ -10384,7 +10393,7 @@ namespace Chummer
                     objGear.Rating = Convert.ToInt32(nudCyberwareRating.Value);
 
                     // See if a Bonus node exists.
-                    if (objGear.Bonus != null)
+                    if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                     {
                         _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                         if (!string.IsNullOrEmpty(objGear.Extra))
@@ -10393,7 +10402,10 @@ namespace Chummer
                             if (objGear.Extra.EndsWith(", Hacked"))
                                 _objImprovementManager.ForcedValue = objGear.Extra.Replace(", Hacked", string.Empty);
                         }
-                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        if (objGear.Bonus != null)
+                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
                     }
 
                     treCyberware.SelectedNode.Text = objGear.DisplayName;
@@ -10717,7 +10729,7 @@ namespace Chummer
                 Gear objGear = CommonFunctions.DeepFindById(treGear.SelectedNode.Tag.ToString(), _objCharacter.Gear);
 
                 objGear.Rating = Convert.ToInt32(nudGearRating.Value);
-                if (objGear.Bonus != null)
+                if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                 {
                     _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                     if (!string.IsNullOrEmpty(objGear.Extra))
@@ -10733,7 +10745,12 @@ namespace Chummer
                             blnAddBonus = false;
                     }
                     if (blnAddBonus)
-                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                    {
+                        if (objGear.Bonus != null)
+                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                    }
 
                 }
 
@@ -10789,34 +10806,46 @@ namespace Chummer
                         // Add the Armor's Improevments to the character.
                         if (objArmor.Bonus != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.Bonus, false, 1, objArmor.DisplayNameShort);
+                        if (objArmor.WirelessOn && objArmor.WirelessBonus != null)
+                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.WirelessBonus, false, 1, objArmor.DisplayNameShort);
                         // Add the Improvements from any Armor Mods in the Armor.
                         foreach (ArmorMod objMod in objArmor.ArmorMods)
                         {
-                            if (objMod.Bonus != null && objMod.Equipped)
-                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            if (objMod.Equipped)
+                            {
+                                if (objMod.Bonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                                if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            }
                         }
                         // Add the Improvements from any Gear in the Armor.
                         foreach (Gear objGear in objArmor.Gear)
                         {
-                            if (objGear.Bonus != null && objGear.Equipped)
-                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objGear.Equipped)
+                            {
+                                if (objGear.Bonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            }
                         }
                     }
                     else
                     {
                         // Remove any Improvements the Armor created.
-                        if (objArmor.Bonus != null)
+                        if (objArmor.Bonus != null || (objArmor.WirelessOn && objArmor.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
                         // Remove any Improvements from any Armor Mods in the Armor.
                         foreach (ArmorMod objMod in objArmor.ArmorMods)
                         {
-                            if (objMod.Bonus != null)
+                            if (objMod.Bonus != null || (objMod.WirelessOn && objMod.WirelessBonus != null))
                                 _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                         }
                         // Remove any Improvements from any Gear in the Armor.
                         foreach (Gear objGear in objArmor.Gear)
                         {
-                            if (objGear.Bonus != null)
+                            if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                                 _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                         }
                     }
@@ -10832,14 +10861,19 @@ namespace Chummer
                     objMod.Equipped = chkArmorEquipped.Checked;
                     if (chkArmorEquipped.Checked)
                     {
-                        // Add the Mod's Improevments to the character.
-                        if (objMod.Bonus != null && objMod.Parent.Equipped)
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                        if (objMod.Parent.Equipped)
+                        {
+                            // Add the Mod's Improevments to the character.
+                            if (objMod.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
+                        }
                     }
                     else
                     {
                         // Remove any Improvements the Mod created.
-                        if (objMod.Bonus != null)
+                        if (objMod.Bonus != null || (objMod.WirelessOn && objMod.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                     }
                 }
@@ -10852,13 +10886,18 @@ namespace Chummer
                     if (chkArmorEquipped.Checked)
                     {
                         // Add the Gear's Improevments to the character.
-                        if (objGear.Bonus != null && objFoundArmor.Equipped)
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        if (objFoundArmor.Equipped)
+                        {
+                            if (objGear.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        }
                     }
                     else
                     {
                         // Remove any Improvements the Gear created.
-                        if (objGear.Bonus != null)
+                        if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                     }
                 }
@@ -11745,14 +11784,15 @@ namespace Chummer
                     objSelectedFocus.Bonded = true;
                     if (objSelectedFocus.Equipped)
                     {
-                        if (objSelectedFocus.Bonus != null)
+                        if (objSelectedFocus.Bonus != null || (objSelectedFocus.WirelessOn && objSelectedFocus.WirelessBonus != null))
                         {
                             if (!string.IsNullOrEmpty(objSelectedFocus.Extra))
                                 _objImprovementManager.ForcedValue = objSelectedFocus.Extra;
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objSelectedFocus.InternalId, objSelectedFocus.Bonus, false, objSelectedFocus.Rating, objSelectedFocus.DisplayNameShort);
-
+                            if (objSelectedFocus.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objSelectedFocus.InternalId, objSelectedFocus.Bonus, false, objSelectedFocus.Rating, objSelectedFocus.DisplayNameShort);
                             objSelectedFocus.Extra = _objImprovementManager.SelectedValue;
-
+                            if (objSelectedFocus.WirelessOn && objSelectedFocus.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objSelectedFocus.InternalId, objSelectedFocus.WirelessBonus, false, objSelectedFocus.Rating, objSelectedFocus.DisplayNameShort);
 
                             _objController.PopulateFocusList(treFoci);
                         }
@@ -11777,11 +11817,14 @@ namespace Chummer
                     {
                         foreach (Gear objGear in objStack.Gear)
                         {
-                            if (objGear.Bonus != null)
+                            if (objGear.Bonus != null || (objSelectedFocus.WirelessOn && objSelectedFocus.WirelessBonus != null))
                             {
                                 if (!string.IsNullOrEmpty(objGear.Extra))
                                     _objImprovementManager.ForcedValue = objGear.Extra;
-                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objGear.Bonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objSelectedFocus.WirelessOn && objSelectedFocus.WirelessBonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
                             }
                         }
                     }
@@ -11934,14 +11977,14 @@ namespace Chummer
                 treArmor.SelectedNode.Text = objGear.DisplayName;
 
                 // See if a Bonus node exists.
-                if (objGear.Bonus != null)
+                if ((objGear.Bonus != null && objGear.Bonus.InnerXml.Contains("Rating")) || (objGear.WirelessOn && objGear.WirelessBonus != null && objGear.WirelessBonus.InnerXml.Contains("Rating")))
                 {
                     // If the Bonus contains "Rating", remove the existing Improvements and create new ones.
-                    if (objGear.Bonus.InnerXml.Contains("Rating"))
-                    {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
+                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
+                    if (objGear.Bonus != null)
                         _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
-                    }
+                    if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
                 }
             }
             else if (blnIsMod)
@@ -11950,14 +11993,14 @@ namespace Chummer
                 treArmor.SelectedNode.Text = objMod.DisplayName;
 
                 // See if a Bonus node exists.
-                if (objMod.Bonus != null)
+                if ((objMod.Bonus != null && objMod.Bonus.InnerXml.Contains("Rating")) || (objMod.WirelessOn && objMod.WirelessBonus != null && objMod.WirelessBonus.InnerXml.Contains("Rating")))
                 {
                     // If the Bonus contains "Rating", remove the existing Improvements and create new ones.
-                    if (objMod.Bonus.InnerXml.Contains("Rating"))
-                    {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
+                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
+                    if (objMod.Bonus != null)
                         _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
-                    }
+                    if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
                 }
             }
 

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by

--- a/Chummer/Selection Forms/frmSelectCyberware.cs
+++ b/Chummer/Selection Forms/frmSelectCyberware.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -720,7 +720,7 @@ namespace Chummer
         /// <summary>
         /// Parent cyberware that the current selection will be added to.
         /// </summary>
-        public Cyberware Parent;
+        public Cyberware CyberwareParent;
         #endregion
 
         #region Methods
@@ -865,12 +865,12 @@ namespace Chummer
                 {
                     if (strCost.StartsWith("Parent Cost"))
                     {
-                        if (Parent != null)
+                        if (CyberwareParent != null)
                         {
-                            strCost = strCost.Replace("Parent Cost", Parent.Cost);
+                            strCost = strCost.Replace("Parent Cost", CyberwareParent.Cost);
                             if (strCost.Contains("Rating"))
                             {
-                                strCost = strCost.Replace("Rating", Parent.Rating.ToString());
+                                strCost = strCost.Replace("Rating", CyberwareParent.Rating.ToString());
                             }
                         }
                         else

--- a/Chummer/Selection Forms/frmSelectLifestyle.cs
+++ b/Chummer/Selection Forms/frmSelectLifestyle.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -100,13 +100,13 @@ namespace Chummer
                 if (nodMultiplier != null && int.TryParse(nodMultiplier.InnerText, out int intCost))
                 {
                     nodOption.Text = intCost > 0
-                        ? $"{objXmlOption["translate"]?.InnerText ?? strOptionName} [+{intCost}{strBaseString}%"
-                        : $"{objXmlOption["translate"]?.InnerText ?? strOptionName} [{intCost}{strBaseString}%";
+                        ? $"{objXmlOption["translate"]?.InnerText ?? strOptionName} [+{intCost}{strBaseString}%]"
+                        : $"{objXmlOption["translate"]?.InnerText ?? strOptionName} [{intCost}{strBaseString}%]";
                 }
                 else
                 {
                     string strCost = objXmlOption["cost"]?.InnerText ?? string.Empty;
-                    nodOption.Text = $"{objXmlOption["translate"]?.InnerText ?? strOptionName} [{strCost}¥";
+                    nodOption.Text = $"{objXmlOption["translate"]?.InnerText ?? strOptionName} [{strCost}¥]";
                 }
                 treQualities.Nodes.Add(nodOption);
             }

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -22,6 +22,7 @@ Data Changes:
 - Added German-exclusives vehicles from Aspahltkreiger (german Rigger 5.0).
 - Fixed behaviour of spellcasting foci to scale based on Force. 
 - Fixed missing increased seating bonus for the Amenities (Squatter) vehicle modification.
+- Added entries for Chakram from the Run & Gun errata and the Horizon BoomerEye from the bottom of Boomerang's statblock in Run & Gun.
 
 New Strings:
 - Label_Options_SpellShapingFocus

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -11,7 +11,9 @@ Application Changes:
 - Fixed a crash caused by other applications querying Chummer's windows, such as narration tools. 
 - Fixed display of nuyen karma cost in the karma cost summary to not switch to the actual nuyen value. 
 - Fixed quirks with attribute point warnings when moving to career mode. 
-- Fixed an issue when loading critters that caused them to have lower attribute values than intended. 
+- Fixed an issue when loading critters that caused them to have lower attribute values than intended.
+- Added backend support for wireless bonuses to Gear, Armor, Armor Mods, Vehicle Mods, and Cyberware.
+- Fixed an issue where lifestyle qualities would not have closing square brackets for their costs.
 
 Data Changes:
 

--- a/Chummer/controllers/clsMainController.cs
+++ b/Chummer/controllers/clsMainController.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -949,6 +949,8 @@ namespace Chummer
                                     if (!string.IsNullOrEmpty(objFociGear.Extra))
                                         _objImprovementManager.ForcedValue = objFociGear.Extra;
                                     _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objFociGear.Bonus, false, objFociGear.Rating, objFociGear.DisplayNameShort);
+                                    if (objFociGear.WirelessOn)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objFociGear.WirelessBonus, false, objFociGear.Rating, objFociGear.DisplayNameShort);
                                 }
                                 objNode.Checked = true;
                             }
@@ -1104,7 +1106,7 @@ namespace Chummer
             if (blnEquipped)
             {
                 // Add any Improvements from the Gear.
-                if (objGear.Bonus != null)
+                if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                 {
                     bool blnAddImprovement = true;
                     // If this is a Focus which is not bonded, don't do anything.
@@ -1117,7 +1119,10 @@ namespace Chummer
                         {
                             if (!string.IsNullOrEmpty(objGear.Extra))
                                 _objImprovementManager.ForcedValue = objGear.Extra;
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objGear.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
                             objGear.Extra = _objImprovementManager.SelectedValue;
                         }
                     }
@@ -1132,7 +1137,10 @@ namespace Chummer
                                 {
                                     if (!string.IsNullOrEmpty(objFociGear.Extra))
                                         _objImprovementManager.ForcedValue = objFociGear.Extra;
-                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objFociGear.Bonus, false, objFociGear.Rating, objFociGear.DisplayNameShort);
+                                    if (objGear.Bonus != null)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objFociGear.Bonus, false, objFociGear.Rating, objFociGear.DisplayNameShort);
+                                    if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
                                 }
                             }
                         }
@@ -1142,7 +1150,7 @@ namespace Chummer
             else
             {
                 // Remove any Improvements from the Gear.
-                if (objGear.Bonus != null)
+                if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                 {
                     if (objGear.Category != "Stacked Focus")
                         _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -780,6 +780,18 @@
       <cost>50</cost>
       <costfor>1</costfor>
     </gear>
+	<gear>
+      <id>5b33b094-5e25-4f0e-9a3d-4f86a3621a3f</id>
+      <name>Horizon BoomerEye</name>
+      <category>Ammunition</category>
+      <rating>0</rating>
+      <source>RG</source>
+      <page>25</page>
+      <avail>4</avail>
+      <addweapon>Horizon BoomerEye</addweapon>
+      <cost>50</cost>
+      <costfor>1</costfor>
+    </gear>
     <gear>
       <id>d3d99f54-4176-4a11-a8cb-8447e285d977</id>
       <name>Harpoon</name>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -2067,6 +2067,25 @@
       <source>SR5</source>
       <page>423</page>
     </weapon>
+	<weapon>
+      <id>dc18811b-eb07-43d8-8d95-d5c468f048f4</id>
+      <name>Chakram</name>
+      <category>Exotic Melee Weapons</category>
+      <type>Melee</type>
+      <conceal>-2</conceal>
+      <accuracy>4</accuracy>
+      <reach>0</reach>
+      <damage>(STR)P</damage>
+      <ap>0</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <avail>8R</avail>
+      <cost>750</cost>
+      <allowaccessory>true</allowaccessory>
+      <source>RG</source>
+      <page>20</page>
+    </weapon>
     <weapon>
       <id>4f1d1416-5af6-4853-a1b3-2bb44a132d8f</id>
       <name>Stimtouch Hosiery</name>
@@ -2222,6 +2241,28 @@
       <range>Aerodynamic Grenade</range>
       <source>RG</source>
       <page>24</page>
+    </weapon>
+	<weapon>
+      <id>dabbf576-066e-4c41-923b-43229f2defa3</id>
+      <name>Horizon BoomerEye</name>
+      <category>Gear</category>
+      <type>Ranged</type>
+      <conceal>-2</conceal>
+      <spec>Aerodynamic</spec>
+      <accuracy>Physical-1</accuracy>
+      <reach>0</reach>
+      <damage>(STR+2)P</damage>
+      <ap>0</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <avail>4</avail>
+      <cost>50</cost>
+      <allowaccessory>true</allowaccessory>
+      <useskill>Throwing Weapons</useskill>
+      <range>Aerodynamic Grenade</range>
+      <source>RG</source>
+      <page>25</page>
     </weapon>
     <weapon>
       <id>011493be-12eb-47ba-a445-f0c8cf139d4f</id>

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -5042,12 +5042,9 @@ namespace Chummer
                         return;
 
                     // Check for Improved Sensor bonus.
-                    if (objMod.Bonus != null)
+                    if (objMod.Bonus?["improvesensor"] != null || (objMod.WirelessOn && objMod.WirelessBonus?["improvesensor"] != null))
                     {
-                        if (objMod.Bonus["improvesensor"] != null)
-                        {
-                            ChangeVehicleSensor(objFoundVehicle, false);
-                        }
+                        ChangeVehicleSensor(objFoundVehicle, false);
                     }
 
                     // If this is the Obsolete Mod, the user must select a percentage. This will create an Expense that costs X% of the Vehicle's base cost to remove the special Obsolete Mod.
@@ -7824,17 +7821,29 @@ namespace Chummer
                     // Add the Armor's Improevments to the character.
                     if (objArmor.Bonus != null)
                         _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.Bonus, false, 1, objArmor.DisplayNameShort);
+                    if (objArmor.WirelessOn && objArmor.WirelessBonus != null)
+                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.WirelessBonus, false, 1, objArmor.DisplayNameShort);
                     // Add the Improvements from any Armor Mods in the Armor.
                     foreach (ArmorMod objMod in objArmor.ArmorMods)
                     {
-                        if (objMod.Bonus != null && objMod.Equipped)
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                        if (objMod.Equipped)
+                        {
+                            if (objMod.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
+                        }
                     }
                     // Add the Improvements from any Gear in the Armor.
                     foreach (Gear objGear in objArmor.Gear)
                     {
-                        if (objGear.Bonus != null && objGear.Equipped)
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        if (objGear.Equipped)
+                        {
+                            if (objGear.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                        }
                     }
                 }
             }
@@ -7854,18 +7863,18 @@ namespace Chummer
                 {
                     objArmor.Equipped = false;
                     // Remove any Improvements the Armor created.
-                    if (objArmor.Bonus != null)
+                    if (objArmor.Bonus != null || (objArmor.WirelessOn && objArmor.WirelessBonus != null))
                         _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
                     // Remove any Improvements from any Armor Mods in the Armor.
                     foreach (ArmorMod objMod in objArmor.ArmorMods)
                     {
-                        if (objMod.Bonus != null)
+                        if (objMod.Bonus != null || (objMod.WirelessOn && objMod.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                     }
                     // Remove any Improvements from any Gear in the Armor.
                     foreach (Gear objGear in objArmor.Gear)
                     {
-                        if (objGear.Bonus != null)
+                        if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                     }
                 }
@@ -10530,12 +10539,9 @@ namespace Chummer
                                     int intOriginal = objCharacterVehicle.TotalCost;
 
                                     // Check for Improved Sensor bonus.
-                                    if (objMod.Bonus != null)
+                                    if (objMod.Bonus?["improvesensor"] != null || (objMod.WirelessOn && objMod.WirelessBonus?["improvesensor"] != null))
                                     {
-                                        if (objMod.Bonus["improvesensor"] != null)
-                                        {
-                                            ChangeVehicleSensor(objCharacterVehicle, false);
-                                        }
+                                        ChangeVehicleSensor(objCharacterVehicle, false);
                                     }
 
                                     objCharacterVehicle.Mods.Remove(objMod);
@@ -12091,12 +12097,9 @@ namespace Chummer
                             if (objMod.InternalId == objEntry.Undo.ObjectId)
                             {
                                 // Check for Improved Sensor bonus.
-                                if (objMod.Bonus != null)
+                                if (objMod.Bonus?["improvesensor"] != null || (objMod.WirelessOn && objMod.WirelessBonus?["improvesensor"] != null))
                                 {
-                                    if (objMod.Bonus["improvesensor"] != null)
-                                    {
-                                        ChangeVehicleSensor(objVehicle, false);
-                                    }
+                                    ChangeVehicleSensor(objVehicle, false);
                                 }
 
                                 // Remove the Vehicle Mod.
@@ -15268,34 +15271,46 @@ namespace Chummer
                             // Add the Armor's Improevments to the character.
                             if (objArmor.Bonus != null)
                                 _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.Bonus, false, 1, objArmor.DisplayNameShort);
+                            if (objArmor.WirelessOn && objArmor.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objArmor.WirelessBonus, false, 1, objArmor.DisplayNameShort);
                             // Add the Improvements from any Armor Mods in the Armor.
                             foreach (ArmorMod objMod in objArmor.ArmorMods)
                             {
-                                if (objMod.Bonus != null && objMod.Equipped)
-                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                                if (objMod.Equipped)
+                                {
+                                    if (objMod.Bonus != null)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                                    if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
+                                }
                             }
                             // Add the Improvements from any Gear in the Armor.
                             foreach (Gear objGear in objArmor.Gear)
                             {
-                                if (objGear.Bonus != null && objGear.Equipped)
-                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objGear.Equipped)
+                                {
+                                    if (objGear.Bonus != null)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                    if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                }
                             }
                         }
                         else
                         {
                             // Remove any Improvements the Armor created.
-                            if (objArmor.Bonus != null)
+                            if (objArmor.Bonus != null || (objArmor.WirelessOn && objArmor.WirelessBonus != null))
                                 _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
                             // Remove any Improvements from any Armor Mods in the Armor.
                             foreach (ArmorMod objMod in objArmor.ArmorMods)
                             {
-                                if (objMod.Bonus != null)
+                                if (objMod.Bonus != null || (objMod.WirelessOn && objMod.WirelessBonus != null))
                                     _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                             }
                             // Remove any Improvements from any Gear in the Armor.
                             foreach (Gear objGear in objArmor.Gear)
                             {
-                                if (objGear.Bonus != null)
+                                if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                                     _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                             }
                         }
@@ -15309,14 +15324,19 @@ namespace Chummer
                         objMod.Equipped = chkArmorEquipped.Checked;
                         if (chkArmorEquipped.Checked)
                         {
-                            // Add the Mod's Improevments to the character.
-                            if (objMod.Bonus != null && objMod.Parent.Equipped)
-                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            if (objMod.Parent.Equipped)
+                            {
+                                // Add the Mod's Improevments to the character.
+                                if (objMod.Bonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.Bonus, false, objMod.Rating, objMod.DisplayNameShort);
+                                if (objMod.WirelessOn && objMod.WirelessBonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objMod.WirelessBonus, false, objMod.Rating, objMod.DisplayNameShort);
+                            }
                         }
                         else
                         {
                             // Remove any Improvements the Mod created.
-                            if (objMod.Bonus != null)
+                            if (objMod.Bonus != null || (objMod.WirelessOn && objMod.WirelessBonus != null))
                                 _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                         }
                     }
@@ -15328,14 +15348,19 @@ namespace Chummer
                         objGear.Equipped = chkArmorEquipped.Checked;
                         if (chkArmorEquipped.Checked)
                         {
-                            // Add the Gear's Improevments to the character.
-                            if (objGear.Bonus != null && objFoundArmor.Equipped)
-                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            if (objFoundArmor.Equipped)
+                            {
+                                // Add the Gear's Improevments to the character.
+                                if (objGear.Bonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
+                            }
                         }
                         else
                         {
                             // Remove any Improvements the Gear created.
-                            if (objGear.Bonus != null)
+                            if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                                 _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                         }
                     }
@@ -17385,11 +17410,14 @@ namespace Chummer
                     objSelectedFocus.Bonded = true;
                     if (objSelectedFocus.Equipped)
                     {
-                        if (objSelectedFocus.Bonus != null)
+                        if (objSelectedFocus.Bonus != null || (objSelectedFocus.WirelessOn && objSelectedFocus.WirelessBonus != null))
                         {
                             if (!string.IsNullOrEmpty(objSelectedFocus.Extra))
                                 _objImprovementManager.ForcedValue = objSelectedFocus.Extra;
-                            _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objSelectedFocus.InternalId, objSelectedFocus.Bonus, false, objSelectedFocus.Rating, objSelectedFocus.DisplayNameShort);
+                            if (objSelectedFocus.Bonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objSelectedFocus.InternalId, objSelectedFocus.Bonus, false, objSelectedFocus.Rating, objSelectedFocus.DisplayNameShort);
+                            if (objSelectedFocus.WirelessOn && objSelectedFocus.WirelessBonus != null)
+                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objSelectedFocus.InternalId, objSelectedFocus.WirelessBonus, false, objSelectedFocus.Rating, objSelectedFocus.DisplayNameShort);
 
                             foreach (Power objPower in _objCharacter.Powers.Where(objPower => objFocus.GearId == objPower.BonusSource))
                             {
@@ -17419,11 +17447,14 @@ namespace Chummer
                     {
                         foreach (Gear objGear in objStack.Gear)
                         {
-                            if (objGear.Bonus != null)
+                            if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
                             {
                                 if (!string.IsNullOrEmpty(objGear.Extra))
                                     _objImprovementManager.ForcedValue = objGear.Extra;
-                                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objGear.Bonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objGear.Bonus, false, objGear.Rating, objGear.DisplayNameShort);
+                                if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.StackedFocus, objStack.InternalId, objGear.WirelessBonus, false, objGear.Rating, objGear.DisplayNameShort);
                             }
                         }
                     }
@@ -21575,7 +21606,7 @@ namespace Chummer
                 }
 
                 frmPickCyberware.AllowModularPlugins = objSelectedCyberware.AllowModularPlugins;
-                frmPickCyberware.Parent = objSelectedCyberware;
+                frmPickCyberware.CyberwareParent = objSelectedCyberware;
                 frmPickCyberware.Subsystems = objSelectedCyberware.AllowedSubsystems;
             }
 
@@ -24910,12 +24941,15 @@ namespace Chummer
         private void AddGearImprovements(Gear objGear)
         {
             string strForce = string.Empty;
-            if (objGear.Bonus != null)
+            if (objGear.Bonus != null || (objGear.WirelessOn && objGear.WirelessBonus != null))
             {
                 if (!string.IsNullOrEmpty(objGear.Extra))
                     strForce = objGear.Extra;
                 _objImprovementManager.ForcedValue = strForce;
-                _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, true, objGear.Rating, objGear.DisplayNameShort);
+                if (objGear.Bonus != null)
+                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.Bonus, true, objGear.Rating, objGear.DisplayNameShort);
+                if (objGear.WirelessOn && objGear.WirelessBonus != null)
+                    _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objGear.WirelessBonus, true, objGear.Rating, objGear.DisplayNameShort);
             }
             foreach (Gear objChild in objGear.Children)
                 AddGearImprovements(objChild);


### PR DESCRIPTION
Under-the-hood Changes:

- Refactored a variable in the Cyberware selection form so that it wouldn't be the same name as one of the properties that said selection form inhereted from its parent class.

Application Changes:

- Added backend support for wireless bonuses to Gear, Armor, Armor Mods, Vehicle Mods, and Cyberware.
- Fixed an issue where lifestyle qualities would not have closing square brackets for their costs.

Data Changes:

- Added entries for Chakram from the Run & Gun errata and the Horizon BoomerEye from the bottom of Boomerang's statblock in Run & Gun.