### PR TITLE
Fixed Cyberware location for all translations

### DIFF
--- a/Chummer/Selection Forms/frmSelectSide.cs
+++ b/Chummer/Selection Forms/frmSelectSide.cs
@@ -48,7 +48,7 @@ namespace Chummer
 
         private void cmdOK_Click(object sender, EventArgs e)
         {
-            _strSelectedSide = cboSide.Text;
+            _strSelectedSide = cboSide.SelectedValue.ToString();
             DialogResult = DialogResult.OK;
         }
 


### PR DESCRIPTION
Fixed a bug where the location for cyberware would get a wrong value when used with a translated version of chummer. E.g. in the german translation the location for a right cyberarm would be 'Rechts' instead of 'Right'.