### PR TITLE
Update Nanoscanner page number

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -6334,7 +6334,7 @@
       <category>Sensor Functions</category>
       <rating>8</rating>
       <source>CF</source>
-      <page>152</page>
+      <page>153</page>
       <avail>8</avail>
       <armorcapacity>[1]</armorcapacity>
       <capacity>[1]</capacity>


### PR DESCRIPTION
I just noticed that the nanoscanner page reference pointed to the page before it is discussed, and corrected it.

Corrected Nanoscanner page number from 152 to 153.