### PR TITLE
Include pre-errata Commanding Voice power

### DIFF
--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -743,6 +743,25 @@
       <maxlevels>3</maxlevels>
     </power>
     <power>
+      <id>95412b12-c02f-4041-9282-71f444786e04</id>
+      <name>Commanding Voice (pre-errata)</name>
+      <points>.25</points>
+      <levels>True</levels>
+      <limit>3</limit>
+      <source>SG</source>
+      <page>170</page>
+      <bonus>
+        <specificskill>
+          <name>Intimidation</name>
+          <bonus>Rating</bonus>
+        </specificskill>
+        <specificskill>
+          <name>Leadership</name>
+          <bonus>Rating</bonus>
+        </specificskill>
+      </bonus>
+    </power>
+    <power>
       <id>6770cfab-8c1a-4c6d-add7-f7d96220e9b0</id>
       <name>Counterstrike</name>
       <points>1</points>


### PR DESCRIPTION
This is related to issue #1350 and also #112. 

I have a player using the original Commanding Voice adept power from Shadow Grimoire who can't use it in Chummer because it was later changed/removed in some errata. 

So I'm proposing with this PR to re-add in the original power printed in SG, with the title: "Commanding Voice (pre-errata)", including the original bonuses and page reference.