### PR TITLE
Forbidden Arcana Aspect Fixes

### DIFF
--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -3956,8 +3956,7 @@ namespace Chummer.Classes
             Log.Info("SourceName = " + SourceName);
 
             Log.Info("Calling CreateImprovement");
-            CreateImprovement(frmPickSpellCategory.SelectedCategory, _objImprovementSource, SourceName, Improvement.ImprovementType.LimitSpellCategory,
-                _strUnique);
+            CreateImprovement(SelectedValue, _objImprovementSource, SourceName, Improvement.ImprovementType.LimitSpellCategory, _strUnique);
         }
 
         public void limitspiritcategory(XmlNode bonusNode)
@@ -3980,8 +3979,15 @@ namespace Chummer.Classes
             {
                 throw new AbortedException();
             }
-            CreateImprovement(frmSelect.SelectedItem, Improvement.ImprovementSource.Quality, SourceName,
-    Improvement.ImprovementType.LimitSpiritCategory,"");
+            SelectedValue = frmSelect.SelectedItem;
+            if (_blnConcatSelectedValue)
+                SourceName += " (" + SelectedValue + ")";
+
+            Log.Info("_strSelectedValue = " + SelectedValue);
+            Log.Info("SourceName = " + SourceName);
+
+            Log.Info("Calling CreateImprovement");
+            CreateImprovement(SelectedValue, _objImprovementSource, SourceName, Improvement.ImprovementType.LimitSpiritCategory, _strUnique);
         }
         public void movementreplace(XmlNode bonusNode)
         {

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -14,6 +14,7 @@ Application Changes:
 - Fixed an issue when loading critters that caused them to have lower attribute values than intended.
 - Added backend support for wireless bonuses to Gear, Armor, Armor Mods, Vehicle Mods, and Cyberware.
 - Fixed an issue where lifestyle qualities would not have closing square brackets for their costs.
+- Altered the Limit Spirit Selection bonus so that it also adds to its selection to the bonus' source. This also makes Apprentice indicate the chosen spirit instead of the chosen spell.
 
 Data Changes:
 
@@ -25,6 +26,7 @@ Data Changes:
 - Fixed behaviour of spellcasting foci to scale based on Force. 
 - Fixed missing increased seating bonus for the Amenities (Squatter) vehicle modification.
 - Added entries for Chakram from the Run & Gun errata and the Horizon BoomerEye from the bottom of Boomerang's statblock in Run & Gun.
+- Added qualities for Explorer and Enchanter, and made minor fixes to Aware. Fixes #1705.
 
 New Strings:
 - Label_Options_SpellShapingFocus

--- a/Chummer/data/priorities.xml
+++ b/Chummer/data/priorities.xml
@@ -979,7 +979,7 @@
           <name>Explorer - 5 Magic</name>
           <value>Explorer</value>
           <qualities>
-            <quality>Aspected Magician</quality>
+            <quality>Explorer</quality>
           </qualities>
           <skillchoices>
             <skill>Arcana</skill>
@@ -1000,7 +1000,7 @@
           <name>Enchanter - 5 Magic</name>
           <value>Enchanter</value>
           <qualities>
-            <quality>Aspected Magician</quality>
+            <quality>Enchanter</quality>
           </qualities>
           <skillgroupchoices>
             <skillgroup>Enchanting</skillgroup>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -186,6 +186,8 @@
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Technomancer</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -218,6 +220,8 @@
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Technomancer</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -251,6 +255,8 @@
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Technomancer</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -282,6 +288,8 @@
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Technomancer</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -314,6 +322,8 @@
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Technomancer</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -345,6 +355,8 @@
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Technomancer</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -553,6 +565,8 @@
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magic Resistance (Rating 2)</quality>
           <quality>Magic Resistance (Rating 3)</quality>
@@ -586,6 +600,8 @@
           <quality>Mystic Adept</quality>
           <quality>Aware</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
@@ -617,6 +633,8 @@
           <quality>Mystic Adept</quality>
           <quality>Aware</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magic Resistance (Rating 2)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
@@ -648,6 +666,8 @@
           <quality>Aware</quality>
           <quality>Mystic Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magic Resistance (Rating 2)</quality>
           <quality>Magic Resistance (Rating 3)</quality>
@@ -672,6 +692,8 @@
         <oneof>
           <quality>Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
@@ -820,6 +842,8 @@
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Nosferatu</quality>
@@ -1091,6 +1115,9 @@
           <quality>Adept</quality>
           <quality>Mystic Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
+		  <quality>Aware</quality>
           <quality>Apprentice</quality>
           <quality>Technomancer</quality>
         </oneof>
@@ -1119,6 +1146,8 @@
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Technomancer</quality>
         </oneof>
@@ -1148,6 +1177,8 @@
           <quality>Magician</quality>
           <quality>Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Technomancer</quality>
         </oneof>
@@ -1178,6 +1209,8 @@
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Adept</quality>
         </oneof>
@@ -1203,6 +1236,8 @@
       <forbidden>
         <oneof>
           <quality>Aware</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
@@ -1228,15 +1263,19 @@
       <forbidden>
         <oneof>
           <quality>Apprentice</quality>
-          <quality>ASpected Magician</quality>
+          <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
           <quality>Adept</quality>
           <quality>Technomancer</quality>
         </oneof>
       </forbidden>
-      <source>SR5</source>
-      <page>69</page>
+      <source>FA</source>
+      <page>49</page>
     </quality>
     <!-- endregion-->
     <!--Region Shadowrun Core Negative Qualities -->
@@ -1404,6 +1443,8 @@
           <quality>Adept</quality>
           <quality>Aware</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
@@ -1907,6 +1948,8 @@
       <required>
         <oneof>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Aware</quality>
           <quality>Adept</quality>
@@ -3148,6 +3191,8 @@
       <required>
         <oneof>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Apprentice</quality>
           <quality>Magician</quality>
           <quality>Adept</quality>
@@ -3528,6 +3573,8 @@
             <quality>Aware</quality>
             <quality>Magician</quality>
             <quality>Aspected Magician</quality>
+			<quality>Enchanter</quality>
+			<quality>Explorer</quality>
             <quality>Apprentice</quality>
             <quality>Infected: Mutaqua</quality>
             <quality>Infected: Nosferatu</quality>
@@ -4923,6 +4970,8 @@
           <quality>Magician</quality>
           <quality>Aware</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
           <quality>Mystic Adept</quality>
           <quality>Apprentice</quality>
           <quality>Infected: Mutaqua</quality>
@@ -6936,6 +6985,8 @@
         <required>
           <oneof>
             <quality>Aspected Magician</quality>
+			<quality>Enchanter</quality>
+			<quality>Explorer</quality>
             <quality>Apprentice</quality>
             <quality>Magician</quality>
             <quality>Aware</quality>
@@ -14085,12 +14136,70 @@
         <unlockskills>Sorcery</unlockskills>
         <unlockskills>Conjuring</unlockskills>
         <limitspellcategory />
-        <limitspiritcategory />
+		<limitspiritcategory />
       </bonus>
       <forbidden>
         <oneof>
           <quality>Aware</quality>
           <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Explorer</quality>
+          <quality>Magician</quality>
+          <quality>Mystic Adept</quality>
+          <quality>Adept</quality>
+          <quality>Technomancer</quality>
+        </oneof>
+      </forbidden>
+      <source>FA</source>
+      <page>47</page>
+    </quality>
+	<quality>
+      <id>a2484390-c4ea-4013-b007-4dc5d3a5c85b</id>
+      <name>Enchanter</name>
+      <contributetolimit>False</contributetolimit>
+      <karma>15</karma>
+      <category>Positive</category>
+      <bonus>
+        <enableattribute>
+          <name>MAG</name>
+        </enableattribute>
+        <enabletab>
+          <name>magician</name>
+        </enabletab>
+        <unlockskills>Enchanting</unlockskills>
+      </bonus>
+      <forbidden>
+        <oneof>
+          <quality>Aware</quality>
+          <quality>Aspected Magician</quality>
+		  <quality>Apprentice</quality>
+		  <quality>Explorer</quality>
+          <quality>Magician</quality>
+          <quality>Mystic Adept</quality>
+          <quality>Adept</quality>
+          <quality>Technomancer</quality>
+        </oneof>
+      </forbidden>
+      <source>FA</source>
+      <page>47</page>
+    </quality>
+	<quality>
+      <id>2f20c108-d724-4684-a642-d40ffe7c51e1</id>
+      <name>Explorer</name>
+      <contributetolimit>False</contributetolimit>
+      <karma>15</karma>
+      <category>Positive</category>
+      <bonus>
+        <enableattribute>
+          <name>MAG</name>
+        </enableattribute>
+      </bonus>
+      <forbidden>
+        <oneof>
+          <quality>Aware</quality>
+          <quality>Aspected Magician</quality>
+		  <quality>Enchanter</quality>
+		  <quality>Apprentice</quality>
           <quality>Magician</quality>
           <quality>Mystic Adept</quality>
           <quality>Adept</quality>


### PR DESCRIPTION
Application Changes:

- Altered the Limit Spirit Selection bonus so that it also adds to its selection to the bonus' source. This also makes Apprentice indicate the chosen spirit instead of the chosen spell.

Data Changes:

- Added qualities for Explorer and Enchanter, and made minor fixes to Aware. Fixes #1705.