### PR TITLE
Mentor Spirit, Adept Power Fixes

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -2062,7 +2062,7 @@ namespace Chummer
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
-                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Power, objPower.InternalId, objNode["bonus"], false, Convert.ToInt32(objPower.Rating), objPower.DisplayNameShort);
+                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Power, objPower.InternalId, objNode["bonus"], false, Convert.ToInt32(objPower.TotalRating), objPower.DisplayNameShort);
                     }
                 }
             }

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -1343,16 +1343,13 @@ namespace Chummer
                         Power objImprovedPower = _objCharacter.Powers.First(objPower => objPower.Name == objImprovement.ImprovedName &&
                                         objPower.Extra == objImprovement.UniqueName);
 
-                        if (objImprovedPower.TotalRating == 0)
+                        if (objImprovedPower.TotalRating <= 0)
                         {
                             objImprovedPower.Deleting = true;
                             _objCharacter.Powers.Remove(objImprovedPower);
                         }
-                        else
-                        {
-                            // TODO Find a better way to trigger OnPropertyChanged() of the Power object
-                            objImprovedPower.TotalRating = objImprovedPower.TotalRating;
-                        }
+
+                        objImprovedPower.OnPropertyChanged(nameof(objImprovedPower.TotalRating));
                         break;
                 }
             }

--- a/Chummer/Selection Forms/frmSelectPower.cs
+++ b/Chummer/Selection Forms/frmSelectPower.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -88,7 +88,7 @@ namespace Chummer
                 if (objXmlPower["extrapointcost"]?.InnerText != null && blnAdd)
                 {
                     //If this power has already had its rating paid for with PP, we don't care about the extrapoints cost. 
-                    if (!_objCharacter.Powers.Any(power => power.Name == objXmlPower["name"].InnerText && power.Rating > 0))
+                    if (!_objCharacter.Powers.Any(power => power.Name == objXmlPower["name"].InnerText && power.TotalRating > 0))
                         dblPoints += Convert.ToDouble(objXmlPower["extrapointcost"]?.InnerText, GlobalOptions.InvariantCultureInfo);
                 }
                 if (_dblLimitToRating > 0 && blnAdd)

--- a/Chummer/UI/Powers/PowerControl.cs
+++ b/Chummer/UI/Powers/PowerControl.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -71,19 +71,21 @@ namespace Chummer
 
         private void Power_PropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)
         {
-            switch (propertyChangedEventArgs?.PropertyName)
+            string strPropertyName = propertyChangedEventArgs?.PropertyName;
+            if (strPropertyName == nameof(PowerObject.FreeLevels) || strPropertyName == nameof(PowerObject.TotalRating))
             {
-                case nameof(PowerObject.CharacterObject.MAG.TotalValue):
-                //TODO: For skills - probably needs to be rebound to something more specific?
-                case "Karma":
+                PowerObject.DisplayPoints = PowerObject.PowerPoints.ToString();
+                tipTooltip.SetToolTip(lblPowerPoints, PowerObject.ToolTip());
+                cmdDelete.Enabled = PowerObject.FreeLevels == 0;
+            }
+            // Super hacky solution, but we need all values updated properly if maxima change for any reason
+            if (strPropertyName == nameof(PowerObject.TotalMaximumLevels))
+            {
+                nudRating.Maximum = PowerObject.TotalMaximumLevels;
+            }
+            else if (strPropertyName == "Karma" || PowerObject.Name == "Improved Ability (skill)" || strPropertyName == nameof(PowerObject.CharacterObject.MAG.TotalValue))
+            {
                 PowerObject.ForceEvent(nameof(PowerObject.TotalMaximumLevels));
-                    break;
-                case nameof(PowerObject.FreeLevels):
-                case nameof(PowerObject.TotalRating):
-                    PowerObject.DisplayPoints = PowerObject.PowerPoints.ToString();
-                    tipTooltip.SetToolTip(lblPowerPoints, PowerObject.ToolTip());
-                    cmdDelete.Enabled = PowerObject.FreeLevels == 0;
-                    break;
             }
         }
 

