### PR TITLE
Forbidden Arcana, Adept, & Other Fixes

### DIFF
--- a/Chummer/Backend/Attributes/Attribute.Core.cs
+++ b/Chummer/Backend/Attributes/Attribute.Core.cs
@@ -1,4 +1,4 @@
-﻿using Chummer.Annotations;
+using Chummer.Annotations;
 using Chummer.Backend.Equipment;
 using System;
 using System.Collections.Generic;
@@ -730,15 +730,19 @@ namespace Chummer.Backend.Attributes
                         intReturn = 1;
                 }
 
-                if (_objCharacter.EssencePenalty == 0 || _strAbbrev != "MAG" && _strAbbrev != "RES" && _strAbbrev != "DEP") return intReturn;
+                int intEssencePenalty = _objCharacter.EssencePenalty;
+                if (_strAbbrev == "MAG")
+                    intEssencePenalty = _objCharacter.EssencePenaltyMAG;
+
+                if (intEssencePenalty == 0 || _strAbbrev != "MAG" && _strAbbrev != "RES" && _strAbbrev != "DEP") return intReturn;
 
                 if (!_objCharacter.Options.ESSLossReducesMaximumOnly)
                 {
-                    return Math.Max(intReturn - _objCharacter.EssencePenalty, 0);
+                    return Math.Max(intReturn - intEssencePenalty, 0);
                 }
-                if (_objCharacter.EssencePenalty >= TotalMaximum)
+                if (intEssencePenalty >= TotalMaximum)
                 {
-                    intReturn = Math.Max(intReturn - _objCharacter.EssencePenalty, 0);
+                    intReturn = Math.Max(intReturn - intEssencePenalty, 0);
                 }
                 return intReturn;
             }
@@ -1136,7 +1140,11 @@ namespace Chummer.Backend.Attributes
                 // Find the character's Essence Loss. This applies unless the house rule to have ESS Loss only affect the Maximum of the CharacterAttribute is turned on.
                 int intEssenceLoss = 0;
                 if (!_objCharacter.Options.ESSLossReducesMaximumOnly)
+                {
                     intEssenceLoss = _objCharacter.EssencePenalty;
+                    if (_strAbbrev == "MAG")
+                        intEssenceLoss = _objCharacter.EssencePenaltyMAG;
+                }
 
                 // Don't apply the ESS loss penalty to EDG.
                 int intUseEssenceLoss = intEssenceLoss;

--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -1296,6 +1296,15 @@ namespace Chummer.Backend.Equipment
                     else
                         strDamage = strDamageExpression.Replace("STR", (_objCharacter.STR.TotalValue + intThrowDV).ToString());
                 }
+
+                foreach(Attributes.CharacterAttrib objLoopAttribute in _objCharacter.AttributeList)
+                {
+                    strDamage = strDamage.Replace(objLoopAttribute.Abbrev, objLoopAttribute.TotalValue.ToString());
+                }
+                foreach (Attributes.CharacterAttrib objLoopAttribute in _objCharacter.SpecialAttributeList)
+                {
+                    strDamage = strDamage.Replace(objLoopAttribute.Abbrev, objLoopAttribute.TotalValue.ToString());
+                }
             }
             else
             {

--- a/Chummer/Backend/Shared Methods/CharacterShared.cs
+++ b/Chummer/Backend/Shared Methods/CharacterShared.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -76,7 +76,18 @@ namespace Chummer
         public void AutoSaveCharacter()
         {
             if (!Directory.Exists(Path.Combine(Application.StartupPath, "saves", "autosave")))
-                Directory.CreateDirectory(Path.Combine(Application.StartupPath, "saves", "autosave"));
+            {
+                try
+                {
+                    Directory.CreateDirectory(Path.Combine(Application.StartupPath, "saves", "autosave"));
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    MessageBox.Show(LanguageManager.Instance.GetString("Message_Insufficient_Permissions_Warning"));
+                    Autosave_StopWatch.Restart();
+                    return;
+                }
+            }
             
             string[] strFile = _objCharacter.FileName.Split(Path.DirectorySeparatorChar);
             string strShowFileName = strFile[strFile.Length - 1];
@@ -84,14 +95,7 @@ namespace Chummer
             if (string.IsNullOrEmpty(strShowFileName))
                 strShowFileName = _objCharacter.Alias;
             string strFilePath = Path.Combine(Application.StartupPath, "saves", "autosave", strShowFileName);
-            try
-            {
-                _objCharacter.Save(strFilePath);
-            }
-            catch
-            {
-                // ignored, no point crashing the application if we can't backup.
-            }
+            _objCharacter.Save(strFilePath);
             Autosave_StopWatch.Restart();
         }
         protected void RedlinerCheck()

--- a/Chummer/Backend/Shared Methods/SelectionShared.cs
+++ b/Chummer/Backend/Shared Methods/SelectionShared.cs
@@ -223,11 +223,20 @@ namespace Chummer.Backend.Shared_Methods
             {
                 case "attribute":
                     // Check to see if an Attribute meets a requirement.
-                    CharacterAttrib objAttribute =
-                        character.GetAttribute(node["name"].InnerText);
+                    CharacterAttrib objAttribute = character.GetAttribute(node["name"].InnerText);
                     name = $"\n\t{objAttribute.DisplayAbbrev} {node["total"].InnerText}";
-                    return objAttribute.TotalValue >=
-                           Convert.ToInt32(node["total"].InnerText);
+                    int intTargetValue = Convert.ToInt32(node["total"].InnerText);
+                    // Special cases for when we want to check if a special attribute is enabled
+                    if (intTargetValue == 1)
+                    {
+                        if (objAttribute.Abbrev == "MAG")
+                            return character.MAGEnabled;
+                        if (objAttribute.Abbrev == "RES")
+                            return character.RESEnabled;
+                        if (objAttribute.Abbrev == "DEP")
+                            return character.DEPEnabled;
+                    }
+                    return objAttribute.TotalValue >= intTargetValue;
 
                 case "attributetotal":
                     // Check if the character's Attributes add up to a particular total.

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -242,6 +242,7 @@ namespace Chummer
                 tabCharacterTabs.TabPages.Remove(tabCritter);
             if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
             {
+                /*
                 // Hide the pieces that only apply to mages or mystic adepts
                 treSpells.Nodes[4].Remove();
                 treSpells.Nodes[3].Remove();
@@ -251,6 +252,7 @@ namespace Chummer
                 lblDrainAttributesLabel.Visible = false;
                 lblDrainAttributes.Visible = false;
                 lblDrainAttributesValue.Visible = false;
+                */
                 lblSpirits.Visible = false;
                 cmdAddSpirit.Visible = false;
                 panSpirits.Visible = false;
@@ -1967,6 +1969,9 @@ namespace Chummer
 
             _blnReapplyImprovements = true;
 
+            // Wipe all improvements that we will reapply, this is mainly to eliminate orphaned improvements caused by certain bugs and also for a performance increase
+            _objImprovementManager.RemoveImprovements(0, string.Empty, true);
+
             // Refresh Qualities.
             XmlDocument objXmlDocument = XmlManager.Instance.Load("qualities.xml");
             foreach (Quality objQuality in _objCharacter.Qualities)
@@ -1976,7 +1981,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/qualities/quality[name = \"" + objQuality.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Quality, objQuality.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Quality, objQuality.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -2008,7 +2014,8 @@ namespace Chummer
                     XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/martialarts/martialart[name = \"" + objMartialArt.Name + "\"]/techniques/technique[name = \"" + objAdvantage.Name + "\"]");
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.MartialArtAdvantage, objAdvantage.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.MartialArtAdvantage, objAdvantage.InternalId);
                         if (objNode["bonus"] != null)
                         {
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.MartialArtAdvantage, objAdvantage.InternalId, objNode["bonus"], false, 1, objAdvantage.DisplayName);
@@ -2026,7 +2033,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/spells/spell[name = \"" + objSpell.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Spell, objSpell.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Spell, objSpell.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -2058,7 +2066,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/powers/power[name = \"" + objPower.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Power, objPower.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Power, objPower.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -2074,7 +2083,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/complexforms/complexform[name = \"" + objProgram.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ComplexForm, objProgram.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ComplexForm, objProgram.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         foreach (TreeNode objParentNode in treComplexForms.Nodes)
@@ -2099,7 +2109,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/programs/program[name = \"" + objProgram.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.AIProgram, objProgram.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.AIProgram, objProgram.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         foreach (TreeNode objParentNode in treAIPrograms.Nodes)
@@ -2127,7 +2138,8 @@ namespace Chummer
 
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.CritterPower, objPower.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.CritterPower, objPower.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         int intRating = 0;
@@ -2164,7 +2176,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Metamagic, objMetamagic.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Metamagic, objMetamagic.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Metamagic, objMetamagic.InternalId, objNode["bonus"], false, 1, objMetamagic.DisplayNameShort);
                     }
@@ -2176,7 +2189,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Echo, objMetamagic.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Echo, objMetamagic.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Echo, objMetamagic.InternalId, objNode["bonus"], false, 1, objMetamagic.DisplayNameShort);
                     }
@@ -2193,7 +2207,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objCyberware.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objCyberware.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Cyberware, objCyberware.InternalId, objNode["bonus"], false, objCyberware.Rating, objCyberware.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2218,7 +2233,8 @@ namespace Chummer
 
                         if (objChild != null)
                         {
-                            _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objPlugin.InternalId);
+                            // Because all improvements are wiped at the start, no need to go and remove them again
+                            //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objPlugin.InternalId);
                             if (objChild["bonus"] != null)
                                 _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Cyberware, objPlugin.InternalId, objChild["bonus"], false, objPlugin.Rating, objPlugin.DisplayNameShort);
                         }
@@ -2231,7 +2247,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId, objNode["bonus"], false, objCyberware.Rating, objCyberware.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2256,7 +2273,8 @@ namespace Chummer
 
                         if (objChild != null)
                         {
-                            _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objPlugin.InternalId);
+                            // Because all improvements are wiped at the start, no need to go and remove them again
+                            //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objPlugin.InternalId);
                             if (objChild["bonus"] != null)
                                 _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Bioware, objPlugin.InternalId, objChild["bonus"], false, objPlugin.Rating, objPlugin.DisplayNameShort);
                         }
