### PR TITLE
Minor enhancements to character sheets

### DIFF
--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -3083,11 +3083,17 @@
     <Content Include="sheets\xt.Calendar.xslt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="sheets\xt.ComplexForms.xslt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="sheets\xt.ConditionMonitor.xslt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <SubType>Designer</SubType>
     </Content>
     <Content Include="sheets\xt.Contacts.xslt">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="sheets\xt.CritterPowers.xslt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="sheets\xt.Expenses.xslt">

--- a/Chummer/data/sheets.xml
+++ b/Chummer/data/sheets.xml
@@ -234,14 +234,14 @@
       <filename>Contacts</filename>
     </sheet>
     <sheet>
-      <id>9e85039b-c634-41b1-8be3-be4482374c26</id>
-      <name>Dossier</name>
-      <filename>Dossier</filename>
-    </sheet>
-    <sheet>
       <id>d9991497-3d74-4f88-bc69-48188b778947</id>
       <name>Dépenses</name>
       <filename>Expenses</filename>
+    </sheet>
+    <sheet>
+      <id>9e85039b-c634-41b1-8be3-be4482374c26</id>
+      <name>Dossier</name>
+      <filename>Dossier</filename>
     </sheet>
     <sheet>
       <id>ddbb9a60-6625-4091-8b42-59079538bb71</id>
@@ -408,6 +408,11 @@
   </sheets>
   <sheets lang="pt-br">
     <sheet>
+      <id>1ce3583c-d6b4-4ad4-b64c-67361ec53997</id>
+      <name>Blocos Chiques</name>
+      <filename>Fancy Blocks</filename>
+    </sheet>
+    <sheet>
       <id>8b16e238-18c6-40e0-85ca-a3a6c1854bd9</id>
       <name>Calendário</name>
       <filename>Calendar</filename>
@@ -423,29 +428,14 @@
       <filename>Contacts</filename>
     </sheet>
     <sheet>
-      <id>4feb3343-b759-47a6-a4e4-2fe308d30afa</id>
-      <name>Dossiê</name>
-      <filename>Dossier</filename>
-    </sheet>
-    <sheet>
       <id>ee596d7a-300b-4cd6-8fb0-2d180b8a1cd0</id>
       <name>Despesas</name>
       <filename>Expenses</filename>
     </sheet>
     <sheet>
-      <id>1ce3583c-d6b4-4ad4-b64c-67361ec53997</id>
-      <name>Blocos Chiques</name>
-      <filename>Fancy Blocks</filename>
-    </sheet>
-    <sheet>
-      <id>32949e5b-49ec-4231-8954-30366c5364a1</id>
-      <name>Somente Texto Formatado</name>
-      <filename>Formatted Text-Only</filename>
-    </sheet>
-    <sheet>
-      <id>0a04bce3-5d9f-4aee-a54d-4514eaf86ee0</id>
-      <name>Sumário do Mestre</name>
-      <filename>Game Master Summary</filename>
+      <id>4feb3343-b759-47a6-a4e4-2fe308d30afa</id>
+      <name>Dossiê</name>
+      <filename>Dossier</filename>
     </sheet>
     <sheet>
       <id>682a0fff-e064-4208-91fd-e386acf8fdda</id>
@@ -496,6 +486,16 @@
       <id>5e4fa26c-22bc-46a8-b342-68d5ec975d35</id>
       <name>Somente Texto</name>
       <filename>Text-Only</filename>
+    </sheet>
+    <sheet>
+      <id>32949e5b-49ec-4231-8954-30366c5364a1</id>
+      <name>Somente Texto Formatado</name>
+      <filename>Formatted Text-Only</filename>
+    </sheet>
+    <sheet>
+      <id>0a04bce3-5d9f-4aee-a54d-4514eaf86ee0</id>
+      <name>Sumário do Mestre</name>
+      <filename>Game Master Summary</filename>
     </sheet>
     <sheet>
       <id>995ad8c4-2c0b-4aaa-876e-5d3ae962ee84</id>

--- a/Chummer/sheets/Expenses set.xslt
+++ b/Chummer/sheets/Expenses set.xslt
@@ -78,7 +78,7 @@
               </th>
             </tr>
             <xsl:call-template name="Expenses">
-              <xsl:with-param name="type" select="$lang.Karma"/>
+              <xsl:with-param name="type" select="'Karma'"/>
               <xsl:with-param name="sfx" select="'&#160;&#160;'"/>
             </xsl:call-template>
             <tr>
@@ -116,7 +116,7 @@
               </th>
             </tr>
             <xsl:call-template name="Expenses">
-              <xsl:with-param name="type" select="$lang.Nuyen"/>
+              <xsl:with-param name="type" select="'Nuyen'"/>
             </xsl:call-template>
             <tr>
               <td><xsl:value-of select="$lang.RemainingAvailable"/></td>

--- a/Chummer/sheets/Fancy Blocks set.xslt
+++ b/Chummer/sheets/Fancy Blocks set.xslt
@@ -564,22 +564,22 @@
             <tr><td colspan="2"><xsl:value-of select="$lang.MatrixCold" /></td><td colspan="2"><strong><xsl:value-of select="matrixcoldinit" /></strong></td></tr>
             <tr><td colspan="2"><xsl:value-of select="$lang.MatrixHot" /></td><td colspan="2"><strong><xsl:value-of select="matrixhotinit" /></strong></td></tr>
             <tr><td colspan="4"><hr /></td></tr>
-            <tr><td colspan="2"><xsl:value-of select="$lang.PhysicalTrack" /></td><td colspan="2"><strong><xsl:value-of select="physicalcm" /></strong></td></tr>
-            <tr><td colspan="2">Overflow</td><td colspan="2"><strong><xsl:value-of select="cmoverflow - 1"/></strong></td></tr>
-            <tr><td colspan="2"><xsl:value-of select="$lang.StunTrack" /></td><td colspan="2"><strong><xsl:value-of select="stuncm" /></strong></td></tr>
-            <tr><td colspan="2"><xsl:value-of select="$lang.PhysicalNaturalRecovery" /></td><td colspan="2"><strong><xsl:value-of select="physicalcmnaturalrecovery" /></strong></td></tr>
-            <tr><td colspan="2"><xsl:value-of select="$lang.StunNaturalRecovery" /></td><td colspan="2"><strong><xsl:value-of select="stuncmnaturalrecovery"/></strong></td></tr>
+            <tr><td colspan="3"><xsl:value-of select="$lang.PhysicalTrack" /></td><td><strong><xsl:value-of select="physicalcm" /></strong></td></tr>
+            <tr><td colspan="3">Overflow</td><td><strong><xsl:value-of select="cmoverflow - 1"/></strong></td></tr>
+            <tr><td colspan="3"><xsl:value-of select="$lang.StunTrack" /></td><td><strong><xsl:value-of select="stuncm" /></strong></td></tr>
+            <tr><td colspan="3"><xsl:value-of select="$lang.PhysicalNaturalRecovery" /></td><td><strong><xsl:value-of select="physicalcmnaturalrecovery" /></strong></td></tr>
+            <tr><td colspan="3"><xsl:value-of select="$lang.StunNaturalRecovery" /></td><td><strong><xsl:value-of select="stuncmnaturalrecovery"/></strong></td></tr>
     </table>
   </xsl:template>
 
   <xsl:template name="print_mugshot_and_priorities">
     <table class="stats general">
-      <tr><td colspan="2"><div class="bigheader">[<xsl:value-of select="$lang.Mugshot" />]</div></td></tr>
-      <tr><td colspan="2" style="text-align:center; width: 100%;">
-        <xsl:if test="mainmugshotbase64 != ''">
+      <xsl:if test="mainmugshotbase64 != ''">
+        <tr><td colspan="2"><div class="bigheader">[<xsl:value-of select="$lang.Mugshot" />]</div></td></tr>
+        <tr><td colspan="2" style="text-align:center; width: 100%;">
           <img src="data:image/png;base64,{mainmugshotbase64}" class="mugshot" />
-        </xsl:if>
-      </td></tr>
+        </td></tr>
+      </xsl:if>
       <xsl:if test="prioritymetatype != ''">
         <tr><td colspan="2"><div class="bigheader">[<xsl:value-of select="$lang.Priorities" />]</div></td></tr>
                         <tr><td><xsl:value-of select="$lang.Metatype" /></td><td><strong><xsl:value-of select="prioritymetatype" /></strong></td></tr>
