### PR TITLE
Actually check value of boolean isknowledge; fixes #1937

### DIFF
--- a/Chummer/Backend/Skills/Skill.cs
+++ b/Chummer/Backend/Skills/Skill.cs
@@ -175,7 +175,7 @@ namespace Chummer.Skills
             if (element != null) skill.Id = Guid.Parse(element.InnerText);
 
             bool blnIsKnowledgeSkill = false;
-            if (n.TryGetBoolFieldQuickly("isknowledge", ref blnIsKnowledgeSkill))
+            if (n.TryGetBoolFieldQuickly("isknowledge", ref blnIsKnowledgeSkill) && blnIsKnowledgeSkill)
             {
                 string strCategoryString = string.Empty;
                 if (n.TryGetStringFieldQuickly("skillcategory", ref strCategoryString) && !string.IsNullOrEmpty(strCategoryString))


### PR DESCRIPTION
TryGetBoolFieldQuickly returns true if it parsed successfully, regardless of whether the actual value is true or false. The actual parsed value is assigned to blnIsKnowledgeSkill.
Lazy evaluation of && means it won't evaluate the second argument until it discovers that the first value is true (ie. until TryGetBoolFieldQuickly returns), thus allowing time for blnIsKnowledgeSkill to be set to True.