@@ -2272,7 +2290,8 @@ namespace Chummer
 
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
                     if (objNode["bonus"] != null)
                         _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objNode["bonus"], false, 1, objArmor.DisplayNameShort);
                     if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2297,7 +2316,8 @@ namespace Chummer
 
                     if (objChild != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                         if (objChild["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objChild["bonus"], false, 1, objMod.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2327,7 +2347,8 @@ namespace Chummer
 
                     if (objChild != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                         if (objChild["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objChild["bonus"], false, objGear.Rating, objGear.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2360,7 +2381,8 @@ namespace Chummer
 
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -2389,7 +2411,8 @@ namespace Chummer
 
                     if (objChild != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objPlugin.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objPlugin.InternalId);
                         if (objChild["bonus"] != null)
                         {
                             _objImprovementManager.ForcedValue = strPluginSelected;
@@ -2421,7 +2444,8 @@ namespace Chummer
 
                         if (objSubChild != null)
                         {
-                            _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objSubPlugin.InternalId);
+                            // Because all improvements are wiped at the start, no need to go and remove them again
+                            //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objSubPlugin.InternalId);
                             if (objSubChild["bonus"] != null)
                             {
                                 _objImprovementManager.ForcedValue = strSubPluginSelected;
@@ -4059,6 +4083,11 @@ namespace Chummer
                 return;
 
             objSpell.FreeBonus = frmPickSpell.FreeBonus;
+            // Barehanded Adept
+            if (objSpell.FreeBonus && _objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled && objSpell.Range == "T")
+            {
+                objSpell.UsesUnarmed = true;
+            }
             _objCharacter.Spells.Add(objSpell);
 
             switch (objSpell.Category)
@@ -4084,11 +4113,15 @@ namespace Chummer
                     treSpells.Nodes[4].Expand();
                     break;
                 case "Rituals":
+                    /*
                     int intNode = 5;
                     if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
                         intNode = 0;
                     treSpells.Nodes[intNode].Nodes.Add(objNode);
                     treSpells.Nodes[intNode].Expand();
+                    */
+                    treSpells.Nodes[5].Nodes.Add(objNode);
+                    treSpells.Nodes[5].Expand();
                     break;
             }
 
@@ -9268,11 +9301,15 @@ namespace Chummer
                     treSpells.Nodes[4].Expand();
                     break;
                 case "Rituals":
+                    /*
                     int intNode = 5;
                     if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
                         intNode = 0;
                     treSpells.Nodes[intNode].Nodes.Add(objNode);
                     treSpells.Nodes[intNode].Expand();
+                    */
+                    treSpells.Nodes[5].Nodes.Add(objNode);
+                    treSpells.Nodes[5].Expand();
                     break;
             }
 
@@ -13130,29 +13167,40 @@ namespace Chummer
             int spellPoints = 0;
             int ritualPoints = 0;
             int prepPoints = 0;
-            if (_objCharacter.MagicianEnabled)
+            if (_objCharacter.MagicianEnabled ||
+                    _objCharacter.Improvements.Any(objImprovement => objImprovement.ImproveType == Improvement.ImprovementType.FreeSpells ||
+                                                                     objImprovement.ImproveType == Improvement.ImprovementType.FreeSpellsATT ||
+                                                                     objImprovement.ImproveType == Improvement.ImprovementType.FreeSpellsSkill))
             {
                 // Count the number of Spells the character currently has and make sure they do not try to select more Spells than they are allowed.
                 int spells = _objCharacter.Spells.Where(spell => (!spell.Alchemical) && spell.Category != "Rituals" && !spell.FreeBonus).Count();
+                int intTouchOnlySpells = _objCharacter.Spells.Where(spell => (!spell.Alchemical) && spell.Category != "Rituals" && spell.Range == "T" && !spell.FreeBonus).Count();
                 int rituals = _objCharacter.Spells.Where(spell => (!spell.Alchemical) && spell.Category == "Rituals" && !spell.FreeBonus).Count();
                 int preps = _objCharacter.Spells.Where(spell => spell.Alchemical && !spell.FreeBonus).Count();
 
                 int limit = _objCharacter.SpellLimit;
                 int limitMod = _objImprovementManager.ValueOf(Improvement.ImprovementType.SpellLimit) +
                                _objImprovementManager.ValueOf(Improvement.ImprovementType.FreeSpells);
-                foreach (
-                    Improvement imp in
-                    _objCharacter.Improvements.Where(i => i.ImproveType == Improvement.ImprovementType.FreeSpellsATT))
+                int limitModTouchOnly = 0;
+                foreach (Improvement imp in _objCharacter.Improvements.Where(i => i.ImproveType == Improvement.ImprovementType.FreeSpellsATT))
                 {
-                    CharacterAttrib att = _objCharacter.GetAttribute(imp.UniqueName);
-                    limitMod += att.TotalValue;
+                    int intAttValue = _objCharacter.GetAttribute(imp.ImprovedName).TotalValue;
+                    if (imp.UniqueName.Contains("half"))
+                        intAttValue = (intAttValue + 1) / 2;
+                    if (imp.UniqueName.Contains("touchonly"))
+                        limitModTouchOnly += intAttValue;
+                    else
+                        limitMod += intAttValue;
                 }
-                foreach (
-                    Improvement imp in
-                    _objCharacter.Improvements.Where(i => i.ImproveType == Improvement.ImprovementType.FreeSpellsSkill))
+                foreach (Improvement imp in _objCharacter.Improvements.Where(i => i.ImproveType == Improvement.ImprovementType.FreeSpellsSkill))
                 {
-                    Skill objSkill = _objCharacter.SkillsSection.Skills.First(x => x.Name == imp.ImprovedName);
-                    limitMod += objSkill.LearnedRating;
+                    int intSkillValue = _objCharacter.SkillsSection.Skills.First(x => x.Name == imp.ImprovedName).LearnedRating;
+                    if (imp.UniqueName.Contains("half"))
+                        intSkillValue = (intSkillValue + 1) / 2;
+                    if (imp.UniqueName.Contains("touchonly"))
+                        limitModTouchOnly += intSkillValue;
+                    else
+                        limitMod += intSkillValue;
                 }
 
                 if (nudMysticAdeptMAGMagician.Value > 0)
@@ -13167,6 +13215,9 @@ namespace Chummer
                         intKarmaPointsRemain -= intAttributePointsUsed;
                     }
                 }
+                spells -= intTouchOnlySpells;
+                intTouchOnlySpells = Math.Max(0, intTouchOnlySpells - limitModTouchOnly);
+                spells += intTouchOnlySpells;
                 for (int i = limit+limitMod; i > 0; i--)
                 {
                     if (spells > 0)
@@ -14729,9 +14780,9 @@ namespace Chummer
             string strCounterSpelling = LanguageManager.Instance.GetString("Label_CounterspellingDice");
             string strSpellResistance = LanguageManager.Instance.GetString("String_SpellResistanceDice");
             //Indirect Dodge
-            lblSpellDefenceIndirectDodge.Text = (_objCharacter.AGI.TotalValue + _objCharacter.REA.TotalValue).ToString();
+            lblSpellDefenceIndirectDodge.Text = (_objCharacter.INT.TotalValue + _objCharacter.REA.TotalValue + _objCharacter.TotalBonusDodgeRating).ToString();
             strSpellTooltip = $"{strModifiers}: " +
-                              $"{_objCharacter.INT.DisplayAbbrev} ({_objCharacter.INT.TotalValue}) + {_objCharacter.REA.DisplayAbbrev} ({_objCharacter.REA.TotalValue})";
+                              $"{_objCharacter.INT.DisplayAbbrev} ({_objCharacter.INT.TotalValue}) + {_objCharacter.REA.DisplayAbbrev} ({_objCharacter.REA.TotalValue}) + {strModifiers} ({_objCharacter.TotalBonusDodgeRating})";
             tipTooltip.SetToolTip(lblSpellDefenceIndirectDodge, strSpellTooltip);
             //Indirect Soak
             lblSpellDefenceIndirectSoak.Text = (_objCharacter.TotalArmorRating + _objCharacter.BOD.TotalValue).ToString();
@@ -18538,11 +18589,15 @@ namespace Chummer
                                 treSpells.Nodes[4].Expand();
                                 break;
                             case "Rituals":
+                                /*
                                 int intNode = 5;
                                 if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
                                     intNode = 0;
                                 treSpells.Nodes[intNode].Nodes.Add(objNode);
                                 treSpells.Nodes[intNode].Expand();
+                                */
+                                treSpells.Nodes[5].Nodes.Add(objNode);
+                                treSpells.Nodes[5].Expand();
                                 break;
                         }
 

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -18092,7 +18092,16 @@ namespace Chummer
                     // Create a pre-Career Mode backup of the character.
                     // Make sure the backup directory exists.
                     if (!Directory.Exists(Path.Combine(Application.StartupPath, "saves", "backup")))
-                        Directory.CreateDirectory(Path.Combine(Application.StartupPath, "saves", "backup"));
+                    {
+                        try
+                        {
+                            Directory.CreateDirectory(Path.Combine(Application.StartupPath, "saves", "backup"));
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            MessageBox.Show(LanguageManager.Instance.GetString("Message_Insufficient_Permissions_Warning"));
+                        }
+                    }
 
                     string strFileName = _objCharacter.FileName;
                     string[] strParts = strFileName.Split(Path.DirectorySeparatorChar);

--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -2013,6 +2013,25 @@ namespace Chummer.Classes
                 ValueToInt(bonusNode.InnerText, _intRating));
         }
 
+        // Check for Dodge modifiers.
+        public void dodge(XmlNode bonusNode)
+        {
+            Log.Info("dodge");
+            Log.Info("dodge = " + bonusNode.OuterXml.ToString());
+            Log.Info("Calling CreateImprovement");
+            string strUseUnique = _strUnique;
+            if (bonusNode.Attributes["precedence"] != null)
+            {
+                strUseUnique = "precedence" + bonusNode.Attributes["precedence"].InnerText;
+            }
+            else if (bonusNode.Attributes["group"] != null)
+            {
+                strUseUnique = "group" + bonusNode.Attributes["group"].InnerText;
+            }
+            CreateImprovement("", _objImprovementSource, SourceName, Improvement.ImprovementType.Dodge, strUseUnique,
+                ValueToInt(bonusNode.InnerText, _intRating));
+        }
+
         // Check for Reach modifiers.
         public void reach(XmlNode bonusNode)
         {
@@ -3212,6 +3231,9 @@ namespace Chummer.Classes
         {
             Log.Info("freespells");
             Log.Info("freespells = " + bonusNode.OuterXml.ToString());
+            string strSpellTypeLimit = string.Empty;
+            if (!string.IsNullOrWhiteSpace(bonusNode.Attributes?["limit"].InnerText))
+                strSpellTypeLimit = bonusNode.Attributes?["limit"].InnerText;
             if (bonusNode.Attributes?["attribute"] != null)
             {
                 Log.Info("attribute");
@@ -3220,7 +3242,7 @@ namespace Chummer.Classes
                 {
                     Log.Info(att.Abbrev);
                     Log.Info("Calling CreateImprovement");
-                    CreateImprovement(att.Abbrev, _objImprovementSource, SourceName, Improvement.ImprovementType.FreeSpellsATT, string.Empty);
+                    CreateImprovement(att.Abbrev, _objImprovementSource, SourceName, Improvement.ImprovementType.FreeSpellsATT, strSpellTypeLimit);
                 }
             }
             else if (bonusNode.Attributes?["skill"] != null)
@@ -3231,7 +3253,7 @@ namespace Chummer.Classes
                 if (objSkill != null)
                 {
                     Log.Info("Calling CreateImprovement");
-                    CreateImprovement(objSkill.Name, _objImprovementSource, SourceName, Improvement.ImprovementType.FreeSpellsSkill,string.Empty);
+                    CreateImprovement(objSkill.Name, _objImprovementSource, SourceName, Improvement.ImprovementType.FreeSpellsSkill, strSpellTypeLimit);
                 }
             }
             else

--- a/Chummer/Classes/AddImprovementCollection.cs
+++ b/Chummer/Classes/AddImprovementCollection.cs
@@ -3232,8 +3232,8 @@ namespace Chummer.Classes
             Log.Info("freespells");
             Log.Info("freespells = " + bonusNode.OuterXml.ToString());
             string strSpellTypeLimit = string.Empty;
-            if (!string.IsNullOrWhiteSpace(bonusNode.Attributes?["limit"].InnerText))
-                strSpellTypeLimit = bonusNode.Attributes?["limit"].InnerText;
+            if (!string.IsNullOrWhiteSpace(bonusNode.Attributes?["limit"]?.InnerText))
+                strSpellTypeLimit = bonusNode.Attributes["limit"].InnerText;
             if (bonusNode.Attributes?["attribute"] != null)
             {
                 Log.Info("attribute");
@@ -3352,6 +3352,26 @@ namespace Chummer.Classes
             Log.Info("essencepenalty = " + bonusNode.OuterXml.ToString());
             Log.Info("Calling CreateImprovement");
             CreateImprovement("", _objImprovementSource, SourceName, Improvement.ImprovementType.EssencePenalty, string.Empty,
+                ValueToInt(bonusNode.InnerText, _intRating));
+        }
+
+        // Check for Maximum Essence which will permanently modify the character's Maximum Essence value (input value is 100x the actual value, so essence penalty of -0.25 would be input as "25").
+        public void essencepenaltyt100(XmlNode bonusNode)
+        {
+            Log.Info("essencepenaltyt100");
+            Log.Info("essencepenaltyt100 = " + bonusNode.OuterXml.ToString());
+            Log.Info("Calling CreateImprovement");
+            CreateImprovement("", _objImprovementSource, SourceName, Improvement.ImprovementType.EssencePenaltyT100, string.Empty,
+                ValueToInt(bonusNode.InnerText, _intRating));
+        }
+
+        // Check for Maximum Essence which will permanently modify the character's Maximum Essence value for the purposes of affecting MAG rating (input value is 100x the actual value, so essence penalty of -0.25 would be input as "25").
+        public void essencepenaltymagonlyt100(XmlNode bonusNode)
+        {
+            Log.Info("essencepenaltymagonlyt100");
+            Log.Info("essencepenaltymagonlyt100 = " + bonusNode.OuterXml.ToString());
+            Log.Info("Calling CreateImprovement");
+            CreateImprovement("", _objImprovementSource, SourceName, Improvement.ImprovementType.EssencePenaltyMAGOnlyT100, string.Empty,
                 ValueToInt(bonusNode.InnerText, _intRating));
         }
 

--- a/Chummer/Classes/CharacterOptions.cs
+++ b/Chummer/Classes/CharacterOptions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -192,7 +192,16 @@ namespace Chummer
             // Create the settings directory if it does not exist.
             string settingsDirectoryPath = Path.Combine(Application.StartupPath, "settings");
             if (!Directory.Exists(settingsDirectoryPath))
-                Directory.CreateDirectory(settingsDirectoryPath);
+            {
+                try
+                {
+                    Directory.CreateDirectory(settingsDirectoryPath);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    MessageBox.Show(LanguageManager.Instance.GetString("Message_Insufficient_Permissions_Warning"));
+                }
+            }
 
             // If the default.xml settings file does not exist, attempt to read the settings from the Registry (old storage format), then save them to the default.xml file.
             string strFilePath = Path.Combine(settingsDirectoryPath, "default.xml");

--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -950,6 +950,10 @@ namespace Chummer
             {
                 MessageBox.Show(LanguageManager.Instance.GetString("Message_Save_Error_Warning"));
             }
+            catch (System.UnauthorizedAccessException)
+            {
+                MessageBox.Show(LanguageManager.Instance.GetString("Message_Save_Error_Warning"));
+            }
             objWriter.Close();
             objStream.Close();
         }
@@ -4569,6 +4573,7 @@ namespace Chummer
                         }
                     }
                 decESS += Convert.ToDecimal(_objImprovementManager.ValueOf(Improvement.ImprovementType.EssencePenalty));
+                decESS += Convert.ToDecimal(_objImprovementManager.ValueOf(Improvement.ImprovementType.EssencePenaltyT100)) / 100.0m;
 
                 decESS -= decCyberware + decBioware;
                 // Deduct the Essence Hole value.
@@ -4629,19 +4634,31 @@ namespace Chummer
         }
 
         /// <summary>