@@ -939,7 +939,7 @@
                 <xsl:value-of select="name" />
                 <xsl:if test="extra!=''"> (<xsl:value-of select="extra" />)</xsl:if>
                 <xsl:if test="qty &gt; 1">
-                  <xsl:text> x</xsl:text><xsl:value-of select="qty" />
+                  <xsl:text> ×</xsl:text><xsl:value-of select="qty" />
                 </xsl:if>
                 <xsl:call-template name="print_source_page" />
                 <xsl:call-template name="print_notes" />
@@ -1434,7 +1434,7 @@
     <tr>
       <td>
         <xsl:value-of select="name" />
-        <xsl:if test="qty &gt; 1"> x<xsl:value-of select="qty" /></xsl:if>
+        <xsl:if test="qty &gt; 1"> ×<xsl:value-of select="qty" /></xsl:if>
         <xsl:call-template name="print_source_page" />
       </td>
       <td><xsl:value-of select="devicerating" /></td>
@@ -1589,12 +1589,16 @@
             <td>
               <xsl:value-of select="name" />
               <xsl:if test="extra!=''"> (<xsl:value-of select="extra" />)</xsl:if>
-              <xsl:call-template name="print_source_page" />
-              <xsl:call-template name="print_notes" />
             </td>
             <td><xsl:value-of select="target" /></td>
             <td><xsl:value-of select="duration" /></td>
             <td><xsl:value-of select="fv" /></td>
+          </tr>
+          <tr>
+            <td colspan="4">
+              <xsl:call-template name="print_source_page" />
+              <xsl:call-template name="print_notes" />
+            </td>
           </tr>
         </xsl:for-each>
       </table>
@@ -1769,6 +1773,7 @@
               <xsl:value-of select="name" />
               <xsl:if test="crittername!=''"> (<xsl:value-of select="crittername" />)</xsl:if>
               <xsl:choose>
+                <xsl:when test="fettered = 'True'"> (<xsl:value-of select="$lang.Fettered"/>)</xsl:when>
                 <xsl:when test="bound"> (<xsl:value-of select="$lang.Bound"/>)</xsl:when>
                 <xsl:otherwise> (<xsl:value-of select="$lang.Unbound"/>)</xsl:otherwise>
               </xsl:choose>
@@ -2010,7 +2015,7 @@
                 [<xsl:value-of select="$lang.Permanent"/>]
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="$lang.Cost"/>: <xsl:value-of select="cost" /><xsl:value-of select="$lang.NuyenSymbol"/> (<xsl:value-of select="totalmonthlycost" /><xsl:value-of select="$lang.NuyenSymbol"/>) x<xsl:value-of select="months" /> = <xsl:value-of select="totalcost" /><xsl:value-of select="$lang.NuyenSymbol"/>;
+                <xsl:value-of select="$lang.Cost"/>: <xsl:value-of select="cost" /><xsl:value-of select="$lang.NuyenSymbol"/> (<xsl:value-of select="totalmonthlycost" /><xsl:value-of select="$lang.NuyenSymbol"/>) × <xsl:value-of select="months" /> = <xsl:value-of select="totalcost" /><xsl:value-of select="$lang.NuyenSymbol"/>;
               </xsl:otherwise>
             </xsl:choose>
             <br />
@@ -2190,7 +2195,7 @@
         <xsl:text> [R</xsl:text><xsl:value-of select="rating" />]
       </xsl:if>
       <xsl:if test="qty and qty &gt; 1">
-        <xsl:text> x</xsl:text><xsl:value-of select="qty" />
+        <xsl:text> ×</xsl:text><xsl:value-of select="qty" />
       </xsl:if>
       <xsl:call-template name="print_source_page" />
       <xsl:if test="extra!='' and $is_long_extra">

--- a/Chummer/sheets/Notes set.xslt
+++ b/Chummer/sheets/Notes set.xslt
@@ -5,6 +5,8 @@
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
+  <xsl:include href="xt.ComplexForms.xslt"/>
+  <xsl:include href="xt.CritterPowers.xslt"/>
   <xsl:include href="xt.Lifestyles.xslt"/>
   <xsl:include href="xt.Notes.xslt"/>
   <xsl:include href="xt.Nothing2Show.xslt"/>
