### PR TITLE
Added weapon alternative range to sheet

### DIFF
--- a/Chummer/sheets/de-de/xz.language.xslt
+++ b/Chummer/sheets/de-de/xz.language.xslt
@@ -261,7 +261,7 @@
   <xsl:variable name="lang.PersonalData"    select="'Charakterdaten'"/>
   <xsl:variable name="lang.PersonalLife"    select="'Privatleben'"/>
   <xsl:variable name="lang.PhysicalTrack"  select="'Körperliche Schadensleiste'"/>
-  <xsl:variable name="lang.PhysicalNaturalRecovery"  select="'Natural Recovery Pool (1 day)'"/>
+  <xsl:variable name="lang.PhysicalNaturalRecovery"  select="'Natürliche Genesung Pool (1 Tag)'"/>
   <xsl:variable name="lang.PreferredPayment"    select="'Bevorzugte Zahlungsmethode'"/>
   <xsl:variable name="lang.PrimaryArm"    select="'Primärer Arm'"/>
   <xsl:variable name="lang.PublicAwareness"  select="'Prominenz'"/>
@@ -275,7 +275,7 @@
   <xsl:variable name="lang.StreetCred"    select="'Straßenruf'"/>
   <xsl:variable name="lang.StreetName"    select="'Straßenname'"/>
   <xsl:variable name="lang.StunTrack"    select="'Geistige Schadensleiste'"/>
-  <xsl:variable name="lang.StunNaturalRecovery"  select="'Natural Recovery Pool (1 hour)'"/>
+  <xsl:variable name="lang.StunNaturalRecovery"  select="'Natürliche Genesung Pool (1 Stunde)'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'Wandlungsgrad'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'Unbenannter Charakter'"/>
   <xsl:variable name="lang.VehicleBody"    select="'Rumpf'"/>

--- a/Chummer/sheets/xt.RangedWeapons.xslt
+++ b/Chummer/sheets/xt.RangedWeapons.xslt
@@ -64,31 +64,35 @@
         <xsl:value-of select="page"/>
       </td>
     </tr>
-    <xsl:if test="ranges/short != ''">
-      <tr style="text-align: center">
-        <xsl:if test="position() mod 2 != 1">
-          <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-        </xsl:if>
-        <td/>
-        <td style="text-align: center">
-          <xsl:value-of select="$lang.S"/>:
-          <xsl:value-of select="ranges/short"/>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="$lang.M"/>:
-          <xsl:value-of select="ranges/medium"/>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="$lang.L"/>:
-          <xsl:value-of select="ranges/long"/>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="$lang.E"/>:
-          <xsl:value-of select="ranges/extreme"/>
-        </td>
-        <td colspan="5"/>
-      </tr>
+
+    <xsl:variable name="weaponPosition" select="position()" />
+    <xsl:for-each select="ranges | alternateranges">
+      <xsl:if test="short != ''">
+        <tr style="text-align: center">
+          <xsl:if test="$weaponPosition mod 2 != 1">
+            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+          </xsl:if>
+          <td/>
+          <td style="text-align: center">
+            <xsl:value-of select="$lang.S"/>:
+            <xsl:value-of select="short"/>
+          </td>
+          <td style="text-align: center">
+            <xsl:value-of select="$lang.M"/>:
+            <xsl:value-of select="medium"/>
+          </td>
+          <td style="text-align: center">
+            <xsl:value-of select="$lang.L"/>:
+            <xsl:value-of select="long"/>
+          </td>
+          <td style="text-align: center">
+            <xsl:value-of select="$lang.E"/>:
+            <xsl:value-of select="extreme"/>
+          </td>
+          <td colspan="5"/>
+        </tr>
       </xsl:if>
+    </xsl:for-each>
 
     <xsl:if test="accessories/accessory or mods/weaponmod">
       <tr>


### PR DESCRIPTION
- German translations for new sheet texts (natural recovery).

- Added alternate weapon ranges for ranged weapons.
Might not be the best implementation in terms of "clean xslt and best practive" but works. Implemented using a simple for-each loop over ranges and alternateranges.
Partly solves issue #2070 by adding the alternate range table. Still missing a name/description of the range table that needs to be added to the print xml first.