--- a/Chummer/UI/Powers/PowersTabUserControl.cs
+++ b/Chummer/UI/Powers/PowersTabUserControl.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -122,7 +122,7 @@ namespace Chummer.UI.Powers
                 new Tuple<string, IComparer<Power>>(LanguageManager.Instance.GetString("Skill_SortAlphabetical"),
                     new PowerSorter((x, y) => x.DisplayName.CompareTo(y.DisplayName))),
                 new Tuple<string, IComparer<Power>>(LanguageManager.Instance.GetString("Skill_SortRating"),
-                    new PowerSorter((x, y) => y.Rating.CompareTo(x.Rating))),
+                    new PowerSorter((x, y) => y.TotalRating.CompareTo(x.TotalRating))),
                 new Tuple<string, IComparer<Power>>(LanguageManager.Instance.GetString("Power_SortAction"),
                     new PowerSorter((x, y) => y.DisplayAction.CompareTo(x.DisplayAction))),
                 //new Tuple<string, IComparer<Power>>(LanguageManager.Instance.GetString("Skill_SortCategory"),
@@ -230,11 +230,13 @@ namespace Chummer.UI.Powers
             XmlDocument objXmlDocument = XmlManager.Instance.Load("powers.xml");
 
             XmlNode objXmlPower = objXmlDocument.SelectSingleNode("/chummer/powers/power[name = \"" + frmPickPower.SelectedPower + "\"]");
-            objPower.Create(objXmlPower, ObjCharacter.ObjImprovementManager);
-            ObjCharacter.Powers.Add(objPower);
-            MissingDatabindingsWorkaround();
-            if (frmPickPower.AddAgain)
-                cmdAddPower_Click(sender, e);
+            if (objPower.Create(objXmlPower))
+            {
+                ObjCharacter.Powers.Add(objPower);
+                MissingDatabindingsWorkaround();
+                if (frmPickPower.AddAgain)
+                    cmdAddPower_Click(sender, e);
+            }
         }
 
         /// <summary>

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -22,6 +22,12 @@ Application Changes:
 - Fixed a bug where bonuses granting free levels of certain adept powers, e.g. Improved Ability, would not actually have their effect applied, and would also not have their effect properly removed if the source of the bonus was removed.
 - Made minor performance optimization to code that constructs the dicepool tooltips for skills.
 - The "Select Skill" form can now process multiple skill group inclusions, skill group exclusions, and skill category inclusions the same way it does for multiple skill inclusions (the old way of handling multiple skill category inclusions still works). It can also handle multiple filters at once, e.g. list only Physical Skills that are linked to STR, or list all Social Skills excluding the ones in the Acting skill group.
+- Fixed a bug that prevented bonuses granting free levels of certain powers from updating values boosted by said powers. Fixes #1834 and #1856.
+- Fixed a bug that made removing items that granted free levels of adept powers sometimes not actually remove the improvements added by said adept powers.
+- Fixed a bug that allowed the deletion of some powers without levels that were granted by free levels of adept powers.
+- Maximum values for adept powers should now update properly with changes to MAG values, and in the case of Improved Ability, changes to skill ratings.
+- Cancelling out of a dialog triggered by selecting an adept power or a property of an adept power will now properly cancel the dialog and not actually add the last/default selected choice.
+- Added support for skill selection dialogs to be able to only show skills for which the runner has a rating greater than 0. In case there are no eligible options, a warning dialog is displayed, and the skill selection dialog is automatically treated as cancelled.
 
 Data Changes:
 
@@ -39,8 +45,9 @@ Data Changes:
 - Updated all mentor spirits whose free adept powers have a restricted selection (e.g. Firebringer, Wise Warrior, Seducer) so that those restrictions properly work.
 - Corrected the text of Seducer mentor spirit's adept bonus to match the one found in the core rulebook.
 - Corrected the page number references of Forbidden Arcana mentor spirits.