@@ -40,6 +42,9 @@
           html {
           height: 100%;
           margin: 0px;  /* this affects the margin on the html before sending to printer */
+          }
+          th {
+          text-align: center;
           }
           .upper {
           text-transform: uppercase;
@@ -102,6 +107,22 @@
           </xsl:call-template>
         </xsl:if>
 
+        <xsl:if test="complexforms/complexform/notes != ''">
+          <div id="ComplexFormsBlock">
+            <table><tr><td/></tr></table>
+            <xsl:call-template name="TableTitle">
+              <xsl:with-param name="name" select="$lang.ComplexForms"/>
+            </xsl:call-template>
+            <table class="tablestyle">
+              <xsl:call-template name="ComplexForms"/>
+            </table>
+          </div>
+          <xsl:call-template name="RowSummary">
+            <xsl:with-param name="text" select="$lang.ComplexForms"/>
+            <xsl:with-param name="blockname" select="'ComplexFormsBlock'"/>
+          </xsl:call-template>
+        </xsl:if>
+
         <xsl:if test="lifestyles/lifestyle/notes != ''">
           <div id="LifestyleBlock">
             <table><tr><td/></tr></table>
@@ -122,11 +143,29 @@
           <xsl:call-template name="notes"/>
         </xsl:if>
 
+        <xsl:if test="critterpowers/critterpower">
+          <div id="CritterBlock">
+            <table><tr><td/></tr></table>
+            <xsl:call-template name="TableTitle">
+              <xsl:with-param name="name" select="$lang.Critters"/>
+            </xsl:call-template>
+            <table class="tablestyle">
+              <xsl:call-template name="CritterPowers"/>
+            </table>
+          </div>
+          <xsl:call-template name="RowSummary">
+            <xsl:with-param name="text" select="$lang.Critters"/>
+            <xsl:with-param name="blockname" select="'CritterBlock'"/>
+          </xsl:call-template>
+        </xsl:if>
+
         <xsl:choose>
           <xsl:when test="qualities/quality/notes != ''"/>
           <xsl:when test="spells/spell/notes != ''"/>
+          <xsl:when test="complexforms/complexform/notes != ''"/>
           <xsl:when test="lifestyles/lifestyle/notes != ''"/>
           <xsl:when test="concat(concept,description,background,notes,gamenotes) !=''"/>
+          <xsl:when test="critterpowers/critterpower != ''"/>
           <xsl:otherwise>
             <xsl:call-template name="nothing2show">
               <xsl:with-param name="namethesheet" select="$lang.Nothing2Show4Notes"/>

--- a/Chummer/sheets/Shadowrun 5 set.xslt
+++ b/Chummer/sheets/Shadowrun 5 set.xslt
@@ -8,8 +8,10 @@
   <xsl:include href="xs.TitleName.xslt"/>
 
   <xsl:include href="xt.Calendar.xslt"/>
+  <xsl:include href="xt.ComplexForms.xslt"/>
   <xsl:include href="xt.ConditionMonitor.xslt"/>
   <xsl:include href="xt.Contacts.xslt"/>
+  <xsl:include href="xt.CritterPowers.xslt"/>
   <xsl:include href="xt.Expenses.xslt"/>
   <xsl:include href="xt.Lifestyles.xslt"/>
   <xsl:include href="xt.MovementRate.xslt"/>
@@ -98,6 +100,7 @@
                   </xsl:choose>
                 </td>
               </tr>
+              <xsl:if test="playername != ''">
               <tr>
                 <td width="16.66%" class="title">
                   <xsl:value-of select="$lang.Player"/>:
@@ -106,6 +109,7 @@
                   <xsl:value-of select="playername"/>
                 </td>
               </tr>
+              </xsl:if>
               <tr>
                 <td width="16.66%" class="upper">
                   <xsl:value-of select="$lang.Metatype"/>:
@@ -507,10 +511,10 @@
                       <th width="70%" style="text-align: left">
                         <xsl:value-of select="$lang.Skill"/>
                       </th>
-                      <th width="10%">
+                      <th width="15%">
                         <xsl:value-of select="$lang.Rtg"/>
                       </th>
-                      <th width="20%">
+                      <th width="15%">
                         <xsl:value-of select="$lang.Pool"/>
                       </th>
                     </tr>
@@ -528,10 +532,10 @@
                       <th width="70%" style="text-align: left">
                         <xsl:value-of select="$lang.Skill"/>
                       </th>
-                      <th width="10%">
+                      <th width="15%">
                         <xsl:value-of select="$lang.Rtg"/>
                       </th>
-                      <th width="20%">
+                      <th width="15%">
                         <xsl:value-of select="$lang.Pool"/>
                       </th>
                     </tr>
@@ -549,10 +553,10 @@
                       <th width="70%" style="text-align: left">
                         <xsl:value-of select="$lang.Skill"/>
                       </th>
-                      <th width="10%">
+                      <th width="15%">
                         <xsl:value-of select="$lang.Rtg"/>
                       </th>
-                      <th width="20%">
+                      <th width="15%">
                         <xsl:value-of select="$lang.Pool"/>
                       </th>
                     </tr>
@@ -771,43 +775,38 @@
                 <th width="10%"/>
                 <th width="10%"/>
               </tr>
-              <xsl:call-template name="armor"/>
-              <xsl:variable name="sumarmor">
-                <xsl:value-of select="sum(armors/armor[equipped='True']/armor)"/>
-              </xsl:variable>
-              <xsl:variable name="otherarmor" select="armor - $sumarmor"/>
-              <xsl:if test="$otherarmor != 0">
+              <xsl:variable name="inarmor" select="armors/armor[equipped = 'True']"/>
+              <xsl:if test="$inarmor">
+                <xsl:for-each select="armors/armor[equipped = 'True']">
+                  <xsl:sort select="name"/>
+                  <xsl:call-template name="armor"/>
+                </xsl:for-each>
                 <tr>
-                  <td>
-                    <xsl:value-of select="$lang.Other"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="$lang.Modifiers"/>
+                  <td style="font-weight: bold">
+                    <xsl:value-of select="$lang.TotalArmor"/>
                   </td>
-                  <td style="text-align: center">
-                    <xsl:call-template name="fnx-pad-l">
-                      <xsl:with-param name="string" select="$otherarmor"/>
-                      <xsl:with-param name="length" select="2"/>
-                    </xsl:call-template>
+                  <td style="font-weight: bold; text-align: center;">
+                    <xsl:value-of select="armor"/>
                   </td>
                   <td/>
                   <td/>
                   <td/>
                 </tr>
               </xsl:if>
-              <tr>
-                <td style="font-weight: bold">
-                  <xsl:value-of select="$lang.Total"/>
-                </td>
-                <td style="font-weight: bold; text-align: center; text-decoration: overline;">
-                  <xsl:call-template name="fnx-pad-l">
-                    <xsl:with-param name="string" select="armor"/>
-                    <xsl:with-param name="length" select="2"/>
+              <xsl:if test="armors/armor[equipped != 'True']">
+                <xsl:if test="$inarmor">
+                  <xsl:call-template name="Xline">
+                    <xsl:with-param name="height" select="'N'"/>
                   </xsl:call-template>
-                </td>
-                <td/>
-                <td/>
-                <td/>
-              </tr>
+                  <tr><td colspan="100%" style="font-weight: bold">
+                      <xsl:value-of select="$lang.OtherArmor"/>
+                  </td></tr>
+                </xsl:if>
+                <xsl:for-each select="armors/armor[equipped != 'True']">
+                  <xsl:sort select="name"/>
+                  <xsl:call-template name="armor"/>
+                </xsl:for-each>
+              </xsl:if>
             </table>
           </div>
           <xsl:call-template name="RowSummary">
@@ -1075,21 +1074,36 @@
               </tr>
               <xsl:if test="arts != ''">
                 <tr>
-                  <th width="100%"><xsl:value-of select="$lang.Arts"/></th>
+                  <td width="80%">
+                    <strong><xsl:value-of select="$lang.Arts"/></strong>
+                  </td>
+                  <td/>
+                  <td/>
                 </tr>
-                <tr><td>
-                  <xsl:for-each select="arts/art">
-                    <xsl:sort select="name"/>
-                    <xsl:value-of select="name"/>
-                    <xsl:value-of select="source"/>
-                    <xsl:text> </xsl:text>
-                    <xsl:value-of select="page"/>
-                    <xsl:if test="notes !=''">
-                      <br><xsl:value-of select="notes"/></br>
-                    </xsl:if>
-                    <xsl:if test="last() &gt; 1">; </xsl:if>
-                  </xsl:for-each>
-                </td></tr>
+                <xsl:for-each select="arts/art">
+                  <xsl:sort select="name"/>
+                  <xsl:if test="position() != 1">
+                    <xsl:call-template name="Xline"/>
+                  </xsl:if>
+                  <tr>
+                    <td style="text-align: left">
+                      <xsl:value-of select="name"/>
+                    </td>
+                    <td/>
+                    <td style="text-align: center">
+                      <xsl:value-of select="source"/>
+                      <xsl:text> </xsl:text>
+                      <xsl:value-of select="page"/>
+                    </td>
+                  </tr>
+                  <xsl:if test="notes != '' and $ProduceNotes">
+                    <tr><td colspan="100%" class="notesrow2">
+                      <xsl:call-template name="PreserveLineBreaks">
+                        <xsl:with-param name="text" select="notes"/>
+                      </xsl:call-template>
+                    </td></tr>
+                  </xsl:if>
+                </xsl:for-each>
               </xsl:if>
               <xsl:if test="metamagics/metamagic">
                 <tr>
@@ -1160,11 +1174,18 @@
               <xsl:for-each select="spirits/spirit">
                 <xsl:sort select="name"/>
                 <tr>
-                  <td><xsl:value-of select="name"/></td>
+                  <td>
+                    <xsl:value-of select="name"/>
+                    <xsl:if test="crittername != ''">: <xsl:value-of select="crittername"/></xsl:if>
+                  </td>
                   <td style="text-align: center"><xsl:value-of select="force"/></td>
                   <td style="text-align: center"><xsl:value-of select="services"/></td>
                   <td style="text-align: center">
                     <xsl:choose>
+                      <xsl:when test="fettered = 'True'">
+                        <xsl:value-of select="$lang.Bound"/>
+                        (<xsl:value-of select="$lang.Fettered"/>)
+                      </xsl:when>
                       <xsl:when test="bound = 'True'">
                         <xsl:value-of select="$lang.Bound"/>
                       </xsl:when>
@@ -1198,11 +1219,11 @@
 <!-- ** ** ** end of magic user details ** ** ** -->
 
 <!--
-      *                      *
-      ***                      ***
+      *                                     *
+      ***                                 ***
       *****     Technomancer details    *****
-      ***                      ***
-      *                      *
+      ***                                 ***
+      *                                     *
 -->
       <xsl:if test="resenabled = 'True'">
         <div class="block" id="StreamBlock">
@@ -1211,15 +1232,17 @@
               <th width="25%" style="text-align: left">
                 <xsl:value-of select="$lang.Stream"/>
               </th>
-              <th width="10%">
+              <th width="20%">
                 <xsl:value-of select="$lang.Drain"/>
               </th>
-              <th width="55%"/>
+              <th width="45%"/>
               <th width="10%"/>
             </tr>
             <tr>
               <td><xsl:value-of select="stream"/></td>
-              <td><xsl:value-of select="drain"/></td>
+              <td style="text-align:center;">
+			    <xsl:value-of select="drain"/>
+			  </td>
               <td/>
               <td style="text-align:center;">
                 <xsl:value-of select="tradition/source" />
@@ -1287,17 +1310,7 @@
         <xsl:if test="complexforms/complexform">
           <div class="block" id="ComplexFormsBlock">
             <table class="tablestyle">
-              <tr>
-                <th width="40%" style="text-align: left">
-                  <xsl:value-of select="$lang.ComplexForm"/>
-                </th>
-                <th width="15%"><xsl:value-of select="$lang.Target"/></th>
-                <th width="15%"><xsl:value-of select="$lang.Duration"/></th>
-                <th width="15%"><xsl:value-of select="$lang.FV"/></th>
-                <th width="5%"/>
-                <th width="10%"/>
-              </tr>
-              <xsl:call-template name="complexforms"/>
+              <xsl:call-template name="ComplexForms"/>
             </table>
           </div>
           <xsl:call-template name="RowSummary">
@@ -1322,7 +1335,10 @@
               <xsl:for-each select="spirits/spirit">
                 <xsl:sort select="name"/>
                 <tr>
-                  <td><xsl:value-of select="name"/></td>
+                  <td>
+                    <xsl:value-of select="name"/>
+                    <xsl:if test="crittername != ''">: <xsl:value-of select="crittername"/></xsl:if>
+                  </td>
                   <td style="text-align: center"><xsl:value-of select="force"/></td>
                   <td style="text-align: center"><xsl:value-of select="services"/></td>
                   <td style="text-align: center">
@@ -1404,14 +1420,7 @@
         <xsl:if test="critterpowers/critterpower">
           <div class="block" id="CritterBlock">
             <table class="tablestyle">
-              <tr>
-                <th width="50%" style="text-align: left">
-                  <xsl:value-of select="$lang.Critter"/>
-                </th>
-                <th width="30%"><xsl:value-of select="$lang.Rating"/></th>
-                <th width="20%"/>
-              </tr>
-              <xsl:call-template name="critterpowers"/>
+              <xsl:call-template name="CritterPowers"/>
             </table>
           </div>
           <xsl:call-template name="RowSummary">
@@ -1421,11 +1430,11 @@
         </xsl:if>
 
 <!--
-        *                      *
-        ***                      ***
+        *                                  *
+        ***                              ***
         *****      notes and such      *****
-        ***                      ***
-        *                      *
+        ***                              ***
+        *                                  *
 -->
       <xsl:if test="$ProduceNotes">
         <xsl:if test="concat(concept,description,background,notes,gamenotes) != ''">
@@ -1583,8 +1592,6 @@
   </xsl:template>
 
   <xsl:template name="armor">
-    <xsl:for-each select="armors/armor">
-      <xsl:sort select="name"/>
       <tr>
         <xsl:if test="position() mod 2 != 1">
           <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
@@ -1698,7 +1705,6 @@
       <xsl:call-template name="Xline">
         <xsl:with-param name="cntl" select="last()-position()"/>
       </xsl:call-template>
-    </xsl:for-each>
   </xsl:template>
 
   <xsl:template name="meleeweapons">
@@ -2344,101 +2350,6 @@
           </td>
         </tr>
       </xsl:if>
-      <xsl:if test="notes != '' and $ProduceNotes">
-        <tr>
-          <xsl:if test="position() mod 2 != 1">
-            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-          </xsl:if>
-          <td colspan="100%" class="notesrow2">
-            <xsl:call-template name="PreserveLineBreaks">
-              <xsl:with-param name="text" select="notes"/>
-            </xsl:call-template>
-          </td>
-        </tr>
-      </xsl:if>
-      <xsl:call-template name="Xline">
-        <xsl:with-param name="cntl" select="last()-position()"/>
-        <xsl:with-param name="nte" select="notes != '' and $ProduceNotes"/>
-      </xsl:call-template>
-    </xsl:for-each>
-  </xsl:template>
-
-  <xsl:template name="critterpowers">
-    <xsl:for-each select="critterpowers/critterpower">
-      <xsl:sort select="name"/>
-      <tr>
-        <xsl:if test="position() mod 2 != 1">
-          <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-        </xsl:if>
-        <td>
-          <xsl:value-of select="name"/>
-          <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="rating"/>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="source"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="page"/>
-        </td>
-      </tr>
-      <xsl:if test="notes != '' and $ProduceNotes">
-        <tr>
-          <xsl:if test="position() mod 2 != 1">
-            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-          </xsl:if>
-          <td colspan="100%" class="notesrow2">
-            <xsl:call-template name="PreserveLineBreaks">
-              <xsl:with-param name="text" select="notes"/>
-            </xsl:call-template>
-          </td>
-        </tr>
-      </xsl:if>
-      <xsl:call-template name="Xline">
-        <xsl:with-param name="cntl" select="last()-position()"/>
-        <xsl:with-param name="nte" select="notes != '' and $ProduceNotes"/>
-      </xsl:call-template>
-    </xsl:for-each>
-  </xsl:template>
-
-  <xsl:template name="complexforms">
-    <xsl:for-each select="complexforms/complexform">
-      <xsl:sort select="name"/>
-      <tr>
-        <xsl:if test="position() mod 2 != 1">
-          <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-        </xsl:if>
-        <td>
-          <xsl:value-of select="name"/>
-          <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-          <xsl:if test="programoptions/programoption"> (<xsl:for-each select="programoptions/programoption">
-            <xsl:sort select="name"/>
-            <xsl:value-of select="name"/>
-            <xsl:if test="rating &gt; 0">
-              <xsl:text> </xsl:text>
-              <xsl:value-of select="rating"/>
-            </xsl:if>
-            <xsl:if test="last() &gt; 1">; </xsl:if>
-          </xsl:for-each>)
-          </xsl:if>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="target"/>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="duration"/>
-        </td>
-        <td style="text-align: center">
-          <xsl:value-of select="fv"/>
-        </td>
-        <td/>
-        <td style="text-align: center">
-          <xsl:value-of select="source"/>
-          <xsl:text> </xsl:text>
-          <xsl:value-of select="page"/>
-        </td>
-      </tr>
       <xsl:if test="notes != '' and $ProduceNotes">
         <tr>
           <xsl:if test="position() mod 2 != 1">
@@ -3158,7 +3069,7 @@
       <xsl:if test="extra != '' and $xtra = 'A'">
         (<xsl:value-of select="extra"/>)
       </xsl:if>
-      <xsl:if test="qty != 1"> x<xsl:value-of select="qty"/></xsl:if>
+      <xsl:if test="qty != 1"> ×<xsl:value-of select="qty"/></xsl:if>
       <xsl:choose>
         <xsl:when test="children/gear">
           <xsl:text> </xsl:text>
@@ -3213,8 +3124,7 @@
           <xsl:if test="extra != '' and $xtra = 'A'">
             (<xsl:value-of select="extra"/>)
           </xsl:if>
-          <xsl:if test="qty != 1">
-            x<xsl:value-of select="qty"/>
+          <xsl:if test="qty != 1"> ×<xsl:value-of select="qty"/>
           </xsl:if>
           <xsl:choose>
             <xsl:when test="children/gear">

--- a/Chummer/sheets/de-de/xz.language.xslt
+++ b/Chummer/sheets/de-de/xz.language.xslt
@@ -3,7 +3,7 @@
 <!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:variable name="lang"  select="'de'"/>
-  <xsl:variable name="locale"  select="'de'"/>
+  <xsl:variable name="locale"  select="'de-de'"/>
 
   <!-- individual words -->
   <xsl:variable name="lang.Acceleration"  select="'Beschleunigung'"/>
@@ -94,6 +94,7 @@
   <xsl:variable name="lang.Eyes"      select="'Augenfarbe'"/>
   <xsl:variable name="lang.Falling"    select="'Fall'"/>
   <xsl:variable name="lang.Fatigue"      select="'Erschöpfung'"/>
+  <xsl:variable name="lang.Fettered"      select="'Gefesselt'"/>
   <xsl:variable name="lang.Fire"    select="'Feuer'"/>
   <xsl:variable name="lang.Firewall"    select="'Firewall'"/>
   <xsl:variable name="lang.Fly"      select="'Fliegen'"/>
@@ -146,7 +147,6 @@
   <xsl:variable name="lang.Mode"      select="'Modus'"/>
   <xsl:variable name="lang.Model"      select="'Model'"/>
   <xsl:variable name="lang.Modifications"  select="'Modifikationen'"/>
-  <xsl:variable name="lang.Modifiers"    select="'Modifikatoren'"/>
   <xsl:variable name="lang.Month"      select="'Monat'"/>
   <xsl:variable name="lang.Months"    select="'Monate'"/>
   <xsl:variable name="lang.Movement"    select="'Bewegung'"/>
@@ -157,11 +157,11 @@
   <xsl:variable name="lang.Notes"      select="'Notizen'"/>
   <xsl:variable name="lang.Notoriety"    select="'Schlechter Ruf'"/>
   <xsl:variable name="lang.Nuyen"      select="'Nuyen'"/>
-  <xsl:variable name="lang.Other"      select="'Andere'"/>
   <xsl:variable name="lang.OVR"      select="'ÜbS&#160;'"/>
   <xsl:variable name="lang.Pathogen"    select="'Pathogen'"/>
   <xsl:variable name="lang.Permanent"    select="'Permanent'"/>
   <xsl:variable name="lang.Persona"    select="'Persona'"/>
+  <xsl:variable name="lang.Pets"      select="'Haustiere'"/>
   <xsl:variable name="lang.Physical"    select="'Körperlich'"/>
   <xsl:variable name="lang.Physiological"  select="'Körperlich'"/>
   <xsl:variable name="lang.Pilot"      select="'Pilot'"/>
@@ -239,7 +239,7 @@
   <xsl:variable name="lang.VR"      select="'VR'"/>
   <xsl:variable name="lang.W"        select="'W'"/>
   <xsl:variable name="lang.Walk"      select="'Gehen'"/>
-  <xsl:variable name="lang.Weaknesses"    select="'Weaknesses'"/>
+  <xsl:variable name="lang.Weaknesses"    select="'Schwächen'"/>
   <xsl:variable name="lang.Weapon"    select="'Waffe'"/>
   <xsl:variable name="lang.Weapons"    select="'Waffen'"/>
   <xsl:variable name="lang.Week"      select="'Woche'"/>
@@ -290,6 +290,7 @@
   <xsl:variable name="lang.Nothing2Show4Notes"    select="'Keine Notizen zur Liste'"/>
   <xsl:variable name="lang.Nothing2Show4Vehicles"    select="'Keine Fahrzeuge zur Liste'"/>
   <xsl:variable name="lang.OptionalPowers"    select="'Optional Powers'"/>
+  <xsl:variable name="lang.OtherArmor"      select="'Andere Panzerung'"/>
   <xsl:variable name="lang.OtherMugshots"    select="'Andere Portraits'"/>
   <xsl:variable name="lang.PageBreak"      select="'Seitenumbruch: '"/>
   <xsl:variable name="lang.ToxinsAndPathogens"  select="'Toxine und Pathogene'"/>
@@ -312,6 +313,7 @@
   <xsl:variable name="lang.StunNaturalRecovery"  select="'Natural Recovery Pool (1 hour)'"/>
   <xsl:variable name="lang.StunTrack"    select="'Geistige Schadensleiste'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'Wandlungsgrad'"/>
+  <xsl:variable name="lang.TotalArmor"  select="'Insgesamt ausgestattete höchste Rüstung und Zubehör'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'unbenannter Charakter'"/>
   <xsl:variable name="lang.VehicleBody"    select="'Rumpf'"/>
   <xsl:variable name="lang.VehicleCost"    select="'Fahrzeugkosten'"/>

--- a/Chummer/sheets/fr-fr/xz.language.xslt
+++ b/Chummer/sheets/fr-fr/xz.language.xslt
@@ -3,7 +3,7 @@
 <!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:variable name="lang"  select="'fr'"/>
-  <xsl:variable name="locale"  select="'fr'"/>
+  <xsl:variable name="locale"  select="'fr-fr'"/>
 
   <!-- individual words -->
   <xsl:variable name="lang.Acceleration"  select="'Accélération'"/>
@@ -94,6 +94,7 @@
   <xsl:variable name="lang.Eyes"      select="'Yeux'"/>
   <xsl:variable name="lang.Falling"    select="'Tomber'"/>
   <xsl:variable name="lang.Fatigue"      select="'Fatigue'"/>
+  <xsl:variable name="lang.Fettered"      select="'Enchaîné'"/>
   <xsl:variable name="lang.Fire"    select="'Feu'"/>
   <xsl:variable name="lang.Firewall"    select="'Firewall'"/>
   <xsl:variable name="lang.Fly"      select="'Mouche'"/>
@@ -146,7 +147,6 @@
   <xsl:variable name="lang.Mode"      select="'Mode'"/>
   <xsl:variable name="lang.Model"      select="'Modèle'"/>
   <xsl:variable name="lang.Modifications"  select="'Modificateurs'"/>
-  <xsl:variable name="lang.Modifiers"    select="'Modificateurs'"/>
   <xsl:variable name="lang.Month"      select="'Mois'"/>
   <xsl:variable name="lang.Months"    select="'Mois'"/>
   <xsl:variable name="lang.Movement"    select="'Mouvement'"/>
@@ -157,11 +157,11 @@
   <xsl:variable name="lang.Notes"      select="'Remarques'"/>
   <xsl:variable name="lang.Notoriety"    select="'Rumeur'"/>
   <xsl:variable name="lang.Nuyen"      select="'Nuyen'"/>
-  <xsl:variable name="lang.Other"      select="'Autre'"/>
   <xsl:variable name="lang.OVR"      select="'OVR&#160;'"/>
   <xsl:variable name="lang.Pathogen"    select="'Pathogènes'"/>
   <xsl:variable name="lang.Permanent"    select="'Permanent'"/>
   <xsl:variable name="lang.Persona"    select="'Persona'"/>
+  <xsl:variable name="lang.Pets"      select="'Animaux de compagnie'"/>
   <xsl:variable name="lang.Physical"    select="'Physique'"/>
   <xsl:variable name="lang.Physiological"  select="'Physiologique'"/>
   <xsl:variable name="lang.Pilot"      select="'Pilote'"/>
@@ -239,7 +239,7 @@
   <xsl:variable name="lang.VR"      select="'RV'"/>
   <xsl:variable name="lang.W"        select="'V'"/>
   <xsl:variable name="lang.Walk"      select="'Marche'"/>
-  <xsl:variable name="lang.Weaknesses"    select="'Weaknesses'"/>
+  <xsl:variable name="lang.Weaknesses"    select="'Faiblesses'"/>
   <xsl:variable name="lang.Weapon"    select="'Arme'"/>
   <xsl:variable name="lang.Weapons"    select="'Armes'"/>
   <xsl:variable name="lang.Week"      select="'Semaine'"/>
@@ -290,6 +290,7 @@
   <xsl:variable name="lang.Nothing2Show4Notes"    select="'Pas de notes à la liste'"/>
   <xsl:variable name="lang.Nothing2Show4Vehicles"    select="'Aucun véhicule à la liste'"/>
   <xsl:variable name="lang.OptionalPowers"    select="'Optional Powers'"/>
+  <xsl:variable name="lang.OtherArmor"      select="'Autre armure'"/>
   <xsl:variable name="lang.OtherMugshots"    select="'Autres portraits'"/>
   <xsl:variable name="lang.PageBreak"      select="'Saut de page: '"/>
   <xsl:variable name="lang.ToxinsAndPathogens"  select="'Toxines et Pathogènes'"/>
@@ -312,6 +313,7 @@
   <xsl:variable name="lang.StunNaturalRecovery"  select="'Natural Recovery Pool (1 hour)'"/>
   <xsl:variable name="lang.StunTrack"    select="'Moniteur de Condition Étourdissant'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'Degré de submersion'"/>
+  <xsl:variable name="lang.TotalArmor"  select="'Total des armures et des accessoires les mieux équipés'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'Personnage sans nom'"/>
   <xsl:variable name="lang.VehicleBody"    select="'Structure du véhicule'"/>
   <xsl:variable name="lang.VehicleCost"    select="'Coût du véhicule'"/>

--- a/Chummer/sheets/ja-jp/xz.language.xslt
+++ b/Chummer/sheets/ja-jp/xz.language.xslt
@@ -3,7 +3,7 @@
 <!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:variable name="lang"  select="'jp'"/>
-  <xsl:variable name="locale"  select="'jp'"/>
+  <xsl:variable name="locale"  select="'ja-jp'"/>
 
   <!-- individual words -->
   <xsl:variable name="lang.Acceleration"  select="'Acceleration'"/>
@@ -94,6 +94,7 @@
   <xsl:variable name="lang.Eyes"      select="'Eyes'"/>
   <xsl:variable name="lang.Falling"    select="'Falling'"/>
   <xsl:variable name="lang.Fatigue"      select="'Fatigue'"/>
+  <xsl:variable name="lang.Fettered"      select="'Fettered'"/>
   <xsl:variable name="lang.Fire"    select="'Fire'"/>
   <xsl:variable name="lang.Firewall"    select="'Firewall'"/>
   <xsl:variable name="lang.Fly"      select="'Fly'"/>
@@ -146,7 +147,6 @@
   <xsl:variable name="lang.Mode"      select="'Mode'"/>
   <xsl:variable name="lang.Model"      select="'Model'"/>
   <xsl:variable name="lang.Modifications"  select="'Modifications'"/>
-  <xsl:variable name="lang.Modifiers"    select="'Modifiers'"/>
   <xsl:variable name="lang.Month"      select="'月'"/>
   <xsl:variable name="lang.Months"    select="'月'"/>
   <xsl:variable name="lang.Movement"    select="'Movement'"/>
@@ -157,11 +157,11 @@
   <xsl:variable name="lang.Notes"      select="'Notes'"/>
   <xsl:variable name="lang.Notoriety"    select="'Notoriety'"/>
   <xsl:variable name="lang.Nuyen"      select="'Nuyen'"/>
-  <xsl:variable name="lang.Other"      select="'Other'"/>
   <xsl:variable name="lang.OVR"      select="'OVR&#160;'"/>
   <xsl:variable name="lang.Pathogen"    select="'Pathogen'"/>
   <xsl:variable name="lang.Permanent"    select="'Permanent'"/>
   <xsl:variable name="lang.Persona"    select="'Persona'"/>
+  <xsl:variable name="lang.Pets"      select="'Pets'"/>
   <xsl:variable name="lang.Physical"    select="'Physical'"/>
   <xsl:variable name="lang.Physiological"  select="'Physiological'"/>
   <xsl:variable name="lang.Pilot"      select="'Pilot'"/>
@@ -290,6 +290,7 @@
   <xsl:variable name="lang.Nothing2Show4Notes"    select="'No Notes to list'"/>
   <xsl:variable name="lang.Nothing2Show4Vehicles"    select="'No Vehicles to list'"/>
   <xsl:variable name="lang.OptionalPowers"    select="'Optional Powers'"/>
+  <xsl:variable name="lang.OtherArmor"      select="'Other Armor'"/>
   <xsl:variable name="lang.OtherMugshots"    select="'Other Portraits'"/>
   <xsl:variable name="lang.PageBreak"      select="'Page Break: '"/>
   <xsl:variable name="lang.ToxinsAndPathogens"  select="'Toxins and Pathogens'"/>
@@ -312,6 +313,7 @@
   <xsl:variable name="lang.StunNaturalRecovery"  select="'Natural Recovery Pool (1 hour)'"/>
   <xsl:variable name="lang.StunTrack"    select="'Stun Damage Track'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'Submersion Grade'"/>
+  <xsl:variable name="lang.TotalArmor"  select="'Total of equipped single highest armor and accessories'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'Unnamed Character'"/>
   <xsl:variable name="lang.VehicleBody"    select="'Body'"/>
   <xsl:variable name="lang.VehicleCost"    select="'Vehicle Cost'"/>

--- a/Chummer/sheets/pt-br/xz.language.xslt
+++ b/Chummer/sheets/pt-br/xz.language.xslt
@@ -94,6 +94,7 @@
   <xsl:variable name="lang.Eyes"      select="'Olhos'"/>
   <xsl:variable name="lang.Falling"    select="'Queda'"/>
   <xsl:variable name="lang.Fatigue"      select="'Fadiga'"/>
+  <xsl:variable name="lang.Fettered"      select="'Encadernado'"/>
   <xsl:variable name="lang.Fire"    select="'Fogo'"/>
   <xsl:variable name="lang.Firewall"    select="'Firewall'"/>
   <xsl:variable name="lang.Fly"      select="'Voo'"/>
@@ -146,7 +147,6 @@
   <xsl:variable name="lang.Mode"      select="'Modo'"/>
   <xsl:variable name="lang.Model"      select="'Modelo'"/>
   <xsl:variable name="lang.Modifications"  select="'Modificações'"/>
-  <xsl:variable name="lang.Modifiers"    select="'Modificadores'"/>
   <xsl:variable name="lang.Month"      select="'Mês'"/>
   <xsl:variable name="lang.Months"    select="'Meses'"/>
   <xsl:variable name="lang.Movement"    select="'Movimento'"/>
@@ -157,11 +157,11 @@
   <xsl:variable name="lang.Notes"      select="'Observações'"/>
   <xsl:variable name="lang.Notoriety"    select="'Notoriedade'"/>
   <xsl:variable name="lang.Nuyen"      select="'Neoiene'"/>
-  <xsl:variable name="lang.Other"      select="'Outros'"/>
   <xsl:variable name="lang.OVR"      select="'EXC'"/>
   <xsl:variable name="lang.Pathogen"    select="'Patógeno'"/>
   <xsl:variable name="lang.Permanent"    select="'Permanente'"/>
   <xsl:variable name="lang.Persona"    select="'Persona'"/>
+  <xsl:variable name="lang.Pets"      select="'Animais de estimação'"/>
   <xsl:variable name="lang.Physical"    select="'Físico'"/>
   <xsl:variable name="lang.Physiological"  select="'Físico'"/>
   <xsl:variable name="lang.Pilot"      select="'Piloto'"/>
@@ -239,7 +239,7 @@
   <xsl:variable name="lang.VR"      select="'RV'"/>
   <xsl:variable name="lang.W"        select="'V'"/>
   <xsl:variable name="lang.Walk"      select="'Andar'"/>
-  <xsl:variable name="lang.Weaknesses"    select="'Weaknesses'"/>
+  <xsl:variable name="lang.Weaknesses"    select="'Fraquezas'"/>
   <xsl:variable name="lang.Weapon"    select="'Arma'"/>
   <xsl:variable name="lang.Weapons"    select="'Armas'"/>
   <xsl:variable name="lang.Week"      select="'Semana'"/>
@@ -290,6 +290,7 @@
   <xsl:variable name="lang.Nothing2Show4Notes"    select="'No Notes to list'"/>
   <xsl:variable name="lang.Nothing2Show4Vehicles"    select="'No Vehicles to list'"/>
   <xsl:variable name="lang.OptionalPowers"    select="'Optional Powers'"/>
+  <xsl:variable name="lang.OtherArmor"      select="'Outros Armadura'"/>
   <xsl:variable name="lang.OtherMugshots"    select="'Outros Retratos'"/>
   <xsl:variable name="lang.PageBreak"      select="'Quebra de Página: '"/>
   <xsl:variable name="lang.ToxinsAndPathogens"  select="'Toxinas e Patógenos'"/>
@@ -312,6 +313,7 @@
   <xsl:variable name="lang.StunNaturalRecovery"  select="'Pilha de Recuperação Natural (1 hora)'"/>
   <xsl:variable name="lang.StunTrack"    select="'Faixa de Dano de Atordoamento'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'Classe de Submersão'"/>
+  <xsl:variable name="lang.TotalArmor"  select="'Total de armaduras e acessórios mais altos equipados'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'Personagem Sem Nome'"/>
   <xsl:variable name="lang.VehicleBody"    select="'Corpo'"/>
   <xsl:variable name="lang.VehicleCost"    select="'Custo de Veículo'"/>

--- a/Chummer/sheets/xt.ComplexForms.xslt
+++ b/Chummer/sheets/xt.ComplexForms.xslt
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Format Complex Forms list of Character Sheet -->
+<!-- Version -500 -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+
+  <xsl:template name="ComplexForms">
+    <tr>
+      <th width="40%" style="text-align: left">
+        <xsl:value-of select="$lang.ComplexForm"/>
+      </th>
+      <th width="15%" style="text-align: center">
+        <xsl:value-of select="$lang.Target"/>
+      </th>
+      <th width="15%" style="text-align: center">
+        <xsl:value-of select="$lang.Duration"/>
+      </th>
+      <th width="15%" style="text-align: center">
+        <xsl:value-of select="$lang.FV"/>
+      </th>
+      <th width="5%"/>
+      <th width="10%"/>
+    </tr>
+
+    <xsl:for-each select="complexforms/complexform">
+      <xsl:sort select="name"/>
+      <tr>
+        <xsl:if test="position() mod 2 != 1">
+          <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+        </xsl:if>
+        <td>
+          <xsl:value-of select="name"/>
+          <xsl:if test="extra != ''">: <xsl:value-of select="extra"/></xsl:if>
+          <xsl:if test="programoptions/programoption"> (<xsl:for-each select="programoptions/programoption">
+            <xsl:sort select="name"/>
+            <xsl:value-of select="name"/>
+            <xsl:if test="rating &gt; 0">
+              <xsl:text> </xsl:text>
+              <xsl:value-of select="rating"/>
+            </xsl:if>
+            <xsl:if test="last() &gt; 1">; </xsl:if>
+          </xsl:for-each>)
+          </xsl:if>
+        </td>
+        <td style="text-align: center">
+          <xsl:value-of select="target"/>
+        </td>
+        <td style="text-align: center">
+          <xsl:value-of select="duration"/>
+        </td>
+        <td style="text-align: center">
+          <xsl:value-of select="fv"/>
+        </td>
+        <td/>
+        <td style="text-align: center">
+          <xsl:value-of select="source"/>
+          <xsl:text> </xsl:text>
+          <xsl:value-of select="page"/>
+        </td>
+      </tr>
+      <xsl:if test="notes != '' and $ProduceNotes">
+        <tr>
+          <xsl:if test="position() mod 2 != 1">
+            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+          </xsl:if>
+          <td colspan="100%" class="notesrow2">
+            <xsl:call-template name="PreserveLineBreaks">
+              <xsl:with-param name="text" select="notes"/>
+            </xsl:call-template>
+          </td>
+        </tr>
+      </xsl:if>
+      <xsl:call-template name="Xline">
+        <xsl:with-param name="cntl" select="last()-position()"/>
+        <xsl:with-param name="nte" select="notes != '' and $ProduceNotes"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/Chummer/sheets/xt.Contacts.xslt
+++ b/Chummer/sheets/xt.Contacts.xslt
@@ -66,6 +66,8 @@
         <td style="text-align: center"><xsl:value-of select="connection"/></td>
         <td style="text-align: center"><xsl:value-of select="loyalty"/></td>
       </tr>
+
+      <xsl:if test="$ProduceNotes">
       <xsl:if test="metatype != '' or sex != '' or age != '' or preferredpayment != '' or hobbiesvice != '' or personallife != '' or contacttype != ''">
       <tr>
         <xsl:if test="position() mod 2 != 1">
@@ -148,7 +150,7 @@
       </tr>
       </xsl:if>
 
-      <xsl:if test="notes != '' and $ProduceNotes">
+      <xsl:if test="notes != ''">
         <tr>
           <xsl:if test="position() mod 2 != 1">
             <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
@@ -160,6 +162,8 @@
           </td>
         </tr>
       </xsl:if>
+      </xsl:if>
+
       <xsl:call-template name="Xline">
         <xsl:with-param name="cntl" select="last()-position()"/>
         <xsl:with-param name="nte" select="notes != '' and $ProduceNotes"/>
@@ -177,6 +181,7 @@
         <xsl:when test="family">Family</xsl:when>
         <xsl:when test="group">Group</xsl:when>
   Note: if group is true connection is supplied as group(connection) -->
+        <xsl:when test="type='Pet'"><xsl:value-of select="$lang.Pets"/></xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="$lang.Type"/>: <xsl:value-of select="type"/>
         </xsl:otherwise>

--- a/Chummer/sheets/xt.CritterPowers.xslt
+++ b/Chummer/sheets/xt.CritterPowers.xslt
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Format Complex Forms list of Character Sheet -->
+<!-- Version -500 -->
+<xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+        xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+
+  <xsl:template name="CritterPowers">
+    <tr>
+      <th width="50%" style="text-align: left">
+        <xsl:value-of select="$lang.Critter"/>
+      </th>
+      <th width="30%"><xsl:value-of select="$lang.Rating"/></th>
+      <th width="10%"/>
+      <th width="10%"/>
+    </tr>
+
+    <xsl:for-each select="critterpowers/critterpower">
+      <xsl:sort select="name"/>
+      <tr>
+        <xsl:if test="position() mod 2 != 1">
+          <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+        </xsl:if>
+        <td>
+          <xsl:value-of select="name"/>
+          <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
+        </td>
+        <td style="text-align: center">
+          <xsl:value-of select="rating"/>
+        </td>
+        <td/>
+        <td style="text-align: center">
+          <xsl:value-of select="source"/>
+          <xsl:text> </xsl:text>
+          <xsl:value-of select="page"/>
+        </td>
+      </tr>
+      <xsl:if test="notes != '' and $ProduceNotes">
+        <tr>
+          <xsl:if test="position() mod 2 != 1">
+            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+          </xsl:if>
+          <td colspan="100%" class="notesrow2">
+            <xsl:call-template name="PreserveLineBreaks">
+              <xsl:with-param name="text" select="notes"/>
+            </xsl:call-template>
+          </td>
+        </tr>
+      </xsl:if>
+      <xsl:call-template name="Xline">
+        <xsl:with-param name="cntl" select="last()-position()"/>
+        <xsl:with-param name="nte" select="notes != '' and $ProduceNotes"/>
+      </xsl:call-template>
+    </xsl:for-each>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/Chummer/sheets/xz.language.xslt
+++ b/Chummer/sheets/xz.language.xslt
@@ -94,6 +94,7 @@
   <xsl:variable name="lang.Eyes"      select="'Eyes'"/>
   <xsl:variable name="lang.Falling"    select="'Falling'"/>
   <xsl:variable name="lang.Fatigue"      select="'Fatigue'"/>
+  <xsl:variable name="lang.Fettered"      select="'Fettered'"/>
   <xsl:variable name="lang.Fire"    select="'Fire'"/>
   <xsl:variable name="lang.Firewall"    select="'Firewall'"/>
   <xsl:variable name="lang.Fly"      select="'Fly'"/>
@@ -146,7 +147,6 @@
   <xsl:variable name="lang.Mode"      select="'Mode'"/>
   <xsl:variable name="lang.Model"      select="'Model'"/>
   <xsl:variable name="lang.Modifications"  select="'Modifications'"/>
-  <xsl:variable name="lang.Modifiers"    select="'Modifiers'"/>
   <xsl:variable name="lang.Month"      select="'Month'"/>
   <xsl:variable name="lang.Months"    select="'Months'"/>
   <xsl:variable name="lang.Movement"    select="'Movement'"/>
@@ -157,11 +157,11 @@
   <xsl:variable name="lang.Notes"      select="'Notes'"/>
   <xsl:variable name="lang.Notoriety"    select="'Notoriety'"/>
   <xsl:variable name="lang.Nuyen"      select="'Nuyen'"/>
-  <xsl:variable name="lang.Other"      select="'Other'"/>
   <xsl:variable name="lang.OVR"      select="'OVR&#160;'"/>
   <xsl:variable name="lang.Pathogen"    select="'Pathogen'"/>
   <xsl:variable name="lang.Permanent"    select="'Permanent'"/>
   <xsl:variable name="lang.Persona"    select="'Persona'"/>
+  <xsl:variable name="lang.Pets"      select="'Pets'"/>
   <xsl:variable name="lang.Physical"    select="'Physical'"/>
   <xsl:variable name="lang.Physiological"  select="'Physiological'"/>
   <xsl:variable name="lang.Pilot"      select="'Pilot'"/>
@@ -290,6 +290,7 @@
   <xsl:variable name="lang.Nothing2Show4Notes"    select="'No Notes to list'"/>
   <xsl:variable name="lang.Nothing2Show4Vehicles"    select="'No Vehicles to list'"/>
   <xsl:variable name="lang.OptionalPowers"    select="'Optional Powers'"/>
+  <xsl:variable name="lang.OtherArmor"      select="'Other Armor'"/>
   <xsl:variable name="lang.OtherMugshots"    select="'Other Portraits'"/>
   <xsl:variable name="lang.PageBreak"      select="'Page Break: '"/>
   <xsl:variable name="lang.ToxinsAndPathogens"  select="'Toxins and Pathogens'"/>
@@ -312,6 +313,7 @@
   <xsl:variable name="lang.StunNaturalRecovery"  select="'Natural Recovery Pool (1 hour)'"/>
   <xsl:variable name="lang.StunTrack"    select="'Stun Damage Track'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'Submersion Grade'"/>
+  <xsl:variable name="lang.TotalArmor"  select="'Total of equipped single highest armor and accessories'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'Unnamed Character'"/>
   <xsl:variable name="lang.VehicleBody"    select="'Body'"/>
   <xsl:variable name="lang.VehicleCost"    select="'Vehicle Cost'"/>

--- a/Chummer/sheets/zh-cn/xz.language.xslt
+++ b/Chummer/sheets/zh-cn/xz.language.xslt
@@ -3,7 +3,7 @@
 <!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:variable name="lang"  select="'zh'"/>
-  <xsl:variable name="locale"  select="'zh'"/>
+  <xsl:variable name="locale"  select="'zh-cn'"/>
 
   <!-- individual words -->
   <xsl:variable name="lang.Acceleration"  select="'加速'"/>
@@ -94,6 +94,7 @@
   <xsl:variable name="lang.Eyes"      select="'瞳色'"/>
   <xsl:variable name="lang.Falling"    select="'Falling'"/>
   <xsl:variable name="lang.Fatigue"      select="'Fatigue'"/>
+  <xsl:variable name="lang.Fettered"      select="'Fettered'"/>
   <xsl:variable name="lang.Fire"    select="'Fire'"/>
   <xsl:variable name="lang.Firewall"    select="'防火墙'"/>
   <xsl:variable name="lang.Fly"      select="'飞行'"/>
@@ -146,7 +147,6 @@
   <xsl:variable name="lang.Mode"      select="'模式'"/>
   <xsl:variable name="lang.Model"      select="'模块'"/>
   <xsl:variable name="lang.Modifications"  select="'改造'"/>
-  <xsl:variable name="lang.Modifiers"    select="'调整'"/>
   <xsl:variable name="lang.Month"      select="'月'"/>
   <xsl:variable name="lang.Months"    select="'月'"/>
   <xsl:variable name="lang.Movement"    select="'移动速度'"/>
@@ -157,11 +157,11 @@
   <xsl:variable name="lang.Notes"      select="'备注'"/>
   <xsl:variable name="lang.Notoriety"    select="'恶名'"/>
   <xsl:variable name="lang.Nuyen"      select="'新円'"/>
-  <xsl:variable name="lang.Other"      select="'其他'"/>
   <xsl:variable name="lang.OVR"      select="'溢&#160;'"/>
   <xsl:variable name="lang.Pathogen"    select="'Pathogen'"/>
   <xsl:variable name="lang.Permanent"    select="'永久法术'"/>
   <xsl:variable name="lang.Persona"    select="'化身'"/>
+  <xsl:variable name="lang.Pets"      select="'Pets'"/>
   <xsl:variable name="lang.Physical"    select="'物理'"/>
   <xsl:variable name="lang.Physiological"  select="'Physiological'"/>
   <xsl:variable name="lang.Pilot"      select="'自驾系统'"/>
@@ -290,6 +290,7 @@
   <xsl:variable name="lang.Nothing2Show4Notes"    select="'No Notes to list'"/>
   <xsl:variable name="lang.Nothing2Show4Vehicles"    select="'No Vehicles to list'"/>
   <xsl:variable name="lang.OptionalPowers"    select="'Optional Powers'"/>
+  <xsl:variable name="lang.OtherArmor"      select="'其他护甲'"/>
   <xsl:variable name="lang.OtherMugshots"    select="'其他肖像'"/>
   <xsl:variable name="lang.PageBreak"      select="'Page Break: '"/>
   <xsl:variable name="lang.ToxinsAndPathogens"  select="'Toxins and Pathogens'"/>
@@ -312,6 +313,7 @@
   <xsl:variable name="lang.StunNaturalRecovery"  select="'Natural Recovery Pool (1 hour)'"/>
   <xsl:variable name="lang.StunTrack"    select="'&#160;&#160;晕眩伤害'"/>
   <xsl:variable name="lang.SubmersionGrade"  select="'深潜阶层'"/>
+  <xsl:variable name="lang.TotalArmor"  select="'Total of equipped single highest armor and accessories'"/>
   <xsl:variable name="lang.UnnamedCharacter"  select="'未命名角色'"/>
   <xsl:variable name="lang.VehicleBody"    select="'机体'"/>
   <xsl:variable name="lang.VehicleCost"    select="'载具售价'"/>


### PR DESCRIPTION
Minor additions / changes to character sheets

### Environment
Chummer Version: 5.197.??
Environment: Windows 7 Home Premium (64-bit)
Runtime: (probably .NET 4.7.1)

#### Fancy Blocks character sheet
1) "[Portrait]" heading printed even if there is no main mugshot
![fancy blocks - no main mugshot](https://user-images.githubusercontent.com/17562417/36046919-79d467f8-0dd2-11e8-85af-3307c18c5f46.png)

2) Spirits section does not indicated if a spirit is fettered