-        /// Character's total Essence Loss penalty.
+        /// Character's total Essence Loss penalty for RES or DEP.
         /// </summary>
         public int EssencePenalty
         {
             get
             {
-                // Subtract the character's current Essence from its maximum. Round the remaining amount up to get the total penalty to MAG and RES.
+                // Subtract the character's current Essence from its maximum. Round the remaining amount up to get the total penalty to RES and DEP.
                 return Convert.ToInt32(Math.Ceiling(EssenceAtSpecialStart + Convert.ToDecimal(_objImprovementManager.ValueOf(Improvement.ImprovementType.EssenceMax), GlobalOptions.InvariantCultureInfo) - Essence));
             }
         }
 
-#region Initiative
-#region Physical
+        /// <summary>
+        /// Character's total Essence Loss penalty for MAG.
+        /// </summary>
+        public int EssencePenaltyMAG
+        {
+            get
+            {
+                // Subtract the character's current Essence from its maximum, but taking into account essence modifiers that only affect MAG. Round the remaining amount up to get the total penalty to MAG.
+                return Convert.ToInt32(Math.Ceiling(EssenceAtSpecialStart + Convert.ToDecimal(_objImprovementManager.ValueOf(Improvement.ImprovementType.EssenceMax), GlobalOptions.InvariantCultureInfo) - Essence - (Convert.ToDecimal(_objImprovementManager.ValueOf(Improvement.ImprovementType.EssencePenaltyMAGOnlyT100), GlobalOptions.InvariantCultureInfo) / 100.0m)));
+            }
+        }
+
+        #region Initiative
+        #region Physical
         /// <summary>
         /// Physical Initiative.
         /// </summary>

--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -948,11 +948,10 @@ namespace Chummer
             }
             catch (XmlException)
             {
-                return;
+                MessageBox.Show(LanguageManager.Instance.GetString("Message_Save_Error_Warning"));
             }
             objWriter.Close();
             objStream.Close();
-
         }
 
         /// <summary>
@@ -1972,8 +1971,17 @@ namespace Chummer
             // If you give it an extension of jpg, gif, or png, it expects the file to be in that format and won't render the image unless it was originally that type.
             // But if you give it the extension img, it will render whatever you give it (which doesn't make any damn sense, but that's IE for you).
                 string mugshotsDirectoryPath = Path.Combine(Application.StartupPath, "mugshots");
-                if (!Directory.Exists(mugshotsDirectoryPath))
+            if (!Directory.Exists(mugshotsDirectoryPath))
+            {
+                try
+                {
                     Directory.CreateDirectory(mugshotsDirectoryPath);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    MessageBox.Show(LanguageManager.Instance.GetString("Message_Insufficient_Permissions_Warning"));
+                }
+            }
             // <mainmugshotpath />
             if (MainMugshot.Length > 0)
             {

--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -4272,6 +4272,10 @@ namespace Chummer
         {
             get
             {
+                if (AdeptEnabled && !MagicianEnabled)
+                {
+                    return "BOD + WIL";
+                }
                 return _strTraditionDrain;
             }
             set
@@ -5508,6 +5512,17 @@ namespace Chummer
             get
             {
                 return ArmorRating + _objImprovementManager.ValueOf(Improvement.ImprovementType.Armor);
+            }
+        }
+
+        /// <summary>
+        /// The Character's total bonus to Dodge Rating (to add on top of REA + INT).
+        /// </summary>
+        public int TotalBonusDodgeRating
+        {
+            get
+            {
+                return _objImprovementManager.ValueOf(Improvement.ImprovementType.Dodge);
             }
         }
 

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -46,6 +46,7 @@ namespace Chummer
             Attribute,
             Text,
             Armor,
+            Dodge,
             Reach,
             Nuyen,
             Essence,
@@ -1026,11 +1027,17 @@ namespace Chummer
         /// </summary>
         /// <param name="objImprovementSource">Type of object that granted these Improvements.</param>
         /// <param name="strSourceName">Name of the item that granted these Improvements.</param>
-        public void RemoveImprovements(Improvement.ImprovementSource objImprovementSource, string strSourceName)
+        /// <param name="blnReapplyImprovements">Remove all improvements from the improvements list that would be reapplied by Reapply Improvements.</param>
+        public void RemoveImprovements(Improvement.ImprovementSource objImprovementSource, string strSourceName, bool blnReapplyImprovements = false)
         {
             Log.Enter("RemoveImprovements");
-            Log.Info("objImprovementSource = " + objImprovementSource.ToString());
-            Log.Info("strSourceName = " + strSourceName);
+            if (blnReapplyImprovements)
+                Log.Info("Wiping all improvements that would be refreshed by Re-Apply Improvements.");
+            else
+            {
+                Log.Info("objImprovementSource = " + objImprovementSource.ToString());
+                Log.Info("strSourceName = " + strSourceName);
+            }
 
             // If there is no character object, don't try to remove any Improvements.
             if (_objCharacter == null)
@@ -1040,7 +1047,25 @@ namespace Chummer
             }
 
             // A List of Improvements to hold all of the items that will eventually be deleted.
-            List<Improvement> objImprovementList = _objCharacter.Improvements.Where(objImprovement => objImprovement.ImproveSource == objImprovementSource && objImprovement.SourceName == strSourceName).ToList();
+            List<Improvement> objImprovementList = null;
+            if (blnReapplyImprovements)
+                objImprovementList = _objCharacter.Improvements.Where(objImprovement =>
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.AIProgram ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Armor ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.ArmorMod ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Bioware ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.ComplexForm ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.CritterPower ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Cyberware ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Echo ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Gear ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.MartialArtAdvantage ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Metamagic ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Power ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Quality ||
+                                                                        objImprovement.ImproveSource == Improvement.ImprovementSource.Spell).ToList();
+            else
+                objImprovementList = _objCharacter.Improvements.Where(objImprovement => objImprovement.ImproveSource == objImprovementSource && objImprovement.SourceName == strSourceName).ToList();
 
             // Now that we have all of the applicable Improvements, remove them from the character.
             foreach (Improvement objImprovement in objImprovementList)

--- a/Chummer/Classes/clsImprovement.cs
+++ b/Chummer/Classes/clsImprovement.cs
@@ -193,6 +193,8 @@ namespace Chummer
             RunSpeed,
             SprintSpeed,
             EssencePenalty,
+            EssencePenaltyT100,
+            EssencePenaltyMAGOnlyT100,
             FreeSpellsATT,
             FreeSpells,
             DrainValue,

--- a/Chummer/Classes/clsOptions.cs
+++ b/Chummer/Classes/clsOptions.cs
@@ -173,7 +173,16 @@ namespace Chummer
 
             string settingsDirectoryPath = Path.Combine(Application.StartupPath, "settings");
             if (!Directory.Exists(settingsDirectoryPath))
-                Directory.CreateDirectory(settingsDirectoryPath);
+            {
+                try
+                {
+                    Directory.CreateDirectory(settingsDirectoryPath);
+                }
+                catch (UnauthorizedAccessException)
+                {
+                    MessageBox.Show(LanguageManager.Instance.GetString("Message_Insufficient_Permissions_Warning"));
+                }
+            }
 
             // Automatic Update.
             LoadBoolFromRegistry(ref _blnAutomaticUpdate, "autoupdate");

--- a/Chummer/Classes/clsUnique.cs
+++ b/Chummer/Classes/clsUnique.cs
@@ -84,6 +84,7 @@ namespace Chummer
         private bool _blnContributeToLimit = true;
         private bool _blnPrint = true;
         private bool _blnDoubleCostCareer = true;
+        private bool _blnCanBuyWithSpellPoints = false;
         private int _intBP;
         private int _intLP;
         private QualityType _objQualityType = QualityType.Positive;
@@ -205,6 +206,7 @@ namespace Chummer
                 _objQualityType = ConvertToQualityType(objXmlQuality["category"].InnerText);
             _objQualitySource = objQualitySource;
             objXmlQuality.TryGetBoolFieldQuickly("doublecareer", ref _blnDoubleCostCareer);
+            objXmlQuality.TryGetBoolFieldQuickly("canbuywithspellpoints", ref _blnCanBuyWithSpellPoints);
             objXmlQuality.TryGetBoolFieldQuickly("print", ref _blnPrint);
             objXmlQuality.TryGetBoolFieldQuickly("implemented", ref _blnImplemented);
             objXmlQuality.TryGetBoolFieldQuickly("contributetolimit", ref _blnContributeToLimit);
@@ -335,6 +337,7 @@ namespace Chummer
             objWriter.WriteElementString("implemented", _blnImplemented.ToString());
             objWriter.WriteElementString("contributetolimit", _blnContributeToLimit.ToString());
             objWriter.WriteElementString("doublecareer", _blnDoubleCostCareer.ToString());
+            objWriter.WriteElementString("canbuywithspellpoints", _blnCanBuyWithSpellPoints.ToString());
             if (_strMetagenetic != null)
             {
                 objWriter.WriteElementString("metagenetic", _strMetagenetic);
@@ -383,6 +386,7 @@ namespace Chummer
             objNode.TryGetBoolFieldQuickly("contributetolimit", ref _blnContributeToLimit);
             objNode.TryGetBoolFieldQuickly("print", ref _blnPrint);
             objNode.TryGetBoolFieldQuickly("doublecareer", ref _blnDoubleCostCareer);
+            objNode.TryGetBoolFieldQuickly("canbuywithspellpoints", ref _blnCanBuyWithSpellPoints);
             if (objNode["qualitytype"] != null)
             _objQualityType = ConvertToQualityType(objNode["qualitytype"].InnerText);
             if (objNode["qualitysource"] != null)
@@ -606,6 +610,15 @@ namespace Chummer
         {
             get => _blnDoubleCostCareer;
             set => _blnDoubleCostCareer = value;
+        }
+
+        /// <summary>
+        /// Whether or not the quality can be bought with free spell points instead
+        /// </summary>
+        public bool CanBuyWithSpellPoints
+        {
+            get => _blnCanBuyWithSpellPoints;
+            set => _blnCanBuyWithSpellPoints = value;
         }
 
         /// <summary>

--- a/Chummer/Selection Forms/frmSelectPower.cs
+++ b/Chummer/Selection Forms/frmSelectPower.cs
@@ -16,7 +16,8 @@
  *  You can obtain the full source code for Chummer5a at
  *  https://github.com/chummer5a/chummer5a
  */
-﻿using System;
+using Chummer.Backend.Shared_Methods;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Windows.Forms;
@@ -74,34 +75,33 @@ namespace Chummer
             }
             foreach (XmlNode objXmlPower in objXmlPowerList)
             {
-                bool blnAdd = true;
-
                 double dblPoints = Convert.ToDouble(objXmlPower["points"].InnerText, GlobalOptions.InvariantCultureInfo);
                 if (objXmlPower["limit"] != null && !IgnoreLimits)
                 {
                     if (_objCharacter.Powers.Count(power => power.Name == objXmlPower["name"].InnerText) >=
                         Convert.ToInt32(objXmlPower["limit"].InnerText))
                     {
-                        blnAdd = false;
+                        continue;
                     }
                 }
-                if (objXmlPower["extrapointcost"]?.InnerText != null && blnAdd)
+                if (objXmlPower["extrapointcost"]?.InnerText != null)
                 {
                     //If this power has already had its rating paid for with PP, we don't care about the extrapoints cost. 
                     if (!_objCharacter.Powers.Any(power => power.Name == objXmlPower["name"].InnerText && power.TotalRating > 0))
                         dblPoints += Convert.ToDouble(objXmlPower["extrapointcost"]?.InnerText, GlobalOptions.InvariantCultureInfo);
                 }
-                if (_dblLimitToRating > 0 && blnAdd)
+                if (_dblLimitToRating > 0 && dblPoints > _dblLimitToRating)
                 {
-                    blnAdd = dblPoints <= _dblLimitToRating;
+                    continue;
                 }
-                if (blnAdd)
-                {
+
+                if (!SelectionShared.RequirementsMet(objXmlPower, false, _objCharacter, null, null, _objXmlDocument))
+                    continue;
+
                 ListItem objItem = new ListItem();
                 objItem.Value = objXmlPower["name"].InnerText;
                     objItem.Name = objXmlPower["translate"]?.InnerText ?? objXmlPower["name"].InnerText;
                 lstPower.Add(objItem);
-                }
             }
             SortListItem objSort = new SortListItem();
             lstPower.Sort(objSort.Compare);

--- a/Chummer/UI/Skills/SkillControl2.Designer.cs
+++ b/Chummer/UI/Skills/SkillControl2.Designer.cs
@@ -154,6 +154,9 @@ namespace Chummer.UI.Skills
             this.chkKarma.Size = new System.Drawing.Size(15, 14);
             this.chkKarma.TabIndex = 18;
             this.chkKarma.UseVisualStyleBackColor = true;
+            /* Delnar: Awaiting other authors' approval before activation.
+            this.chkKarma.CheckedChanged += new System.EventHandler(this.chkKarma_CheckChanged);
+            */
             // 
             // cmdDelete
             // 

--- a/Chummer/UI/Skills/SkillControl2.cs
+++ b/Chummer/UI/Skills/SkillControl2.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -324,11 +324,18 @@ namespace Chummer.UI.Skills
 
         private void cboSpec_TextChanged(object sender, EventArgs e)
         {
-            if (nudSkill.Value == 0 && !string.IsNullOrWhiteSpace(cboSpec.Text))
+            if (!string.IsNullOrWhiteSpace(cboSpec.Text) && (nudSkill.Value == 0 || !nudSkill.Enabled))
             {
                 chkKarma.Checked = true;
             }
         }
+
+        /* Delnar: Awaiting other authors' approval before activation.
+        private void chkKarma_CheckChanged(object sender, EventArgs e)
+        {
+            cboSpec_TextChanged(sender, e);
+        }
+        */
 
         private void RatingChanged(object sender, EventArgs e)
         {

--- a/Chummer/Utilities/frmUpdate.cs
+++ b/Chummer/Utilities/frmUpdate.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -289,8 +289,16 @@ namespace Chummer
                         if (entry.FullName.Length > 0 && entry.FullName[entry.FullName.Length - 1] == '/')
                             continue;
                         string strLoopPath = Path.Combine(_strAppPath, entry.FullName);
-                        Directory.CreateDirectory(Path.GetDirectoryName(strLoopPath));
-                        entry.ExtractToFile(strLoopPath, true);
+                        try
+                        {
+                            Directory.CreateDirectory(Path.GetDirectoryName(strLoopPath));
+                            entry.ExtractToFile(strLoopPath, true);
+                        }
+                        catch (UnauthorizedAccessException)
+                        {
+                            MessageBox.Show(LanguageManager.Instance.GetString("Message_Insufficient_Permissions_Warning"));
+                            break;
+                        }
                     }
                 }
                 Log.Info("Restart Chummer");

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -28,6 +28,10 @@ Application Changes:
 - Maximum values for adept powers should now update properly with changes to MAG values, and in the case of Improved Ability, changes to skill ratings.
 - Cancelling out of a dialog triggered by selecting an adept power or a property of an adept power will now properly cancel the dialog and not actually add the last/default selected choice.
 - Added support for skill selection dialogs to be able to only show skills for which the runner has a rating greater than 0. In case there are no eligible options, a warning dialog is displayed, and the skill selection dialog is automatically treated as cancelled.
