### PR TITLE
Character Validation, Qualities, & Metatype Attributes Fixes

### DIFF
--- a/Chummer/Backend/Attributes/Attribute.Core.cs
+++ b/Chummer/Backend/Attributes/Attribute.Core.cs
@@ -155,6 +155,10 @@ namespace Chummer.Backend.Attributes
             set
             {
                 _intMetatypeMin = value;
+                OnPropertyChanged(nameof(TotalMinimum));
+                OnPropertyChanged(nameof(FreeBase));
+                OnPropertyChanged(nameof(TotalBase));
+                OnPropertyChanged(nameof(AugmentedMetatypeLimits));
             }
         }
 
@@ -175,6 +179,7 @@ namespace Chummer.Backend.Attributes
             set
             {
                 _intMetatypeMax = value;
+                OnPropertyChanged(nameof(AugmentedMetatypeLimits));
             }
         }
 
@@ -190,6 +195,7 @@ namespace Chummer.Backend.Attributes
             set
             {
                 _intMetatypeAugMax = value;
+                OnPropertyChanged(nameof(AugmentedMetatypeLimits));
             }
         }
 

--- a/Chummer/Backend/Equipment/Vehicle.cs
+++ b/Chummer/Backend/Equipment/Vehicle.cs
@@ -2270,7 +2270,7 @@ namespace Chummer.Backend.Equipment
         {
             string[] arrCategories = new string[6] { "Powertrain", "Protection", "Weapons", "Body", "Electromagnetic", "Cosmetic" };
             return !string.IsNullOrEmpty(strCheckCapacity) && arrCategories.Contains(strCheckCapacity)
-                ? arrCategories.Any(strCategory => CalcCategoryUsed(strCheckCapacity) > CalcCategoryAvail(strCheckCapacity))
+                ? CalcCategoryUsed(strCheckCapacity) > CalcCategoryAvail(strCheckCapacity)
                 : arrCategories.Any(strCategory => CalcCategoryUsed(strCategory) > CalcCategoryAvail(strCategory));
         }
 