3) Complex Forms notes are only printed in a quarter of the column
![fancy blocks - complex forms](https://user-images.githubusercontent.com/17562417/36046957-8e8904f6-0dd2-11e8-9f41-c43c94183163.png)

#### Notes character sheet
1) Echoes are not included

2) Complex Forms are not included

3) Metamagic Arts are not included

4) Sprites are not included.

5) Critter Powers notes not printed

6) Format of Pets as a type of Contact

#### Shadowrun 5* character sheets
1) Stream section "Drain" column is too narrow for the definition.
![drain size](https://user-images.githubusercontent.com/17562417/36046977-a3107210-0dd2-11e8-821b-fc13b7ac5093.png)

2) Sprites section does not include "crittername" value.
![sprite panel](https://user-images.githubusercontent.com/17562417/36047005-baf43f1a-0dd2-11e8-8d2e-cd452f57aa1e.png)
![sprite section](https://user-images.githubusercontent.com/17562417/36047006-bb5b066e-0dd2-11e8-87e5-e001b51bb5ee.png)

3) Spirits section does not include "crittername" value.

4) Spirits section does not indicated if a spirit is fettered

5) Metamagic Arts are not printed correctly

6) Format of Pets as a type of Contact

7) Since accessories began to be stored with "+" the armor section displays 'Other Modifiers' as "NaN"
![armour](https://user-images.githubusercontent.com/17562417/36047070-ee2223e8-0dd2-11e8-8459-0e963bfdcf90.png)

8) Skills section 'RTG' column headings are split over two lines in Chinese character sheets
![chinese - knowledge rating column](https://user-images.githubusercontent.com/17562417/36047106-06383cec-0dd3-11e8-9038-3fd99a2247c0.png)

#### Contacts character sheet
1) Format of Pets as a type of Contact