-- Spider (Alt) now properly gives 2 levels of Spirit Claw instead of 1.
+- Spider (Alt) now properly gives 2 levels of Spirit Claw instead of 1. (Yes, Spirit Claw does not have levels, so Forbidden Arcana will need to be errata'd, but Chummer5 can handle this sort of thing regardless)
 - Changed the name of "Great Mother" mentor spirit from SASS to "Great Mother (SASS)" to differentiate it from an identically named mentor spirit from Forbidden Arcana.
+- Improved Ability can no longer be taken for skills that have a rating of 0, as 0 x1.5 is still 0. This extends to Mentor Spirits that would give free levels of Improved Ability.
 
 New Strings:
 - Label_Options_SpellShapingFocus
@@ -49,6 +56,8 @@ New Strings:
 - Label_Options_FlexibleSignatureFocus
 - Label_Options_DisenchantingFocus
 - Label_Options_AlchemicalFocus
+- Message_Improvement_EmptySelectionList
+- Message_Improvement_EmptySelectionListNamed
 
 Changes Strings:
 - Message_PositiveQualityLimit

--- a/Chummer/data/mentors.xml
+++ b/Chummer/data/mentors.xml
@@ -245,7 +245,7 @@
               <name>Improved Ability (skill)</name>
               <val>1</val>
 			  <bonusoverride>
-				<selectskill>
+				<selectskill requireexistingnonzerorating="true">
 					<val>Rating</val>
 					<applytorating>yes</applytorating>
 					<skillcategories>
@@ -432,7 +432,7 @@
               <name>Improved Ability (skill)</name>
               <val>1</val>
 			  <bonusoverride>
-				<selectskill skillcategory="Physical Active">
+				<selectskill skillcategory="Physical Active" requireexistingnonzerorating="true">
 					<val>Rating</val>
 					<applytorating>yes</applytorating>
 				</selectskill>
@@ -473,7 +473,7 @@
               <name>Improved Ability (skill)</name>
               <val>1</val>
 			  <bonusoverride>
-				<selectskill skillgroup="Acting,Influence">
+				<selectskill skillgroup="Acting,Influence" requireexistingnonzerorating="true">
 					<val>Rating</val>
 					<applytorating>yes</applytorating>
 				</selectskill>
@@ -625,7 +625,7 @@
               <name>Improved Ability (skill)</name>
               <val>1</val>
               <bonusoverride>
-				<selectskill skillcategory="Combat Active">
+				<selectskill skillcategory="Combat Active" requireexistingnonzerorating="true">
 					<val>Rating</val>
 					<applytorating>yes</applytorating>
 				</selectskill>
@@ -2608,7 +2608,7 @@
               <name>Improved Ability (skill)</name>
               <val>1</val>
 			  <bonusoverride>
-				<selectskill limittoskill="Artisan,Aeronautics Mechanic,Automotive Mechanic,Industrial Mechanic,Nautical Mechanic">
+				<selectskill limittoskill="Artisan,Aeronautics Mechanic,Automotive Mechanic,Industrial Mechanic,Nautical Mechanic" requireexistingnonzerorating="true">
 					<val>Rating</val>
 					<applytorating>yes</applytorating>
 				</selectskill>
@@ -2735,7 +2735,7 @@
               <name>Improved Ability (skill)</name>
               <val>1</val>
 			  <bonusoverride>
-				<selectskill limittoskill="Con,Impersonation,Performance,Etiquette,Leadership,Negotiation">
+				<selectskill limittoskill="Con,Impersonation,Performance,Etiquette,Leadership,Negotiation" requireexistingnonzerorating="true">
 					<val>Rating</val>
 					<applytorating>yes</applytorating>
 				</selectskill>

--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -204,7 +204,7 @@
         </required>
       </adeptwayrequires>
       <bonus>
-        <selectskill>
+        <selectskill requireexistingnonzerorating="true">
           <val>Rating</val>
           <applytorating>yes</applytorating>
           <skillcategories>

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -1927,7 +1927,7 @@ namespace Chummer
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
-                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Power, objPower.InternalId, objNode["bonus"], false, Convert.ToInt32(objPower.Rating), objPower.DisplayNameShort);
+                        _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Power, objPower.InternalId, objNode["bonus"], false, Convert.ToInt32(objPower.TotalRating), objPower.DisplayNameShort);
                     }
                 }
             }

