### PR TITLE
Fixes to critters.xml

### DIFF
--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -19076,7 +19076,7 @@
       </powers>
       <skills>
         <skill rating="5">Astral Combat</skill>
-        <skill rating="5" spec="Lightning">Exotic Range Weapon</skill>
+        <skill rating="5" spec="Lightning">Exotic Ranged Weapon</skill>
         <skill rating="5">Flight</skill>
         <skill rating="6">Perception</skill>
         <skill rating="5">Unarmed Combat</skill>
@@ -22458,7 +22458,7 @@
       <skills>
         <skill rating="4">Gymnastics</skill>
         <skill rating="4">Perception</skill>
-        <skill rating="6">Shadowing</skill>
+        <skill rating="6">Sneaking</skill>
         <skill rating="5">Unarmed Combat</skill>
       </skills>
       <source>HS</source>
@@ -40258,7 +40258,7 @@
         <power select="Sonar">Enhanced Senses</power>
         <power rating="2">Armor</power>
         <power>AR-Parallelism</power>
-        <power>Cozenge</power>
+        <power>Cozenage</power>
         <power>Gremlins</power>
         <power>Tunnel</power>
       </powers>
@@ -40687,7 +40687,7 @@
         <power>Gestalt Consciousness</power>
         <power rating="3">Fragile</power>
         <power>AR-Parallelism</power>
-        <power>Cozenge</power>
+        <power>Cozenage</power>
         <power>Gremlins</power>
         <power>Tunnel</power>
       </powers>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -40344,7 +40344,7 @@
       </bonus>
       <powers>
         <power select="Smell">Enhanced Senses</power>
-        <power select="Antlers: DV (STR+1)P, AP -1">Natural Weapons</power>
+        <power select="Antlers: DV (STR+1)P, AP -1">Natural Weapon</power>
         <power rating="2">Armor</power>
         <power>AR-Parallelism</power>
         <power>Resonance Feed</power>


### PR DESCRIPTION
- The technocritter with a power originally listed as Cozenge should be Cozenage.
- There was one SR5 critter with the Shadowing skill I've corrected to Sneaking
- There was one critter with "Exotic Range Weapon" instead of "Exotic Ranged Weapon."