#### Expenses character sheet
1) Expenses not listed of local language translates "Karma" or "Nuyen" (e.g. Portuguese)
![portugeuse - expenses](https://user-images.githubusercontent.com/17562417/36047132-1a5d3592-0dd3-11e8-9a16-07f7c3e11067.png)

### Character sheet changes
/data/sheets			moved "Blocos Chiques" to first alphabetically

/sheets/Expenses set		hard-coded "Karma" and "Nuyen" replacing local variable
/sheets/Fancy Blocks
- only print "[Portrait]" if there is a main mugshot
- added print of "Fettered" for spirits
- corrected printing of Complex Forms notes
/sheets/Notes set
- added print of Echoes notes
- added print of Complex Forms notes
- added print of Metamagic Arts
- added print of Sprites notes
- added print of Critter Power notes
/sheets/Shadowrun 5 set
- expanded Drain column width
- added print of crittername for sprites
- added print of crittername for spirits
- added print of "Fettered" for spirits
- corrected print of Metamagic Arts
- added print of Critter Power notes
- removed 'Other Modifiers' from armor section and indicated highest armor only is used
/sheets/xt.Contacts		added "Pets" to contacts processed

/sheets/xz.language		new literals
/sheets/de-de/xz.language	new German literals
/sheets/fr-fr/xz.language	new French literals
/sheets/ja-jp/xz.language	new literals
/sheets/pt-pr/xz.language	new Portuguese literals
/sheets/zh-cn/xz.language	new literals
- new literal: Fettered
- new literal: Pets
- new literal: Other Armor
- new literal: Total of equipped armor used

Added:
/sheets/xt.ComplexForms
/sheets/xt.CritterPowers