+- Added support for bonuses to defense dice (e.g. Combat Sense, Reakt).
+- Added support for Barehanded Adept and qualities similar to it.
+- Drain for Physical Adepts is now properly displayed and calculated as BOD + WIL.
+- Reapply Improvements will now starts by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
 
 Data Changes:
 
@@ -48,6 +52,8 @@ Data Changes:
 - Spider (Alt) now properly gives 2 levels of Spirit Claw instead of 1. (Yes, Spirit Claw does not have levels, so Forbidden Arcana will need to be errata'd, but Chummer5 can handle this sort of thing regardless)
 - Changed the name of "Great Mother" mentor spirit from SASS to "Great Mother (SASS)" to differentiate it from an identically named mentor spirit from Forbidden Arcana.
 - Improved Ability can no longer be taken for skills that have a rating of 0, as 0 x1.5 is still 0. This extends to Mentor Spirits that would give free levels of Improved Ability.
+- Reakt and Combat Sense now give dodge bonuses.
+- Barehanded Adept can now be taken by Mystic Adepts as well, and it will now properly provide free Touch-ranged spells that use Unarmed Combat in place of Spellcasting.
 
 New Strings:
 - Label_Options_SpellShapingFocus

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -33,6 +33,7 @@ Application Changes:
 - Drain for Physical Adepts is now properly displayed and calculated as BOD + WIL.
 - Reapply Improvements will now starts by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
 - Chummer5 will now warn users when it does not have the proper write permissions to its own folder, or if an error was encountered that prevented a character from being saved. Fixes #1915.
+- The "Buy Specialization with Karma" checkbox is now also automatically checked if buying a specialization for a skill that was ranked up with skill group points.
 
 Data Changes:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -34,6 +34,10 @@ Application Changes:
 - Reapply Improvements will now starts by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
 - Chummer5 will now warn users when it does not have the proper write permissions to its own folder, or if an error was encountered that prevented a character from being saved. Fixes #1915.
 - The "Buy Specialization with Karma" checkbox is now also automatically checked if buying a specialization for a skill that was ranked up with skill group points.
+- Added support for qualities that can be purchased with skill points instead of karma at chargen.
+- Added support for essence penalty improvements that only affect MAG, as well as essence penalty improvements that have hundredths-level precision instead of integer precision.
+- Fixed a bug where the optional rule that allows Mystic Adept PPs to be bought with priority spell points also allowed purchasing of PPs with free spell points given by Dedicated Spellslinger.
+- Requirements that check for whether MAG, RES, or DEP are >= 1 will now instead check for if the corresponding attribute is enabled.
 
 Data Changes:
 
@@ -57,6 +61,12 @@ Data Changes:
 - Implemented content from Shadows in Focus: Metropole. Life Modules are untested because they're awful.
 - Reakt and Combat Sense now give dodge bonuses.
 - Barehanded Adept can now be taken by Mystic Adepts as well, and it will now properly provide free Touch-ranged spells that use Unarmed Combat in place of Spellcasting.
+- Fixed non-Awakened characters being eligible to take Mastery and Blood Crystal qualities from Forbidden Arcana.
+- When free spell points are available at chargen, and real spell costs (costs charged for the character) are not greater than unmodified spell costs (costs set in Options), all Mastery qualities from Forbidden Arcana will now deduct from spell points instead of from free karma at a rate of 1 point per [unmodified spell cost] karma, rounded down (so e.g. at 5 karma per spell, an 8 karma Mastery quality will cost 1 spell point and 3 karma instead of 8 karma).
+- All Blood Crystal qualities now properly reduce both condition monitors by 1 for each bonded crystal. Crystal Breath, Crystal Eye, Crystal Gut, Crystal Jaw, Crystal Limb, and Crystal Spine now properly reduce Essence, but in a way that does not affect the character's MAG rating.
+- Crystalline Reflexes now properly gives 2 extra defense dice against attacks.
+- Crystal Gut Stomach now properly reduces lifestyle costs by 10%.
+- Fixed Crystal Spine's initiative bonus stacking with other initiative bonuses.
 
 New Strings:
 - Label_Options_SpellShapingFocus

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -31,7 +31,7 @@ Application Changes:
 - Added support for bonuses to defense dice (e.g. Combat Sense, Reakt).
 - Added support for Barehanded Adept and qualities similar to it.
 - Drain for Physical Adepts is now properly displayed and calculated as BOD + WIL.
-- Reapply Improvements will now starts by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
+- Reapply Improvements will now start by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
 - Chummer5 will now warn users when it does not have the proper write permissions to its own folder, or if an error was encountered that prevented a character from being saved. Fixes #1915.
 - The "Buy Specialization with Karma" checkbox is now also automatically checked if buying a specialization for a skill that was ranked up with skill group points.
 - Added support for qualities that can be purchased with spell points instead of karma at chargen.

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -34,7 +34,7 @@ Application Changes:
 - Reapply Improvements will now starts by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
 - Chummer5 will now warn users when it does not have the proper write permissions to its own folder, or if an error was encountered that prevented a character from being saved. Fixes #1915.
 - The "Buy Specialization with Karma" checkbox is now also automatically checked if buying a specialization for a skill that was ranked up with skill group points.
-- Added support for qualities that can be purchased with skill points instead of karma at chargen.
+- Added support for qualities that can be purchased with spell points instead of karma at chargen.
 - Added support for essence penalty improvements that only affect MAG, as well as essence penalty improvements that have hundredths-level precision instead of integer precision.
 - Fixed a bug where the optional rule that allows Mystic Adept PPs to be bought with priority spell points also allowed purchasing of PPs with free spell points given by Dedicated Spellslinger.
 - Requirements that check for whether MAG, RES, or DEP are >= 1 will now instead check for if the corresponding attribute is enabled.

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -38,6 +38,8 @@ Application Changes:
 - Added support for essence penalty improvements that only affect MAG, as well as essence penalty improvements that have hundredths-level precision instead of integer precision.
 - Fixed a bug where the optional rule that allows Mystic Adept PPs to be bought with priority spell points also allowed purchasing of PPs with free spell points given by Dedicated Spellslinger.
 - Requirements that check for whether MAG, RES, or DEP are >= 1 will now instead check for if the corresponding attribute is enabled.
+- When adding adept powers, the list of available adept powers will hide powers whose prerequisites are not met.
+- Added support for any attribute or special attribute to be used in a weapon's damage code.
 
 Data Changes:
 
@@ -67,6 +69,7 @@ Data Changes:
 - Crystalline Reflexes now properly gives 2 extra defense dice against attacks.
 - Crystal Gut Stomach now properly reduces lifestyle costs by 10%.
 - Fixed Crystal Spine's initiative bonus stacking with other initiative bonuses.
+- Added appropriate power prerequisites to Elemental Strike, Elemental Body, and Toxic Strike. Users can now choose what toxic element Toxic Strike will take.
 
 New Strings:
 - Label_Options_SpellShapingFocus

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -32,6 +32,7 @@ Application Changes:
 - Added support for Barehanded Adept and qualities similar to it.
 - Drain for Physical Adepts is now properly displayed and calculated as BOD + WIL.
 - Reapply Improvements will now starts by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
+- Chummer5 will now warn users when it does not have the proper write permissions to its own folder, or if an error was encountered that prevented a character from being saved. Fixes #1915.
 
 Data Changes:
 
@@ -65,6 +66,8 @@ New Strings:
 - Label_Options_AlchemicalFocus
 - Message_Improvement_EmptySelectionList
 - Message_Improvement_EmptySelectionListNamed
+- Message_Insufficient_Permissions_Warning
+- Message_Save_Error_Warning
 
 Changes Strings:
 - Message_PositiveQualityLimit

--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -1835,6 +1835,9 @@
       <capacity>0</capacity>
       <avail>10</avail>
       <cost>75000</cost>
+	  <bonus>
+        <dodge>2</dodge>
+      </bonus>
       <source>CF</source>
       <page>161</page>
     </bioware>

--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -94,6 +94,9 @@
           </oneof>
         </required>
       </adeptwayrequires>
+	  <bonus>
+        <dodge>Rating</dodge>
+      </bonus>
     </power>
     <power>
       <id>dbf16604-164c-485c-96c8-fe3136cd5caa</id>

--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -766,6 +766,11 @@
       <page>170</page>
       <action>Complex</action>
       <adeptway>.5</adeptway>
+	  <required>
+        <oneof>
+          <power>Elemental Strike</power>
+        </oneof>
+      </required>
       <bonus>
         <selecttext />
       </bonus>
@@ -780,6 +785,11 @@
       <page>170</page>
       <action>Simple</action>
       <adeptway>.25</adeptway>
+	  <required>
+        <oneof>
+          <power>Killing Hands</power>
+        </oneof>
+      </required>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1274,6 +1284,14 @@
       <page>176</page>
       <action>Simple</action>
       <adeptway>.25</adeptway>
+	  <required>
+        <oneof>
+          <power>Killing Hands</power>
+        </oneof>
+      </required>
+	  <bonus>
+        <selecttext />
+      </bonus>
     </power>
     <!-- End Region -->
     <!-- Region Bullets and Bandages -->

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -12189,6 +12189,7 @@
       <id>dcba5a01-849b-412c-83ba-f0ac5aa46e71</id>
       <name>Adept Healer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
@@ -12196,6 +12197,12 @@
         <oneof>
           <power>Empathic Healing</power>
         </oneof>
+		<allof>
+			<attribute>
+				<name>MAG</name>
+				<total>1</total>
+			</attribute>
+		</allof>
       </required>
       <source>FA</source>
       <page>31</page>
@@ -12204,6 +12211,7 @@
       <id>e508350b-f61d-4878-bd6d-98f8c9e3588b</id>
       <name>Alchemical Armorer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus>
@@ -12220,6 +12228,10 @@
             <name>Armorer</name>
             <val>4</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -12229,12 +12241,17 @@
       <id>73bbf3ca-44c0-4b91-a511-9f1229b4efd3</id>
       <name>Alchemical Bomb Maker</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <metamagic>Advanced Alchemy</metamagic>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -12255,10 +12272,17 @@
       <id>3e9881c4-6556-4df1-8e9c-bc839ba683b2</id>
       <name>Animal Familiar</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Animal Handling</name>
@@ -12273,6 +12297,7 @@
       <id>79c1be77-1da7-405e-8b2b-99a06abc4327</id>
       <name>Apt Pupil</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
@@ -12282,6 +12307,10 @@
             <name>Arcana</name>
             <val>6</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -12308,6 +12337,7 @@
       <id>9f02d7f6-6fe3-4a9c-8c0e-83ae788f1985</id>
       <name>Arcane Bodyguard</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>20</karma>
       <category>Positive</category>
       <bonus />
@@ -12317,6 +12347,10 @@
             <name>Counterspelling</name>
             <val>4</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -12326,6 +12360,7 @@
       <id>ec302d7a-1955-43bb-9c1f-2c32da7ca8c0</id>
       <name>Arcane Improviser</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
@@ -12351,6 +12386,10 @@
             <name>Manipulation</name>
             <count>4</count>
           </spellcategory>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <group>
@@ -12422,6 +12461,7 @@
       <id>f65a7108-0b57-4f82-950d-9896be68aae9</id>
       <name>Archivist</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
@@ -12431,6 +12471,10 @@
             <name>Arcana</name>
             <val>5</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -12440,10 +12484,17 @@
       <id>f5e31754-4270-43a0-8dbf-528dd7274afb</id>
       <name>Astral Bouncer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Assensing</name>
@@ -12463,12 +12514,17 @@
       <id>0591e06b-4465-47fe-875a-89d4b52d4f61</id>
       <name>Astral Infiltrator</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <initiategrade>1</initiategrade>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -12489,9 +12545,16 @@
       <id>742caf46-a10b-4aa1-a6bc-a53feb99748c</id>
       <name>Barehanded Adept</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -12536,12 +12599,17 @@
       <id>3fa061b9-c3bd-40bb-a292-eb35a8f8f5f8</id>
       <name>Blood Necromancer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <metamagicart>Blood Magic</metamagicart>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -12562,8 +12630,17 @@
       <id>8c49fcfb-54fa-43ce-b2af-51780dabf40f</id>
       <name>Chain Breaker</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
+      </required>
       <costdiscount>
         <required>
           <oneof>
@@ -12580,10 +12657,17 @@
       <id>56d00933-379d-4442-8878-6db5b08fd20c</id>
       <name>Chakra Interrupter</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <power>Nerve Strike</power>
@@ -12657,6 +12741,7 @@
       <id>6d6356ab-3a88-441a-8368-05a8fb8307a7</id>
       <name>Charlatan</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
@@ -12666,6 +12751,10 @@
             <name>Assensing</name>
             <val>5</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -12695,10 +12784,17 @@
       <id>578e1220-09f9-41eb-9616-cae4b7c96e56</id>
       <name>Chosen Follower</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <quality>Mentor Spirit</quality>
         </oneof>
@@ -12715,6 +12811,12 @@
       <limit>3</limit>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <metamagic>Spell Shaping</metamagic>
           <skill>
@@ -12730,10 +12832,17 @@
       <id>39384189-d15a-4f2e-97a9-7f9a0b85ef64</id>
       <name>Dark Ally</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Binding</name>
@@ -12752,11 +12861,18 @@
       <id>36e76b70-bf6a-4e66-8dac-13cd529b9274</id>
       <name>Death Dealer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <limit>3</limit>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <power>Critical Strike</power>
           <skill>
@@ -12777,6 +12893,7 @@
       <id>2a599984-62e4-4110-9784-dc1922df395d</id>
       <name>Dedicated Conjurer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <costdiscount>
@@ -12789,10 +12906,16 @@
       </costdiscount>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Summoning</name>
-            <val>1</val>
+            <total>1</total>
           </skill>
         </oneof>
       </required>
@@ -12803,6 +12926,7 @@
       <id>bbc6879e-b50d-4862-b85c-a86c5b9e5d67</id>
       <name>Dedicated Spellslinger</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <costdiscount>
@@ -12818,10 +12942,16 @@
         <spellkarmadiscount>-1</spellkarmadiscount>
       </bonus>
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Spellcasting</name>
-            <val>1</val>
+            <total>1</total>
           </skill>
         </oneof>
       </required>
@@ -12832,10 +12962,17 @@
       <id>b618c943-41f7-46ae-80e7-69e543bc0ec6</id>
       <name>Dual-Natured Defender</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <critterpower>Dual Natured</critterpower>
           <skill>
@@ -12851,10 +12988,17 @@
       <id>ef1e36f8-6c4c-4908-9155-ecef6c376c6e</id>
       <name>Durable Preparations</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Alchemy</name>
@@ -12869,10 +13013,17 @@
       <id>05089559-972e-463c-a276-641e358a9201</id>
       <name>Elemental Master</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>20</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -12950,6 +13101,7 @@
       <id>39c97163-ffab-4705-91e1-82aef058cc86</id>
       <name>Flesh Sculpter</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <limit>3</limit>
@@ -12970,6 +13122,10 @@
             <val>6</val>
             <type>Knowledge</type>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <spell>Shapechange</spell>
@@ -12983,6 +13139,7 @@
       <id>e12f7c66-d0a0-4e93-9454-69024b945220</id>
       <name>Healer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
@@ -12992,6 +13149,10 @@
             <name>First Aid</name>
             <val>3</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -13012,11 +13173,18 @@
       <id>a8a3d83d-034c-4729-ae3e-435fa52b4c4b</id>
       <name>Illusionist</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <limit>3</limit>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Spellcasting</name>
@@ -13032,10 +13200,17 @@
       <id>8f18e68a-fbaf-46b6-bf00-c99910292c20</id>
       <name>Items of Power</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>25</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Artificing</name>
@@ -13050,10 +13225,17 @@
       <id>c6ceed11-802c-4ff6-a636-4213663fcf21</id>
       <name>Mage Hunter I</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Spellcasting</name>
@@ -13073,12 +13255,17 @@
       <id>79ed28ba-fab7-4fc3-b4c1-5c177a92f9a6</id>
       <name>Mage Hunter II</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <quality>Mage Hunter I</quality>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -13099,12 +13286,17 @@
       <id>1126c856-7e2e-43de-91ce-8ff70f2368a4</id>
       <name>Mage Hunter III</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <quality>Mage Hunter II</quality>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -13125,6 +13317,7 @@
       <id>1510e2fd-4821-4e4c-bcd3-eacb0eed5f20</id>
       <name>Missile Deflector</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
@@ -13132,6 +13325,10 @@
         <allof>
           <power>Missile Parry</power>
           <power>Counterstrike</power>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -13141,6 +13338,7 @@
       <id>39b19ecb-f3a8-488e-a413-f399a1991b55</id>
       <name>Mystic Foreman</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
@@ -13154,6 +13352,10 @@
             <name>Chemistry</name>
             <val>4</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -13174,12 +13376,17 @@
       <id>f6e65194-8055-484e-8db1-30ef63ec8eef</id>
       <name>Mystic Pitcher</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <spell>Fling</spell>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <skill>
@@ -13200,12 +13407,17 @@
       <id>727e5ca7-0b64-462f-a3dc-254c451db3a1</id>
       <name>Pacifist Adept</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
           <power>Cool Resolve</power>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <quality>Pacifist I</quality>
@@ -13219,6 +13431,7 @@
       <id>9ce70b7b-b0cd-4ec8-87f6-42c3b74faf2a</id>
       <name>Potion Maker</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
@@ -13232,6 +13445,10 @@
             <name>Alchemy</name>
             <val>4</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -13241,10 +13458,17 @@
       <id>bed784d2-33dc-448e-acf6-a682bb286954</id>
       <name>Practiced Alchemist</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -13266,11 +13490,18 @@
       <id>b9808fa8-744f-46e2-b769-bed5ce0b3ad1</id>
       <name>Puppet Master</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <limit>3</limit>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -13329,11 +13560,18 @@
       <id>b15bbc5a-626c-4f04-b08e-203cb24c6b1a</id>
       <name>Reckless Spell Master</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <limit>6</limit>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Spellcasting</name>
@@ -13348,10 +13586,17 @@
       <id>baa0cfd8-3c53-48ba-b3b7-61de0bc48695</id>
       <name>Renaissance Ritualist</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>8</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -13393,10 +13638,17 @@
       <id>cd712655-a83b-4905-923d-be07ced1677b</id>
       <name>Revenant Adept</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <power>Rapid Healing</power>
         </oneof>
@@ -13408,10 +13660,17 @@
         <id>820ec42b-5255-4c73-93af-e8caa5b6abbf</id>
         <name>Shock Mage</name>
         <doublecareer>False</doublecareer>
+		<canbuywithspellpoints>True</canbuywithspellpoints>
         <karma>15</karma>
         <category>Positive</category>
         <bonus />
         <required>
+		  <allof>
+			<attribute>
+			  <name>MAG</name>
+			  <total>1</total>
+			</attribute>
+		  </allof>
           <oneof>
             <skill>
               <name>Spellcasting</name>
@@ -13426,6 +13685,7 @@
       <id>16cb1300-bdf4-42d0-9556-3b681ef517fc</id>
       <name>Skinwalker</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <limit>3</limit>
@@ -13433,6 +13693,10 @@
       <required>
         <allof>
           <spell>[Critter] Form</spell>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <group>
@@ -13475,9 +13739,18 @@
       <id>25f5745d-8e1d-463f-9b96-c047bc99a587</id>
       <name>Spectral Warden</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
+      </required>
       <source>FA</source>
       <page>40</page>
     </quality>
@@ -13485,10 +13758,17 @@
       <id>632aebb2-e6f2-4b38-81c7-be494964c614</id>
       <name>Spell Jammer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>20</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Counterspelling</name>
@@ -13503,11 +13783,18 @@
       <id>7bd24b5c-9ad4-4083-b58b-5dcc420d1950</id>
       <name>Spirit Hunter I</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>20</karma>
       <category>Positive</category>
       <limit>3</limit>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <power>Killing Hands</power>
           <skill>
@@ -13532,6 +13819,7 @@
       <id>3ef898e6-b57d-4254-88d8-b8e37491e186</id>
       <name>Spirit Hunter II</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>20</karma>
       <category>Positive</category>
       <limit>3</limit>
@@ -13539,6 +13827,10 @@
       <required>
         <allof>
           <quality>Spirit Hunter I</quality>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <power>Killing Hands</power>
@@ -13564,6 +13856,7 @@
       <id>80b557bc-c7fd-413f-8b8a-4571c8f3fa56</id>
       <name>Spirit Hunter III</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>20</karma>
       <category>Positive</category>
       <limit>3</limit>
@@ -13571,6 +13864,10 @@
       <required>
         <allof>
           <quality>Spirit Hunter II</quality>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
         <oneof>
           <power>Killing Hands</power>
@@ -13596,6 +13893,7 @@
       <id>268ea4c4-15af-4b16-8960-a3b34963fe01</id>
       <name>Spiritual Lodge</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
@@ -13609,6 +13907,10 @@
             <name>Artisan</name>
             <val>3</val>
           </skill>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -13618,10 +13920,17 @@
       <id>d815700b-9e8a-410b-8795-83196629a5ad</id>
       <name>Spiritual Pilgrim</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -13663,7 +13972,7 @@
             </skill>
             <skill>
               <name>Magical Theory</name>
-              <val>1</val>
+              <total>1</total>
               <type>Knowledge</type>
             </skill>
             <tradition>Buddhism</tradition>
@@ -13675,7 +13984,7 @@
             </skill>
             <skill>
               <name>Magical Theory (Academic)</name>
-              <val>1</val>
+              <total>1</total>
               <type>Knowledge</type>
             </skill>
             <tradition>Buddhism</tradition>
@@ -13687,7 +13996,7 @@
             </skill>
             <skill>
               <name>Magical Theory (Street)</name>
-              <val>1</val>
+              <total>1</total>
               <type>Knowledge</type>
             </skill>
             <tradition>Buddhism</tradition>
@@ -13701,10 +14010,17 @@
       <id>c1145d3c-a9e2-4e91-8f1f-49f69a1f219e</id>
       <name>Sprawl Tamer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>10</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Animal Handling</name>
@@ -13719,6 +14035,7 @@
       <id>c9ea31d0-eef7-4489-bc11-04a2e41a4932</id>
       <name>Stalwart Ally</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
@@ -13729,6 +14046,10 @@
             <val>4</val>
           </skill>
           <spell>Create Ally Spirit</spell>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <source>FA</source>
@@ -13738,10 +14059,17 @@
       <id>fcde8bed-ed62-4378-b995-80f96ff423af</id>
       <name>Taboo Transformer</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>15</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <group>
             <skill>
@@ -13848,10 +14176,17 @@
       <id>4db55b27-c211-48f2-b9a0-446bd9d32db6</id>
       <name>Vexcraft</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>7</karma>
       <category>Positive</category>
       <bonus />
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+        </allof>
         <oneof>
           <skill>
             <name>Disenchanting</name>
@@ -13866,11 +14201,16 @@
       <id>665d2f01-636b-4bde-b91f-47b388a0a57a</id>
       <name>Worship Leader</name>
       <doublecareer>False</doublecareer>
+	  <canbuywithspellpoints>True</canbuywithspellpoints>
       <karma>5</karma>
       <category>Positive</category>
       <bonus />
       <required>
         <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
           <skill>
             <name>Leadership</name>
             <val>4</val>
@@ -13892,31 +14232,747 @@
       <karma>5</karma>
       <category>Positive</category>
       <limit>no</limit>
-      <bonus />
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
       <source>FA</source>
       <page>132</page>
     </quality>
     <quality>
       <id>1abbf9a5-af57-4e9f-af7a-05872ae8ddad</id>
-      <name>Crystal Eye</name>
+      <name>Crystal Eye (One Eye)</name>
       <contributetolimit>False</contributetolimit>
       <doublecareer>False</doublecareer>
       <karma>10</karma>
       <category>Positive</category>
       <limit>no</limit>
-      <bonus />
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>132</page>
+    </quality>
+	<quality>
+      <id>6b669cf8-ef03-49c1-8e42-b16e0daea0bc</id>
+      <name>Crystal Eye (Two Eyes)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+	  <forbidden>
+        <oneof>
+          <quality>Cyclopean Eye</quality>
+        </oneof>
+      </forbidden>
+	  <required>
+		<allof>
+			<attribute>
+				<name>MAG</name>
+				<total>1</total>
+			</attribute>
+		</allof>
+	  </required>
+      <limit>no</limit>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>132</page>
+    </quality>
+	<quality>
+      <id>135796d3-038a-4132-b002-996e4a2ef56d</id>
+      <name>Crystal Eye (Three Eyes)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+	  <forbidden>
+        <oneof>
+          <quality>Cyclopean Eye</quality>
+        </oneof>
+      </forbidden>
+	  <required>
+		<allof>
+			<quality>Third Eye</quality>
+			<attribute>
+				<name>MAG</name>
+				<total>1</total>
+			</attribute>
+		</allof>
+	  </required>
+      <limit>no</limit>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
       <source>FA</source>
       <page>132</page>
     </quality>
     <quality>
       <id>82ad9ac5-5ff7-4ea6-9925-a4012af6fe50</id>
-      <name>Crystal Gut</name>
+      <name>Crystal Gut (Liver)</name>
       <contributetolimit>False</contributetolimit>
       <doublecareer>False</doublecareer>
       <karma>5</karma>
       <category>Positive</category>
       <limit>no</limit>
-      <bonus />
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-50</essencepenaltyt100>
+		<essencepenaltymagonlyt100>50</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>40f0ec08-0948-41dc-b0a2-2804ae913936</id>
+      <name>Crystal Gut (Kidneys)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>5</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-50</essencepenaltyt100>
+		<essencepenaltymagonlyt100>50</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>1ca531dc-8d76-42aa-a667-874c94166f0e</id>
+      <name>Crystal Gut (Stomach)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>5</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-50</essencepenaltyt100>
+		<essencepenaltymagonlyt100>50</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>c3c759fd-4b38-46d9-bccc-64ceb1e0247b</id>
+      <name>Crystal Gut (Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>5</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-50</essencepenaltyt100>
+		<essencepenaltymagonlyt100>50</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>35e38f80-6054-4f2d-9da7-13dc8e95e923</id>
+      <name>Crystal Gut (Liver, Kidneys)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+		  <quality>Crystal Gut (Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>3f17850d-5d1c-4dc3-8bb2-09614dd15862</id>
+      <name>Crystal Gut (Liver, Stomach)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+		  <quality>Crystal Gut (Stomach)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>aafc734a-91f9-4b40-af9b-5f771e5dcf37</id>
+      <name>Crystal Gut (Liver, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>5d155e0a-b7fa-4047-8a50-43e9616cb354</id>
+      <name>Crystal Gut (Kidneys, Stomach)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+		  <quality>Crystal Gut (Kidneys)</quality>
+		  <quality>Crystal Gut (Stomach)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>e3613a3d-31c9-40db-a54c-154130ddafe2</id>
+      <name>Crystal Gut (Kidneys, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+		  <quality>Crystal Gut (Kidneys)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>84e80b32-52b7-4fc0-a990-5a74fb5d497c</id>
+      <name>Crystal Gut (Stomach, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>10</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+		  <quality>Crystal Gut (Stomach)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>d635f134-3b02-45eb-96d2-e42e100b47cc</id>
+      <name>Crystal Gut (Liver, Kidneys, Stomach)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>15</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+		  <quality>Crystal Gut (Kidneys)</quality>
+		  <quality>Crystal Gut (Stomach)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-150</essencepenaltyt100>
+		<essencepenaltymagonlyt100>150</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>5093e803-da71-4d8c-acb0-22e9ecae3112</id>
+      <name>Crystal Gut (Liver, Kidneys, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>15</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+		  <quality>Crystal Gut (Kidneys)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-150</essencepenaltyt100>
+		<essencepenaltymagonlyt100>150</essencepenaltymagonlyt100>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>9e390ad1-a8cb-4fbd-a0bb-cf2f3b56dfc1</id>
+      <name>Crystal Gut (Liver, Stomach, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>15</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+		  <quality>Crystal Gut (Stomach)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-150</essencepenaltyt100>
+		<essencepenaltymagonlyt100>150</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>d62eadf5-071e-4270-86c7-d4fb299ff440</id>
+      <name>Crystal Gut (Kidneys, Stomach, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>15</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Kidneys)</quality>
+		  <quality>Crystal Gut (Stomach)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-150</essencepenaltyt100>
+		<essencepenaltymagonlyt100>150</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
+      <source>FA</source>
+      <page>133</page>
+    </quality>
+	<quality>
+      <id>9c8e4825-507f-4683-a477-bf7d895b75b1</id>
+      <name>Crystal Gut (Liver, Kidneys, Stomach, Intestines)</name>
+      <contributetolimit>False</contributetolimit>
+      <doublecareer>False</doublecareer>
+      <karma>20</karma>
+      <category>Positive</category>
+      <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <forbidden>
+        <oneof>
+          <quality>Crystal Gut (Liver)</quality>
+          <quality>Crystal Gut (Kidneys)</quality>
+		  <quality>Crystal Gut (Stomach)</quality>
+		  <quality>Crystal Gut (Intestines)</quality>
+          <quality>Crystal Gut (Liver, Kidneys)</quality>
+          <quality>Crystal Gut (Liver, Stomach)</quality>
+          <quality>Crystal Gut (Liver, Intestines)</quality>
+          <quality>Crystal Gut (Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Stomach)</quality>
+		  <quality>Crystal Gut (Liver, Kidneys, Intestines)</quality>
+		  <quality>Crystal Gut (Liver, Stomach, Intestines)</quality>
+		  <quality>Crystal Gut (Kidneys, Stomach, Intestines)</quality>
+        </oneof>
+      </forbidden>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-200</essencepenaltyt100>
+		<essencepenaltymagonlyt100>200</essencepenaltymagonlyt100>
+		<lifestylecost>-10</lifestylecost>
+	  </bonus>
       <source>FA</source>
       <page>133</page>
     </quality>
@@ -13928,7 +14984,22 @@
       <karma>10</karma>
       <category>Positive</category>
       <limit>no</limit>
-      <bonus />
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+      <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
+	  </bonus>
       <naturalweapons>
         <naturalweapon>
           <name>Crystal Jaw</name>
@@ -13952,7 +15023,21 @@
       <karma>10</karma>
       <category>Positive</category>
       <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
       <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
         <armor>1</armor>
         <selectside />
       </bonus>
@@ -13967,7 +15052,21 @@
       <karma>10</karma>
       <category>Positive</category>
       <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
       <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
         <armor>1</armor>
         <selectside />
       </bonus>
@@ -13982,9 +15081,23 @@
       <karma>10</karma>
       <category>Positive</category>
       <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
       <bonus>
+		<conditionmonitor>
+			<physical>-1</physical>
+			<stun>-1</stun>
+		</conditionmonitor>
+		<essencepenaltyt100>-100</essencepenaltyt100>
+		<essencepenaltymagonlyt100>100</essencepenaltymagonlyt100>
         <armor>1</armor>
-        <initiative>2</initiative>
+        <initiative precedence="0">2</initiative>
       </bonus>
       <source>FA</source>
       <page>133</page>
@@ -14001,6 +15114,10 @@
         <allof>
           <quality>Crystal Limb (Arm)</quality>
           <quality>Crystalline Claws</quality>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
         </allof>
       </required>
       <naturalweapons>
@@ -14026,6 +15143,14 @@
       <karma>5</karma>
       <category>Positive</category>
       <limit>no</limit>
+	  <required>
+        <allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
         <naturalweapons>
           <naturalweapon>
             <name>Crystal Claw</name>
@@ -14050,6 +15175,12 @@
       <category>Positive</category>
       <limit>no</limit>
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
         <oneof>
           <quality>Crystal Breath</quality>
         </oneof>
@@ -14066,6 +15197,12 @@
       <category>Positive</category>
       <limit>no</limit>
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
         <oneof>
           <quality>Crystal Limb (Leg)</quality>
         </oneof>
@@ -14081,6 +15218,17 @@
       <karma>15</karma>
       <category>Positive</category>
       <limit>no</limit>
+	  <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
+      </required>
+	  <bonus>
+		<dodge>2</dodge>
+	  </bonus>
       <source>FA</source>
       <page>134</page>
     </quality>
@@ -14093,6 +15241,12 @@
       <category>Positive</category>
       <limit>no</limit>
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
         <oneof>
           <quality>Crystal Limb (Arm)</quality>
         </oneof>
@@ -14124,8 +15278,16 @@
         <unlockskills name="Assensing">Name</unlockskills>
       </bonus>
       <required>
+		<allof>
+		  <attribute>
+			<name>MAG</name>
+			<total>1</total>
+		  </attribute>
+		</allof>
         <oneof>
-          <quality>Crystal Eye</quality>
+          <quality>Crystal Eye (One Eye)</quality>
+		  <quality>Crystal Eye (Two Eyes)</quality>
+		  <quality>Crystal Eye (Three Eyes)</quality>
         </oneof>
       </required>
       <source>FA</source>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -12491,11 +12491,7 @@
       <doublecareer>False</doublecareer>
       <karma>10</karma>
       <category>Positive</category>
-      <bonus />
       <required>
-        <allof>
-          <quality>Adept</quality>
-        </allof>
         <oneof>
           <group>
             <skill>
@@ -12503,14 +12499,36 @@
               <val>4</val>
             </skill>
             <tradition>Buddhism</tradition>
+			<quality>Adept</quality>
           </group>
-          <skill>
-            <name>Unarmed Combat</name>
-            <val>6</val>
-          </skill>
+		  <group>
+            <skill>
+              <name>Unarmed Combat</name>
+              <val>4</val>
+            </skill>
+            <tradition>Buddhism</tradition>
+			<quality>Mystic Adept</quality>
+          </group>
+		  <group>
+            <skill>
+              <name>Unarmed Combat</name>
+              <val>6</val>
+            </skill>
+			<quality>Adept</quality>
+          </group>
+		  <group>
+            <skill>
+              <name>Unarmed Combat</name>
+              <val>6</val>
+            </skill>
+			<quality>Mystic Adept</quality>
+          </group>
         </oneof>
       </required>
-      <!-- TODO: How the fuck do I implement getting free spells based on MAG? -->
+      <!-- TODO: Source code for this is super hacky, so it definitely needs cleaning up at the next opportunity -->
+	  <bonus>
+		<freespells attribute="MAG" limit="half,touchonly" />
+	  </bonus>
       <source>FA</source>
       <page>33</page>
     </quality>

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -11947,8 +11947,8 @@ namespace Chummer
             {
                 case NuyenExpenseType.AddCyberware:
                     // Locate the Cyberware that was added.
-                    int intOldPenalty = 0;
-                    int intNewPenalty = 0;
+                    //int intOldPenalty = 0;
+                    //int intNewPenalty = 0;
                     foreach (Cyberware objCyberware in _objCharacter.Cyberware)
                     {
                         if (objCyberware.InternalId == objEntry.Undo.ObjectId)
@@ -11964,11 +11964,11 @@ namespace Chummer
                             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId);
 
                             // Determine the character's Essence penalty before removing the Cyberware.
-                            intOldPenalty = _objCharacter.EssencePenalty;
+                            //intOldPenalty = _objCharacter.EssencePenalty;
                             // Remove the Cyberware.
                             _objCharacter.Cyberware.Remove(objCyberware);
                             // Determine the character's Essence penalty after removing the Cyberware.
-                            intNewPenalty = _objCharacter.EssencePenalty;
+                            //intNewPenalty = _objCharacter.EssencePenalty;
 
                             // Restore the character's MAG/RES if they have it.
                             //if (!_objCharacter.OverrideSpecialAttributeEssenceLoss && !_objCharacter.OverrideSpecialAttributeEssenceLoss)
@@ -19551,6 +19551,7 @@ namespace Chummer
         {
             // Set the Minimum and Maximum values for each CharacterAttribute based on the selected MetaType.
             // Also update the Maximum and Augmented Maximum values displayed.
+            /*
             _blnSkipUpdate = true;
 
             int intEssenceLoss = 0;
@@ -19571,7 +19572,7 @@ namespace Chummer
             }
 
             _blnSkipUpdate = false;
-
+            */
             ScheduleCharacterUpdate();
         }
 
@@ -19680,6 +19681,8 @@ namespace Chummer
 
             // Reduce a character's MAG and RES from Essence Loss.
             int intReduction = _objCharacter.ESS.MetatypeMaximum - Convert.ToInt32(Math.Floor(decESS));
+            int intMagReduction = _objCharacter.ESS.MetatypeMaximum - Convert.ToInt32(Math.Floor(Math.Round(_objCharacter.Essence + _objCharacter.EssencePenalty - _objCharacter.EssencePenaltyMAG, _objCharacter.Options.EssenceDecimals, MidpointRounding.AwayFromZero)));
+
 
             // Remove any Improvements from MAG and RES from Essence Loss.
             _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.EssenceLoss, "Essence Loss");
@@ -19687,11 +19690,15 @@ namespace Chummer
             // Create the Essence Loss Improvements.
             if (intReduction > 0)
             {
-                _objImprovementManager.CreateImprovement("MAG", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, string.Empty, 0, 1, 0, intReduction * -1);
                 _objImprovementManager.CreateImprovement("RES", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, string.Empty, 0, 1, 0, intReduction * -1);
                 _objImprovementManager.CreateImprovement("DEP", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, string.Empty, 0, 1, 0, intReduction * -1);
             }
+            if (intMagReduction > 0)
+            {
+                _objImprovementManager.CreateImprovement("MAG", Improvement.ImprovementSource.EssenceLoss, "Essence Loss", Improvement.ImprovementType.Attribute, string.Empty, 0, 1, 0, intMagReduction * -1);
+            }
 
+            /*
             int intEssenceLoss = 0;
             if (!_objOptions.ESSLossReducesMaximumOnly)
                 intEssenceLoss = _objCharacter.EssencePenalty;
@@ -19708,9 +19715,10 @@ namespace Chummer
                         intEssenceLoss = _objCharacter.RES.Value - _objCharacter.RES.TotalMaximum;
                 }
             }
+            */
 
-                // If the CharacterAttribute reaches 0, the character has burned out.
-                if (_objCharacter.MAG.TotalMaximum < 1 && _objCharacter.MAGEnabled)
+            // If the CharacterAttribute reaches 0, the character has burned out.
+            if (_objCharacter.MAG.TotalMaximum < 1 && _objCharacter.MAGEnabled)
                 {
                     _objCharacter.MAG.Base = 0;
                     _objCharacter.MAG.Karma = 0;

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -604,11 +604,15 @@ namespace Chummer
                         treSpells.Nodes[4].Expand();
                         break;
                     case "Rituals":
+                        /*
                         int intNode = 5;
                         if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
                             intNode = 0;
                         treSpells.Nodes[intNode].Nodes.Add(objNode);
                         treSpells.Nodes[intNode].Expand();
+                        */
+                        treSpells.Nodes[5].Nodes.Add(objNode);
+                        treSpells.Nodes[5].Expand();
                         break;
                     case "Enchantments":
                         treSpells.Nodes[6].Nodes.Add(objNode);
@@ -1832,6 +1836,9 @@ namespace Chummer
 
             _blnReapplyImprovements = true;
 
+            // Wipe all improvements that we will reapply, this is mainly to eliminate orphaned improvements caused by certain bugs and also for a performance increase
+            _objImprovementManager.RemoveImprovements(0, string.Empty, true);
+
             // Refresh Qualities.
             XmlDocument objXmlDocument = XmlManager.Instance.Load("qualities.xml");
             foreach (Quality objQuality in _objCharacter.Qualities)
@@ -1841,7 +1848,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/qualities/quality[name = \"" + objQuality.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Quality, objQuality.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Quality, objQuality.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -1873,7 +1881,8 @@ namespace Chummer
                     XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/martialarts/martialart[name = \"" + objMartialArt.Name + "\"]/techniques/technique[name = \"" + objAdvantage.Name + "\"]");
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.MartialArtAdvantage, objAdvantage.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.MartialArtAdvantage, objAdvantage.InternalId);
                         if (objNode["bonus"] != null)
                         {
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.MartialArtAdvantage, objAdvantage.InternalId, objNode["bonus"], false, 1, objAdvantage.DisplayName);
@@ -1891,7 +1900,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/spells/spell[name = \"" + objSpell.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Spell, objSpell.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Spell, objSpell.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -1923,7 +1933,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/powers/power[name = \"" + objPower.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Power, objPower.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Power, objPower.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -1939,7 +1950,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/complexforms/complexform[name = \"" + objProgram.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ComplexForm, objProgram.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ComplexForm, objProgram.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         foreach (TreeNode objParentNode in treComplexForms.Nodes)
@@ -1964,7 +1976,8 @@ namespace Chummer
                 XmlNode objNode = objXmlDocument.SelectSingleNode("/chummer/programs/program[name = \"" + objProgram.Name + "\"]");
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.AIProgram, objProgram.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.AIProgram, objProgram.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         foreach (TreeNode objParentNode in treAIPrograms.Nodes)
@@ -1992,7 +2005,8 @@ namespace Chummer
 
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.CritterPower, objPower.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.CritterPower, objPower.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         int intRating = 0;
@@ -2029,7 +2043,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Metamagic, objMetamagic.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Metamagic, objMetamagic.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Metamagic, objMetamagic.InternalId, objNode["bonus"], false, 1, objMetamagic.DisplayNameShort);
                     }
@@ -2041,7 +2056,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Echo, objMetamagic.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Echo, objMetamagic.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Echo, objMetamagic.InternalId, objNode["bonus"], false, 1, objMetamagic.DisplayNameShort);
                     }
@@ -2058,7 +2074,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objCyberware.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objCyberware.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Cyberware, objCyberware.InternalId, objNode["bonus"], false, objCyberware.Rating, objCyberware.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2083,7 +2100,8 @@ namespace Chummer
 
                         if (objChild != null)
                         {
-                            _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objPlugin.InternalId);
+                            // Because all improvements are wiped at the start, no need to go and remove them again
+                            //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Cyberware, objPlugin.InternalId);
                             if (objChild["bonus"] != null)
                                 _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Cyberware, objPlugin.InternalId, objChild["bonus"], false, objPlugin.Rating, objPlugin.DisplayNameShort);
                         }
@@ -2096,7 +2114,8 @@ namespace Chummer
 
                     if (objNode != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId);
                         if (objNode["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Bioware, objCyberware.InternalId, objNode["bonus"], false, objCyberware.Rating, objCyberware.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2121,7 +2140,8 @@ namespace Chummer
 
                         if (objChild != null)
                         {
-                            _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objPlugin.InternalId);
+                            // Because all improvements are wiped at the start, no need to go and remove them again
+                            //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Bioware, objPlugin.InternalId);
                             if (objChild["bonus"] != null)
                                 _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Bioware, objPlugin.InternalId, objChild["bonus"], false, objPlugin.Rating, objPlugin.DisplayNameShort);
                         }
@@ -2137,7 +2157,8 @@ namespace Chummer
 
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId);
                     if (objNode["bonus"] != null)
                         _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Armor, objArmor.InternalId, objNode["bonus"], false, 1, objArmor.DisplayNameShort);
                     if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2162,7 +2183,8 @@ namespace Chummer
 
                     if (objChild != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId);
                         if (objChild["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.ArmorMod, objMod.InternalId, objChild["bonus"], false, 1, objMod.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2192,7 +2214,8 @@ namespace Chummer
 
                     if (objChild != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                         if (objChild["bonus"] != null)
                             _objImprovementManager.CreateImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId, objChild["bonus"], false, objGear.Rating, objGear.DisplayNameShort);
                         if (!string.IsNullOrEmpty(_objImprovementManager.SelectedValue))
@@ -2225,7 +2248,8 @@ namespace Chummer
 
                 if (objNode != null)
                 {
-                    _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
+                    // Because all improvements are wiped at the start, no need to go and remove them again
+                    //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objGear.InternalId);
                     if (objNode["bonus"] != null)
                     {
                         _objImprovementManager.ForcedValue = strSelected;
@@ -2254,7 +2278,8 @@ namespace Chummer
 
                     if (objChild != null)
                     {
-                        _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objPlugin.InternalId);
+                        // Because all improvements are wiped at the start, no need to go and remove them again
+                        //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objPlugin.InternalId);
                         if (objChild["bonus"] != null)
                         {
                             _objImprovementManager.ForcedValue = strPluginSelected;
@@ -2286,7 +2311,8 @@ namespace Chummer
 
                         if (objSubChild != null)
                         {
-                            _objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objSubPlugin.InternalId);
+                            // Because all improvements are wiped at the start, no need to go and remove them again
+                            //_objImprovementManager.RemoveImprovements(Improvement.ImprovementSource.Gear, objSubPlugin.InternalId);
                             if (objSubChild["bonus"] != null)
                             {
                                 _objImprovementManager.ForcedValue = strSubPluginSelected;
@@ -3236,9 +3262,9 @@ namespace Chummer
             string strCounterSpelling = LanguageManager.Instance.GetString("Label_CounterspellingDice");
             string strSpellResistance = LanguageManager.Instance.GetString("String_SpellResistanceDice");
             //Indirect Dodge
-            lblSpellDefenceIndirectDodge.Text = (_objCharacter.AGI.TotalValue + _objCharacter.REA.TotalValue).ToString();
+            lblSpellDefenceIndirectDodge.Text = (_objCharacter.INT.TotalValue + _objCharacter.REA.TotalValue + _objCharacter.TotalBonusDodgeRating).ToString();
             strSpellTooltip = $"{strModifiers}: " +
-                              $"{_objCharacter.INT.DisplayAbbrev} ({_objCharacter.INT.TotalValue}) + {_objCharacter.REA.DisplayAbbrev} ({_objCharacter.REA.TotalValue})";
+                              $"{_objCharacter.INT.DisplayAbbrev} ({_objCharacter.INT.TotalValue}) + {_objCharacter.REA.DisplayAbbrev} ({_objCharacter.REA.TotalValue}) + {strModifiers} ({_objCharacter.TotalBonusDodgeRating})";
             tipTooltip.SetToolTip(lblSpellDefenceIndirectDodge, strSpellTooltip);
             //Indirect Soak
             lblSpellDefenceIndirectSoak.Text = (_objCharacter.TotalArmorRating + _objCharacter.BOD.TotalValue).ToString();
@@ -3900,6 +3926,11 @@ namespace Chummer
                     .Replace("{0}", objSpell.DisplayName).Replace("{1}", _objOptions.KarmaSpell.ToString())))
                     return;
             }
+            // Barehanded Adept
+            else if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled && objSpell.Range == "T")
+            {
+                objSpell.UsesUnarmed = true;
+            }
 
             _objCharacter.Spells.Add(objSpell);
 
@@ -3926,11 +3957,15 @@ namespace Chummer
                     treSpells.Nodes[4].Expand();
                     break;
                 case "Rituals":
+                    /*
                     int intNode = 5;
                     if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
                         intNode = 0;
                     treSpells.Nodes[intNode].Nodes.Add(objNode);
                     treSpells.Nodes[intNode].Expand();
+                    */
+                    treSpells.Nodes[5].Nodes.Add(objNode);
+                    treSpells.Nodes[5].Expand();
                     break;
                 case "Enchantments":
                     treSpells.Nodes[6].Nodes.Add(objNode);
@@ -13801,11 +13836,15 @@ namespace Chummer
                     treSpells.Nodes[4].Expand();
                     break;
                 case "Rituals":
+                    /*
                     int intNode = 5;
                     if (_objCharacter.AdeptEnabled && !_objCharacter.MagicianEnabled)
                         intNode = 0;
                     treSpells.Nodes[intNode].Nodes.Add(objNode);
                     treSpells.Nodes[intNode].Expand();
+                    */
+                    treSpells.Nodes[5].Nodes.Add(objNode);
+                    treSpells.Nodes[5].Expand();
                     break;
             }
 

--- a/Chummer/frmViewer.cs
+++ b/Chummer/frmViewer.cs
@@ -117,6 +117,10 @@ namespace Chummer
             {
                 MessageBox.Show(LanguageManager.Instance.GetString("Message_Save_Error_Warning"));
             }
+            catch (System.UnauthorizedAccessException)
+            {
+                MessageBox.Show(LanguageManager.Instance.GetString("Message_Save_Error_Warning"));
+            }
         }
 
         private void frmViewer_FormClosing(object sender, FormClosingEventArgs e)

--- a/Chummer/frmViewer.cs
+++ b/Chummer/frmViewer.cs
@@ -1,4 +1,4 @@
-﻿/*  This file is part of Chummer5a.
+/*  This file is part of Chummer5a.
  *
  *  Chummer5a is free software: you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -109,7 +109,14 @@ namespace Chummer
             if (string.IsNullOrEmpty(strSaveFile))
                 return;
 
-            _objCharacterXML.Save(strSaveFile);
+            try
+            {
+                _objCharacterXML.Save(strSaveFile);
+            }
+            catch (XmlException)
+            {
+                MessageBox.Show(LanguageManager.Instance.GetString("Message_Save_Error_Warning"));
+            }
         }
 
         private void frmViewer_FormClosing(object sender, FormClosingEventArgs e)

--- a/Chummer/lang/de.xml
+++ b/Chummer/lang/de.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--This file is part of Chummer5a.
 
     Chummer5a is free software: you can redistribute it and/or modify
@@ -21,6 +21,14 @@
   <version>-495</version>
   <name>Deutsch (DE)</name>
   <strings>
+	<string>
+		<key>Message_Insufficient_Permissions_Warning</key>
+		<text>Chummer5 is currently not being run with proper permissions! If you are not running Chummer5 as an administrator, please move it to a folder owned by your user.</text>
+	</string>
+	<string>
+		<key>Message_Save_Error_Warning</key>
+		<text>Chummer5 encountered an error while saving the character.</text>
+	</string>
     <string>
       <key>String_BP</key>
       <text>GP</text>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -21,6 +21,15 @@
   <version>-350</version>
   <name>English (US)</name>
   <strings>
+	<!-- Meta Strings -->
+	<string>
+		<key>Message_Insufficient_Permissions_Warning</key>
+		<text>Chummer5 is currently not being run with proper permissions! If you are not running Chummer5 as an administrator, please move it to a folder owned by your user.</text>
+	</string>
+	<string>
+		<key>Message_Save_Error_Warning</key>
+		<text>Chummer5 encountered an error while saving the character.</text>
+	</string>
     <!-- Region Common Strings -->
     <string>
       <key>String_Search</key>

--- a/Chummer/lang/en-us2.xml
+++ b/Chummer/lang/en-us2.xml
@@ -21,6 +21,15 @@
 	<version>-488</version>
 	<name>English (US)</name>
 	<strings>
+		<!-- Meta Strings -->
+		<string>
+			<key>Message_Insufficient_Permissions_Warning</key>
+			<text>Chummer5 is currently not being run with proper permissions! If you are not running Chummer5 as an administrator, please move it to a folder owned by your user.</text>
+		</string>
+		<string>
+			<key>Message_Save_Error_Warning</key>
+			<text>Chummer5 encountered an error while saving the character.</text>
+		</string>
 		<!-- Common Strings -->
 		<string>
 			<key>String_Karma</key>

--- a/Chummer/lang/fr.xml
+++ b/Chummer/lang/fr.xml
@@ -21,6 +21,15 @@
   <version>-494</version>
   <name>Français</name>
   <strings>
+	<!-- Meta Strings -->
+	<string>
+		<key>Message_Insufficient_Permissions_Warning</key>
+		<text>Chummer5 is currently not being run with proper permissions! If you are not running Chummer5 as an administrator, please move it to a folder owned by your user.</text>
+	</string>
+	<string>
+		<key>Message_Save_Error_Warning</key>
+		<text>Chummer5 encountered an error while saving the character.</text>
+	</string>
     <!-- Common Strings -->
     <string>
       <key>String_BP</key>

--- a/Chummer/lang/jp.xml
+++ b/Chummer/lang/jp.xml
@@ -23,6 +23,15 @@
   <version>-497</version>
   <name>日本語 (JP)</name>
   <strings>
+	<!-- Meta Strings -->
+	<string>
+		<key>Message_Insufficient_Permissions_Warning</key>
+		<text>Chummer5 is currently not being run with proper permissions! If you are not running Chummer5 as an administrator, please move it to a folder owned by your user.</text>
+	</string>
+	<string>
+		<key>Message_Save_Error_Warning</key>
+		<text>Chummer5 encountered an error while saving the character.</text>
+	</string>
     <!-- Common Strings -->
     <string>
       <key>String_BP</key>


### PR DESCRIPTION
Application Changes:

- Added support for bonuses to defense dice (e.g. Combat Sense, Reakt).
- Added support for Barehanded Adept and qualities similar to it.
- Drain for Physical Adepts is now properly displayed and calculated as BOD + WIL.
- Reapply Improvements will now start by clearing out all improvements that it would reapply, regardless of source names. This helps clean out old .chum5 saves that have orphaned improvements, which fixes #1916.
- Chummer5 will now warn users when it does not have the proper write permissions to its own folder, or if an error was encountered that prevented a character from being saved. Fixes #1915.
- The "Buy Specialization with Karma" checkbox is now also automatically checked if buying a specialization for a skill that was ranked up with skill group points.
- Added support for qualities that can be purchased with spell points instead of karma at chargen.
- Added support for essence penalty improvements that only affect MAG, as well as essence penalty improvements that have hundredths-level precision instead of integer precision.
- Fixed a bug where the optional rule that allows Mystic Adept PPs to be bought with priority spell points also allowed purchasing of PPs with free spell points given by Dedicated Spellslinger.
- Requirements that check for whether MAG, RES, or DEP are >= 1 will now instead check for if the corresponding attribute is enabled.
- When adding adept powers, the list of available adept powers will hide powers whose prerequisites are not met.
- Added support for any attribute or special attribute to be used in a weapon's damage code.

Data Changes:

- Reakt and Combat Sense now give dodge bonuses. Fixes #1856.
- Barehanded Adept can now be taken by Mystic Adepts as well, and it will now properly provide free Touch-ranged spells that use Unarmed Combat in place of Spellcasting. Fixes #1874.
- Fixed non-Awakened characters being eligible to take Mastery and Blood Crystal qualities from Forbidden Arcana.
- When free spell points are available at chargen, and real spell costs (costs charged for the character) are not greater than unmodified spell costs (costs set in Options), all Mastery qualities from Forbidden Arcana will now deduct from spell points instead of from free karma at a rate of 1 point per [unmodified spell cost] karma, rounded down (so e.g. at 5 karma per spell, an 8 karma Mastery quality will cost 1 spell point and 3 karma instead of 8 karma). Fixes #1873
- All Blood Crystal qualities now properly reduce both condition monitors by 1 for each bonded crystal. Crystal Breath, Crystal Eye, Crystal Gut, Crystal Jaw, Crystal Limb, and Crystal Spine now properly reduce Essence, but in a way that does not affect the character's MAG rating.
- Crystalline Reflexes now properly gives 2 extra defense dice against attacks.
- Crystal Gut Stomach now properly reduces lifestyle costs by 10%.
- Fixed Crystal Spine's initiative bonus stacking with other initiative bonuses.
- Added appropriate power prerequisites to Elemental Strike, Elemental Body, and Toxic Strike. Users can now choose what toxic element Toxic Strike will take.

New Strings:

- Message_Insufficient_Permissions_Warning
- Message_Save_Error_Warning