@@ -2492,6 +2492,27 @@ namespace Chummer.Backend.Equipment
         public int CalcCategoryAvail(string strCategory)
         {
             int intBase = _intBody;
+            switch (strCategory)
+            {
+                case "Powertrain":
+                    intBase += _intAddPowertrainModSlots;
+                    break;
+                case "Weapons":
+                    intBase += _intAddWeaponModSlots;
+                    break;
+                case "Body":
+                    intBase += _intAddBodyModSlots;
+                    break;
+                case "Electromagnetic":
+                    intBase += _intAddElectromagneticModSlots;
+                    break;
+                case "Protection":
+                    intBase += _intAddProtectionModSlots;
+                    break;
+                case "Cosmetic":
+                    intBase += _intAddCosmeticModSlots;
+                    break;
+            }
             foreach (VehicleMod objMod in _lstVehicleMods.Where(objMod => !objMod.IncludedInVehicle && objMod.Installed && (objMod.Category == strCategory)))
             {
                 if (objMod.CalculatedSlots < 0)

--- a/Chummer/Backend/Shared Methods/SelectionShared.cs
+++ b/Chummer/Backend/Shared Methods/SelectionShared.cs
@@ -33,13 +33,41 @@ namespace Chummer.Backend.Shared_Methods
             // Ignore the rules.
             if (objCharacter.IgnoreRules)
                 return true;
+            if (objXmlNode == null)
+                return false;
             if (objMetatypeDocument == null)
                 objMetatypeDocument = XmlManager.Instance.Load("metatypes.xml");
             if (objCritterDocument == null)
                 objCritterDocument = XmlManager.Instance.Load("critters.xml");
             if (objQualityDocument == null)
                 objQualityDocument = XmlManager.Instance.Load("qualities.xml");
-            if (objXmlNode == null) return false;
+            // See if the character is in career mode but would want to add a chargen-only Quality
+            if (objCharacter.Created)
+            {
+                if (objXmlNode["chargenonly"] != null && objXmlNode["chargenonly"]?.InnerText != "no")
+                {
+                    if (blnShowMessage)
+                    {
+                        MessageBox.Show(LanguageManager.Instance.GetString("Message_SelectGeneric_ChargenRestriction").Replace("{0}", strLocalName),
+                            LanguageManager.Instance.GetString("MessageTitle_SelectGeneric_Restriction").Replace("{0}", strLocalName),
+                            MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        return false;
+                    }
+                    return false;
+                }
+            }
+            // See if the character is using priority-based gen and is trying to add a Quality that can only be added through priorities
+            else if ((objCharacter.BuildMethod == CharacterBuildMethod.Priority || objCharacter.BuildMethod == CharacterBuildMethod.SumtoTen) && objXmlNode["onlyprioritygiven"] != null && objXmlNode["onlyprioritygiven"]?.InnerText != "no")
+            {
+                if (blnShowMessage)
+                {
+                    MessageBox.Show(LanguageManager.Instance.GetString("MessageTitle_SelectGeneric_PriorityRestriction").Replace("{0}", strLocalName),
+                        LanguageManager.Instance.GetString("MessageTitle_SelectGeneric_Restriction").Replace("{0}", strLocalName),
+                        MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    return false;
+                }
+                return false;
+            }
             // See if the character already has this Quality and whether or not multiple copies are allowed.
             if (objXmlNode["limit"] != null && objXmlNode["limit"]?.InnerText != "no")
             {

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -17394,7 +17394,7 @@ namespace Chummer
                 }
 
             }
-            int i = _objCharacter.Attributes - CalculateAttributePriorityPoints(_objCharacter.AttributeList);
+            int i = _objCharacter.TotalAttributes - CalculateAttributePriorityPoints(_objCharacter.AttributeList);
             // Check if the character has gone over on Primary Attributes
             if (i < 0)
             {
@@ -17403,7 +17403,7 @@ namespace Chummer
                 strMessage += "\n\t" + LanguageManager.Instance.GetString("Message_InvalidAttributeExcess").Replace("{0}", (i * -1).ToString());
             }
 
-            i = _objCharacter.Special - CalculateAttributePriorityPoints(_objCharacter.SpecialAttributeList);
+            i = _objCharacter.TotalSpecial - CalculateAttributePriorityPoints(_objCharacter.SpecialAttributeList);
             // Check if the character has gone over on Special Attributes
             if (i < 0)
             {
@@ -19409,8 +19409,6 @@ namespace Chummer
                     if (objXmlQuality.SelectNodes("required/allof/metatype[. = \"" + _objCharacter.Metatype + "\"]").Count > 0 || objXmlQuality.SelectNodes("required/allof/metavariant[. = \"" + _objCharacter.Metavariant + "\"]").Count > 0)
                         strQualities += "\n\t" + objQuality.DisplayNameShort;
                 }
-
-
             }
             if (!string.IsNullOrEmpty(strQualities))
             {
@@ -19454,7 +19452,7 @@ namespace Chummer
                     default:
                         break;
                 }
-            }*/
+            }
 
             // Remove any Qualities the character received from their Metatype, then remove the Quality.
             foreach (Quality objQuality in lstRemoveQualities)
@@ -19464,11 +19462,9 @@ namespace Chummer
             }
             lstRemoveQualities.Clear();
 
-            /*
             int intEssenceLoss = 0;
             if (!_objOptions.ESSLossReducesMaximumOnly)
                 intEssenceLoss = _objCharacter.EssencePenalty;
-            */
 
             // Determine the number of points that have been put into Attributes.
             int intBOD = _objCharacter.BOD.Base - _objCharacter.BOD.MetatypeMinimum;
@@ -19483,6 +19479,7 @@ namespace Chummer
             int intDEP = _objCharacter.DEP.Base - _objCharacter.DEP.MetatypeMinimum;
             int intMAG = Math.Max(_objCharacter.MAG.Base - _objCharacter.MAG.MetatypeMinimum, 0);
             int intRES = Math.Max(_objCharacter.RES.Base - _objCharacter.RES.MetatypeMinimum, 0);
+            */
 
             // Build a list of the current Metatype's Improvements to remove if the Metatype changes.
             List<Improvement> lstImprovement = _objCharacter.Improvements.Where(objImprovement => objImprovement.ImproveSource == Improvement.ImprovementSource.Metatype || objImprovement.ImproveSource == Improvement.ImprovementSource.Metavariant || objImprovement.ImproveSource == Improvement.ImprovementSource.Heritage).ToList();
@@ -21571,7 +21568,7 @@ namespace Chummer
             {
                 lstSpecialAttributes.Add(_objCharacter.RES);
             }
-            if (_objCharacter.Metatype == "A.I.")
+            if (_objCharacter.DEPEnabled)
             {
                 lstSpecialAttributes.Add(_objCharacter.DEP);
             }