--- a/Chummer/lang/de.xml
+++ b/Chummer/lang/de.xml
@@ -7435,6 +7435,14 @@
       <key>String_CustomItem_SelectText</key>
       <text>Geben Sie einen Namen für diesen Gegenstand an.</text>
     </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionList</key>
+      <text>No eligible items could be selected for this effect!</text>
+    </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionListNamed</key>
+      <text>No eligible items could be selected for {0} to affect!</text>
+    </string>
     <string>
       <key>String_MetamagicSkillBase</key>
       <text>Basierend auf Ihrer Talentauswahl dürfen Sie {0} auswählen.</text>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -8369,6 +8369,14 @@ Do you want to continue?</text>
       <key>String_CustomItem_SelectText</key>
       <text>Enter a name for this custom item.</text>
     </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionList</key>
+      <text>No eligible items could be selected for this effect!</text>
+    </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionListNamed</key>
+      <text>No eligible items could be selected for {0} to affect!</text>
+    </string>
     <!-- End Region-->
     <!-- Region CharacterOptions Messages -->
     <string>

--- a/Chummer/lang/en-us2.xml
+++ b/Chummer/lang/en-us2.xml
@@ -7262,6 +7262,14 @@ Only one attribute may be at its Maximum value during character creation.</text>
 			<key>String_CustomItem_SelectText</key>
 			<text>Enter a name for this custom item.</text>
 		</string>
+		<string>
+			<key>Message_Improvement_EmptySelectionList</key>
+			<text>No eligible items could be selected for this effect!</text>
+		</string>
+		<string>
+			<key>Message_Improvement_EmptySelectionListNamed</key>
+			<text>No eligible items could be selected for {0} to affect!</text>
+		</string>
 		<!-- CharacterOptions Messages -->
 		<string>
 			<key>Message_CharacterOptions_CannotLoadSetting</key>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -6910,6 +6910,14 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
       <key>String_CustomItem_SelectText</key>
       <text>Entrez un nom pour cet objet personnalisé.</text>
     </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionList</key>
+      <text>No eligible items could be selected for this effect!</text>
+    </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionListNamed</key>
+      <text>No eligible items could be selected for {0} to affect!</text>
+    </string>
     <string>
       <key>MessageTitle_Metatype_SelectTalent</key>
       <text>Selectionner un Talent</text>

--- a/Chummer/lang/jp.xml
+++ b/Chummer/lang/jp.xml
@@ -7347,6 +7347,14 @@
       <key>String_CustomItem_SelectText</key>
       <text>Enter a name for this custom item.</text>
     </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionList</key>
+      <text>No eligible items could be selected for this effect!</text>
+    </string>
+	<string>
+      <key>Message_Improvement_EmptySelectionListNamed</key>
+      <text>No eligible items could be selected for {0} to affect!</text>
+    </string>
     <string>
       <key>String_MetamagicSkillBase</key>
       <text>Based on your talent selection, you may choose {0}.</text>


### PR DESCRIPTION
Application Changes:

- Fixed a bug that prevented bonuses granting free levels of certain powers from updating values boosted by said powers. Fixes #1834 and #1856.
- Fixed a bug that made removing items that granted free levels of adept powers sometimes not actually remove the improvements added by said adept powers.
- Fixed a bug that allowed the deletion of some powers without levels that were granted by free levels of adept powers.
- Maximum values for adept powers should now update properly with changes to MAG values, and in the case of Improved Ability, changes to skill ratings.
- Cancelling out of a dialog triggered by selecting an adept power or a property of an adept power will now properly cancel the dialog and not actually add the last/default selected choice.
- Added support for skill selection dialogs to be able to only show skills for which the runner has a rating greater than 0. In case there are no eligible options, a warning dialog is displayed, and the skill selection dialog is automatically treated as cancelled.

Data Changes:

- Improved Ability can no longer be taken for skills that have a rating of 0, as 0 x1.5 is still 0. This extends to Mentor Spirits that would give free levels of Improved Ability.

New Strings:
- Message_Improvement_EmptySelectionList
- Message_Improvement_EmptySelectionListNamed