### PR TITLE
AVA Fix for internal Weapon mounts

### DIFF
--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -12118,7 +12118,7 @@
       <name>Internal</name>
       <page>163</page>
       <source>R5</source>
-      <avail>4</avail>
+      <avail>2</avail>
       <category>Visibility</category>
       <cost>1500</cost>
       <slots>2</slots>


### PR DESCRIPTION
internal visibility of a weapon mount adds 2 to the avaliability, not 4 (Rigger 5 Page 162)
fixes #2692 partially.