--- a/Chummer/Selection Forms/frmSelectQuality.cs
+++ b/Chummer/Selection Forms/frmSelectQuality.cs
@@ -475,10 +475,10 @@ namespace Chummer
             switch (lstQualities.SelectedValue.ToString())
             {
                 case "Changeling (Class I SURGE)":
-                    _objCharacter.MetageneticLimit = 30;
+                    _objCharacter.MetageneticLimit = 10;
                     break;
                 case "Changeling (Class II SURGE)":
-                    _objCharacter.MetageneticLimit = 30;
+                    _objCharacter.MetageneticLimit = 15;
                     break;
                 case "Changeling (Class III SURGE)":
                     _objCharacter.MetageneticLimit = 30;

--- a/Chummer/Selection Forms/frmSelectQuality.cs
+++ b/Chummer/Selection Forms/frmSelectQuality.cs
@@ -89,6 +89,9 @@ namespace Chummer
                 cboCategory.SelectedIndex = 0;
             cboCategory.EndUpdate();
 
+            if (_objCharacter.MetageneticLimit == 0)
+                chkNotMetagenetic.Checked = true;
+
             lblBPLabel.Text = LanguageManager.Instance.GetString("Label_Karma");
             _blnLoading = false;
             BuildQualityList();

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -43,6 +43,8 @@ Application Changes:
 - Fixed Character Validity Checker not properly counting attribute points and special attribute points. Fixes #1917.
 - Fixed Character Validity Checker not counting vehicle mod slot modifiers when checking vehicle mods are over capacity. Fixes #1875.
 - Fixed attribute points, special attribute points, and displayed metatype limits not updating if/when metatype limits are changed. Fixes #1912.
+- Added support for the following requirements (to qualities): the item can only be taken during character generation, the item cannot be bought separately in priority-based character generation methods.
+- Added support for qualities that refund their cost when removed in career mode. The fact that such a quality can be bought for its normal price in chargen and then refunded for double its price in career mode is working as intended, as per rules for swapping Latent Dracomorphosis for a Drake quality.
 
 Data Changes:
 
@@ -73,6 +75,9 @@ Data Changes:
 - Crystal Gut Stomach now properly reduces lifestyle costs by 10%.
 - Fixed Crystal Spine's initiative bonus stacking with other initiative bonuses.
 - Added appropriate power prerequisites to Elemental Strike, Elemental Body, and Toxic Strike. Users can now choose what toxic element Toxic Strike will take.
+- SURGE I and SURGE II now properly give metagenic quality limits of 10 and 15 respectively (from 30)
+- All Awakened qualities and the Technomancer quality cannot be bought separately during character generation when using Priority or Sum-to-Ten character generation methods.
+- Latent Dracomorphosis is now mutually exclusive with all Infected, Drake, and Changeling qualities, and will now refund its karma cost when removed in career mode.
 
 New Strings:
 - Label_Options_SpellShapingFocus
@@ -85,6 +90,8 @@ New Strings:
 - Message_Improvement_EmptySelectionListNamed
 - Message_Insufficient_Permissions_Warning
 - Message_Save_Error_Warning
+- Message_SelectGeneric_ChargenRestriction
+- MessageTitle_SelectGeneric_PriorityRestriction
 
 Changes Strings:
 - Message_PositiveQualityLimit

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -40,6 +40,9 @@ Application Changes:
 - Requirements that check for whether MAG, RES, or DEP are >= 1 will now instead check for if the corresponding attribute is enabled.
 - When adding adept powers, the list of available adept powers will hide powers whose prerequisites are not met.
 - Added support for any attribute or special attribute to be used in a weapon's damage code.
+- Fixed Character Validity Checker not properly counting attribute points and special attribute points. Fixes #1917.
+- Fixed Character Validity Checker not counting vehicle mod slot modifiers when checking vehicle mods are over capacity. Fixes #1875.
+- Fixed attribute points, special attribute points, and displayed metatype limits not updating if/when metatype limits are changed. Fixes #1912.
 
 Data Changes:
 

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -45,6 +45,7 @@ Application Changes:
 - Fixed attribute points, special attribute points, and displayed metatype limits not updating if/when metatype limits are changed. Fixes #1912.
 - Added support for the following requirements (to qualities): the item can only be taken during character generation, the item cannot be bought separately in priority-based character generation methods.
 - Added support for qualities that refund their cost when removed in career mode. The fact that such a quality can be bought for its normal price in chargen and then refunded for double its price in career mode is working as intended, as per rules for swapping Latent Dracomorphosis for a Drake quality.
+- "Don't Show Metagenetic Qualities" is automatically checked when choosing qualities for characters without any SURGE quality.
 
 Data Changes:
 
@@ -75,7 +76,7 @@ Data Changes:
 - Crystal Gut Stomach now properly reduces lifestyle costs by 10%.
 - Fixed Crystal Spine's initiative bonus stacking with other initiative bonuses.
 - Added appropriate power prerequisites to Elemental Strike, Elemental Body, and Toxic Strike. Users can now choose what toxic element Toxic Strike will take.
-- SURGE I and SURGE II now properly give metagenic quality limits of 10 and 15 respectively (from 30)
+- SURGE I and SURGE II now properly cost 10 and 15 karma respectively (from 30)
 - All Awakened qualities and the Technomancer quality cannot be bought separately during character generation when using Priority or Sum-to-Ten character generation methods.
 - Latent Dracomorphosis is now mutually exclusive with all Infected, Drake, and Changeling qualities, and will now refund its karma cost when removed in career mode.
 

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -1101,6 +1101,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>30</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -1131,6 +1132,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>20</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -1161,6 +1163,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>35</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -1192,6 +1195,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>15</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>RES</name>
@@ -1224,6 +1228,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>15</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -1255,6 +1260,7 @@
       <hide>yes</hide>
       <karma>15</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -1264,8 +1270,6 @@
         <oneof>
           <quality>Apprentice</quality>
           <quality>Aspected Magician</quality>
-		  <quality>Enchanter</quality>
-		  <quality>Explorer</quality>
 		  <quality>Enchanter</quality>
 		  <quality>Explorer</quality>
           <quality>Magician</quality>
@@ -2596,6 +2600,7 @@
         <oneof>
           <quality>Changeling (Class II SURGE)</quality>
           <quality>Changeling (Class III SURGE)</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <source>RF</source>
@@ -2611,6 +2616,7 @@
         <oneof>
           <quality>Changeling (Class I SURGE)</quality>
           <quality>Changeling (Class III SURGE)</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <source>RF</source>
@@ -2626,6 +2632,7 @@
         <oneof>
           <quality>Changeling (Class I SURGE)</quality>
           <quality>Changeling (Class II SURGE)</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <source>RF</source>
@@ -7437,6 +7444,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -7573,6 +7581,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -7697,6 +7706,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -7830,6 +7840,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -7966,6 +7977,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8102,6 +8114,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8238,6 +8251,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8374,6 +8388,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8510,6 +8525,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8646,6 +8662,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8776,6 +8793,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -8910,6 +8928,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9058,6 +9077,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9198,6 +9218,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9341,6 +9362,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9500,6 +9522,7 @@
           <quality>Infected: Mutaqua</quality>
           <quality>Infected: Vampire (Non-Human)</quality>
           <quality>Mystic Adept</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9657,6 +9680,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9785,6 +9809,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -9911,6 +9936,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -10040,6 +10066,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -10167,6 +10194,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -10315,6 +10343,7 @@
           <quality>Magic Resistance (Rating 3)</quality>
           <quality>Magic Resistance (Rating 4)</quality>
           <quality>Technomancer</quality>
+		  <quality>Latent Dracomorphosis</quality>
         </oneof>
       </forbidden>
       <naturalweapons>
@@ -11624,6 +11653,40 @@
       <name>Latent Dracomorphosis</name>
       <karma>5</karma>
       <category>Positive</category>
+	  <refundkarmaonremove />
+	  <forbidden>
+        <oneof>
+          <quality>Dracoform (Eastern Drake)</quality>
+          <quality>Dracoform (Western Drake)</quality>
+		  <quality>Dracoform (Feathered Drake)</quality>
+		  <quality>Dracoform (Sea Drake)</quality>
+          <quality>Changeling (Class I SURGE)</quality>
+		  <quality>Changeling (Class II SURGE)</quality>
+		  <quality>Changeling (Class III SURGE)</quality>
+          <quality>Infected: Bandersnatch</quality>
+          <quality>Infected: Banshee</quality>
+          <quality>Infected: Dzoo-Noo-Qua</quality>
+          <quality>Infected: Fomoraig</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
+          <quality>Infected: Gnawer</quality>
+          <quality>Infected: Goblin</quality>
+          <quality>Infected: Grendel</quality>
+          <quality>Infected: Harvester</quality>
+          <quality>Infected: Loup-Garou</quality>
+          <quality>Infected: Mutaqua</quality>
+          <quality>Infected: Nosferatu</quality>
+          <quality>Infected: Vampire (Human)</quality>
+          <quality>Infected: Vampire (Non-Human)</quality>
+          <quality>Infected: Sukuyan (Human)</quality>
+          <quality>Infected: Sukuyan (Non-Human)</quality>
+          <quality>Infected: Wendigo</quality>
+        </oneof>
+      </forbidden>
       <bonus />
       <source>HS</source>
       <page>164</page>
@@ -11636,6 +11699,14 @@
       <stagedpurchase>True</stagedpurchase>
       <category>Positive</category>
       <limit>no</limit>
+	  <forbidden>
+        <oneof>
+          <quality>Dracoform (Western Drake)</quality>
+		  <quality>Dracoform (Feathered Drake)</quality>
+		  <quality>Dracoform (Sea Drake)</quality>
+          <quality>Latent Dracomorphosis</quality>
+        </oneof>
+      </forbidden>
       <bonus>
         <addqualities>
           <addquality>Wanted</addquality>
@@ -11694,6 +11765,14 @@
       <stagedpurchase>True</stagedpurchase>
       <category>Positive</category>
       <limit>no</limit>
+	  <forbidden>
+        <oneof>
+          <quality>Dracoform (Eastern Drake)</quality>
+		  <quality>Dracoform (Feathered Drake)</quality>
+		  <quality>Dracoform (Sea Drake)</quality>
+          <quality>Latent Dracomorphosis</quality>
+        </oneof>
+      </forbidden>
       <bonus>
         <addqualities>
           <addquality>Wanted</addquality>
@@ -11748,6 +11827,14 @@
       <stagedpurchase>True</stagedpurchase>
       <category>Positive</category>
       <limit>no</limit>
+	  <forbidden>
+        <oneof>
+          <quality>Dracoform (Eastern Drake)</quality>
+          <quality>Dracoform (Western Drake)</quality>
+		  <quality>Dracoform (Sea Drake)</quality>
+          <quality>Latent Dracomorphosis</quality>
+        </oneof>
+      </forbidden>
       <bonus>
         <addqualities>
           <addquality>Wanted</addquality>
@@ -11810,6 +11897,14 @@
       <stagedpurchase>True</stagedpurchase>
       <category>Positive</category>
       <limit>no</limit>
+	  <forbidden>
+        <oneof>
+          <quality>Dracoform (Eastern Drake)</quality>
+          <quality>Dracoform (Western Drake)</quality>
+		  <quality>Dracoform (Feathered Drake)</quality>
+          <quality>Latent Dracomorphosis</quality>
+        </oneof>
+      </forbidden>
       <bonus>
         <addqualities>
           <addquality>Wanted</addquality>
@@ -15301,6 +15396,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>15</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -15334,6 +15430,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>15</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>
@@ -15364,6 +15461,7 @@
       <contributetolimit>False</contributetolimit>
       <karma>15</karma>
       <category>Positive</category>
+	  <onlyprioritygiven />
       <bonus>
         <enableattribute>
           <name>MAG</name>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -7514,6 +7514,14 @@ Do you want to continue?</text>
       <key>Checkbox_SelectGeneric_LimitList</key>
       <text>Show only {0} I can take</text>
     </string>
+	<string>
+      <key>Message_SelectGeneric_ChargenRestriction</key>
+      <text>You cannot select this {0} because your character has already been created.</text>
+    </string>
+	<string>
+      <key>MessageTitle_SelectGeneric_PriorityRestriction</key>
+      <text>You cannot select this {0} because your character's build method does not allow you to buy this {0}.</text>
+    </string>
     <!-- End Region-->
     <!-- Region Select Nexus Window -->
     <string>


### PR DESCRIPTION
Application Changes:

- Fixed Character Validity Checker not properly counting attribute points and special attribute points. Fixes #1917.
- Fixed Character Validity Checker not counting vehicle mod slot modifiers when checking vehicle mods are over capacity. Fixes #1875.
- Fixed attribute points, special attribute points, and displayed metatype limits not updating if/when metatype limits are changed. Fixes #1912.
- Added support for the following requirements (to qualities): the item can only be taken during character generation, the item cannot be bought separately in priority-based character generation methods.
- Added support for qualities that refund their cost when removed in career mode. The fact that such a quality can be bought for its normal price in chargen and then refunded for double its price in career mode is working as intended, as per rules for swapping Latent Dracomorphosis for a Drake quality.
- "Don't Show Metagenetic Qualities" is automatically checked when choosing qualities for characters without any SURGE quality.

Data Changes:

- SURGE I and SURGE II now properly cost 10 and 15 karma respectively (from 30)
- All Awakened qualities and the Technomancer quality cannot be bought separately during character generation when using Priority or Sum-to-Ten character generation methods. Fixes #1706.
- Latent Dracomorphosis is now mutually exclusive with all Infected, Drake, and Changeling qualities, and will now refund its karma cost when removed in career mode.

New Strings:

- Message_SelectGeneric_ChargenRestriction
- MessageTitle_SelectGeneric_PriorityRestriction