### PR TITLE
Redone the GetTextFromPDF method

### DIFF
--- a/Chummer/Backend/Extensions/StringExtensions.cs
+++ b/Chummer/Backend/Extensions/StringExtensions.cs
@@ -85,7 +85,7 @@ namespace Chummer
                     }
                 }
                 achrNewChars[intCurrent++] = chrLoop;
-                SkipChar:;
+            SkipChar:;
             }
             // ... then we create a new string from the new CharArray, but only up to the number of characters that actually ended up getting copied
             return new string(achrNewChars, 0, intCurrent);
@@ -181,6 +181,8 @@ namespace Chummer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string TrimStart(this string strInput, params string[] astrStringToTrim)
         {
+            // without that we could trim a smaller string just because it was found first, this makes sure we found the largest one
+            int intHowMuchToTrim = 0;
             if (!string.IsNullOrEmpty(strInput))
             {
                 int intLength = astrStringToTrim.Length;
@@ -188,14 +190,13 @@ namespace Chummer
                 {
                     string strStringToTrim = astrStringToTrim[i];
                     // Need to make sure string actually starts with the substring, otherwise we don't want to be cutting out the beginning of the string
-                    if (strInput.StartsWith(strStringToTrim))
+                    if (strStringToTrim.Length > intHowMuchToTrim && strInput.StartsWith(strStringToTrim))
                     {
-                        int intTrimLength = strStringToTrim.Length;
-                        return strInput.Substring(intTrimLength, strInput.Length - intTrimLength);
+                        intHowMuchToTrim = strStringToTrim.Length;
                     }
                 }
             }
-            return strInput;
+            return strInput.Substring(intHowMuchToTrim);
         }
 
         /// <summary>
@@ -207,6 +208,8 @@ namespace Chummer
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static string TrimEnd(this string strInput, params string[] astrStringToTrim)
         {
+            // without that we could trim a smaller string just because it was found first, this makes sure we found the largest one
+            int intHowMuchToTrim = 0;
             if (!string.IsNullOrEmpty(strInput))
             {
                 int intLength = astrStringToTrim.Length;
@@ -214,13 +217,13 @@ namespace Chummer
                 {
                     string strStringToTrim = astrStringToTrim[i];
                     // Need to make sure string actually ends with the substring, otherwise we don't want to be cutting out the end of the string
-                    if (strInput.EndsWith(strStringToTrim))
+                    if (strStringToTrim.Length > intHowMuchToTrim && strInput.EndsWith(strStringToTrim))
                     {
-                        return strInput.Substring(0, strInput.Length - strStringToTrim.Length);
+                        intHowMuchToTrim = strStringToTrim.Length;
                     }
                 }
             }
-            return strInput;
+            return strInput.Substring(0, strInput.Length - intHowMuchToTrim);
         }
 
         /// <summary>


### PR DESCRIPTION
Redone the method from scratch, fixing a few kinks and improving how it recognizes text blocks. It works properly with most blocks, being it in paragraph form ("Some Stuff: Description.") or uppercase title form ("SOME TITLE IN UCASE\n"). It is also language independent now, and don't need hardcoded strings like COST or BONUS to recognize extra stuff.

It also has some failsafes to prevent it from overparsing if something goes wrong.

Performance seems to be slightly to much better than the original method. The bottleneck is still the caching of the PDF (PDFReader ctor). This needs some investigation if it can be improved.