### PR TITLE
Armor, vehicles und weapons from German source book 'Hamburg'

### DIFF
--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -3069,6 +3069,51 @@
       <page>70</page>
     </armor>
     <!-- End Region -->
+    <!-- Region Hamburg -->
+    <armor>
+      <id>4b16a172-b328-4717-b632-39a3d07eeb41</id>
+      <name>FleetHead Kappe</name>
+      <category>Armor</category>
+      <armor>0</armor>
+      <armorcapacity>3</armorcapacity>
+      <avail>4</avail>
+      <cost>200</cost>
+      <gears>
+        <usegear>Image Link</usegear>
+      </gears>
+      <source>HAMG</source>
+      <page>173</page>
+    </armor>
+    <armor>
+      <id>fc1c9de6-4600-4c14-8e8a-9fed51389e4a</id>
+      <name>Rheingold Friesennerz</name>
+      <category>Armor</category>
+      <armor>8</armor>
+      <armorcapacity>6</armorcapacity>
+      <avail>6</avail>
+      <cost>850</cost>
+      <mods>
+        <name rating="3">Chemical Protection</name>
+      </mods>
+      <source>HAMG</source>
+      <page>173</page>
+    </armor>
+    <armor>
+      <id>e8065f02-68f3-46f6-8cca-298a1806b97b</id>
+      <name>Ares Victory Friesennerz</name>
+      <category>Armor</category>
+      <armor>6</armor>
+      <armorcapacity>5</armorcapacity>
+      <avail>7</avail>
+      <cost>920</cost>
+      <mods>
+        <name rating="3">Chemical Protection</name>
+        <name>Internal Air Tank (5 Minutes)</name>
+	  </mods>
+      <source>HAMG</source>
+      <page>173</page>
+    </armor>
+    <!-- End Region -->
   </armors>
   <mods>
     <!-- Region Shadowrun 5 -->
@@ -3954,5 +3999,19 @@
       <page>73</page>
     </mod>
     <!-- End Region -->
+	<!-- Region Hamburg -->
+    <mod>
+      <id>80effbdd-047d-4b1f-8159-f13f86bba4e6</id>
+      <name>Internal Air Tank (5 Minutes)</name>
+      <category>General</category>
+      <armor>0</armor>
+      <maxrating>1</maxrating>
+      <armorcapacity>[0]</armorcapacity>
+      <avail>0</avail>
+      <cost>0</cost>
+      <source>HAMG</source>
+      <page>173</page>
+    </mod>
+	<!-- End Region -->
   </mods>
 </chummer>

--- a/Chummer/data/books.xml
+++ b/Chummer/data/books.xml
@@ -242,5 +242,10 @@
       <name>Kill Code</name>
       <code>KC</code>
     </book>
+    <book>
+	  <id>6c97c3e8-8f13-43aa-b692-6218983c9396</id>
+      <name>Hamburg (German-exclusive)</name>
+      <code>HAMG</code>
+    </book>
   </books>
 </chummer>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -9589,6 +9589,173 @@
     <!-- Missing: EMC Kommodore (Would require adjustments in code,
          since it uses building block where each part receives part of the slots) -->
     <!-- End Region -->
+	<!-- Region Hamburg -->
+    <vehicle>
+      <id>18f41586-7f0f-4ca1-8881-eccdabc3351d</id>
+      <name>MK R/evolution</name>
+      <page>174</page>
+      <source>HAMG</source>
+      <accel>3/2</accel>
+      <armor>6</armor>
+      <avail>0</avail>
+      <body>5</body>
+      <category>Bikes</category>
+      <cost>18500</cost>
+      <handling>4(2)/4</handling>
+      <pilot>2</pilot>
+      <sensor>2</sensor>
+      <speed>5/3</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>2</rating>
+          <maxrating>6</maxrating>
+        </gear>
+      </gears>
+      <seats>1</seats>
+    </vehicle>
+    <vehicle>
+      <id>79bf8059-3014-48f8-9bb0-ac3f81b732c3</id>
+      <name>MCT Guppy</name>
+      <page>173</page>
+      <source>HAMG</source>
+      <accel>1</accel>
+      <armor>0</armor>
+      <avail>6</avail>
+      <body>1</body>
+      <category>Drones: Micro</category>
+      <cost>450</cost>
+      <handling>2</handling>
+      <pilot>2</pilot>
+      <sensor>2</sensor>
+      <speed>1</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>2</rating>
+          <maxrating>2</maxrating>
+        </gear>
+      </gears>
+    </vehicle>
+    <vehicle>
+      <id>89251727-a573-4624-96db-697883f3643f</id>
+      <name>Proteus Nachtaal</name>
+      <page>173</page>
+      <source>HAMG</source>
+      <accel>3</accel>
+      <armor>1</armor>
+      <avail>10</avail>
+      <body>1</body>
+      <category>Drones: Mini</category>
+      <cost>4000</cost>
+      <handling>5</handling>
+      <pilot>3</pilot>
+      <sensor>4</sensor>
+      <speed>3</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>4</rating>
+          <maxrating>4</maxrating>
+        </gear>
+      </gears>
+    </vehicle>
+    <vehicle>
+      <id>9a2a8c39-e618-4feb-b779-bc8f30fa76e6</id>
+      <name>Evo Barrakuda</name>
+      <page>173</page>
+      <source>HAMG</source>
+      <accel>3</accel>
+      <armor>3</armor>
+      <avail>8</avail>
+      <body>4</body>
+      <category>Drones: Medium</category>
+      <cost>12000</cost>
+      <handling>5</handling>
+      <pilot>3</pilot>
+      <sensor>3</sensor>
+      <speed>4</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>3</rating>
+          <maxrating>3</maxrating>
+        </gear>
+      </gears>
+    </vehicle>
+    <vehicle>
+      <id>e5108247-0d43-486e-8d6a-2075b02f0681</id>
+      <name>Vulkan Delfin RQ-11</name>
+      <page>175</page>
+      <source>HAMG</source>
+      <accel>1</accel>
+      <armor>10</armor>
+      <avail>12</avail>
+      <body>12</body>
+      <category>Submarines</category>
+      <cost>85000</cost>
+      <handling>2</handling>
+      <pilot>1</pilot>
+      <sensor>1</sensor>
+      <speed>2</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>1</rating>
+          <maxrating>1</maxrating>
+        </gear>
+      </gears>
+      <seats>7</seats>
+    </vehicle>
+    <vehicle>
+      <id>94318a48-9f0d-4c9b-ac3e-9e35d31ffb08</id>
+      <name>MK Harbor Sentry</name>
+      <page>176</page>
+      <source>HAMG</source>
+      <accel>4</accel>
+      <armor>12</armor>
+      <avail>14R</avail>
+      <body>15</body>
+      <category>Boats</category>
+      <cost>152500</cost>
+      <handling>3</handling>
+      <pilot>3</pilot>
+      <sensor>5</sensor>
+      <speed>6</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>5</rating>
+          <maxrating>5</maxrating>
+        </gear>
+      </gears>
+      <seats>6</seats>
+    </vehicle>
+    <vehicle>
+      <id>b6cb1444-1e8b-4285-be64-a5fee0ac3d34</id>
+      <name>Yongkang Water Spirit</name>
+      <page>177</page>
+      <source>HAMG</source>
+      <accel>1</accel>
+      <armor>3</armor>
+      <avail>0</avail>
+      <body>6</body>
+      <category>Boats</category>
+      <cost>8500</cost>
+      <handling>5</handling>
+      <pilot>2</pilot>
+      <sensor>2</sensor>
+      <speed>3</speed>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>2</rating>
+          <maxrating>2</maxrating>
+        </gear>
+      </gears>
+      <seats>1-6</seats>
+    </vehicle>
+    <!-- End Region -->
   </vehicles>
   <mods>
     <!-- Region Vehicle Weapon Mount -->

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -9592,7 +9592,7 @@
 	<!-- Region Hamburg -->
     <vehicle>
       <id>18f41586-7f0f-4ca1-8881-eccdabc3351d</id>
-      <name>MK R/evolution</name>
+      <name>MK R/Evolution</name>
       <page>174</page>
       <source>HAMG</source>
       <accel>3/2</accel>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -14108,6 +14108,45 @@
       <ammoname>Ammo: Renraku/Ingram Supermach</ammoname>
     </weapon>
     <!-- End Region -->
+    <!-- Region Hamburg -->    
+	<weapon>
+      <id>787627c8-a2c4-47c1-9f3e-dd96ebfadf29</id>
+      <name>Elektro-Angel</name>
+      <category>Exotic Melee Weapons</category>
+      <type>Melee</type>
+      <accuracy>4</accuracy>
+      <reach>2</reach>
+      <damage>8S</damage>
+      <ap>-5</ap>
+      <avail>6</avail>
+      <cost>500</cost>
+      <source>HAMG</source>
+      <page>172</page>
+      <useskill>Exotic Melee Weapon</useskill>
+	  <spec>Elektro-Angel</spec>
+    </weapon>
+	<weapon>
+      <id>1a329276-af02-4911-a600-387291465201</id>
+      <name>Elektro-Netz</name>
+      <category>Exotic Ranged Weapons</category>
+      <type>Ranged</type>
+      <conceal>0</conceal>
+      <accuracy>Physical-2</accuracy>
+      <reach>0</reach>
+      <damage>8S</damage>
+      <ap>-5</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <avail>6</avail>
+      <cost>600</cost>
+      <source>HAMG</source>
+      <page>172</page>
+      <range>Thrown Knife</range>
+      <useskill>Exotic Ranged Weapon</useskill>
+      <spec>Elektro-Netz</spec>
+	</weapon>
+    <!-- End Region -->
   </weapons>
   <accessories>
     <!-- Region Shadowrun 5 -->

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -38801,8 +38801,8 @@
 			</vehicle>
 			<vehicle translated="True">
 				<id>18f41586-7f0f-4ca1-8881-eccdabc3351d</id>
-				<name>MK R/evolution</name>
-				<translate>MK R/evolution</translate>
+				<name>MK R/Evolution</name>
+				<translate>MK R/Evolution</translate>
 				<altpage>174</altpage>
 			</vehicle>
 			<vehicle translated="True">

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -1192,6 +1192,24 @@
 				<translate>Standard-Hartschalenrucksack</translate>
 				<altpage>70</altpage>
 			</armor>
+			<armor translated="True">
+				<id>4b16a172-b328-4717-b632-39a3d07eeb41</id>
+				<name>FleetHead Kappe</name>
+				<translate>FleetHead Kappe</translate>
+				<altpage>173</altpage>
+			</armor>
+			<armor translated="True">
+				<id>fc1c9de6-4600-4c14-8e8a-9fed51389e4a</id>
+				<name>Rheingold Friesennerz</name>
+				<translate>Rheingold Friesennerz</translate>
+				<altpage>173</altpage>
+			</armor>
+			<armor translated="True">
+				<id>e8065f02-68f3-46f6-8cca-298a1806b97b</id>
+				<name>Ares Victory Friesennerz</name>
+				<translate>Ares Victory Friesennerz</translate>
+				<altpage>173</altpage>
+			</armor>
 		</armors>
 		<mods>
 			<mod>
@@ -1571,6 +1589,12 @@
 				<name>Personal Drone Rack</name>
 				<translate>Tragbare Drohnenhalterung</translate>
 				<altpage>70</altpage>
+			</mod>
+			<mod translated="True">
+				<id>80effbdd-047d-4b1f-8159-f13f86bba4e6</id>
+				<name>Internal Air Tank (5 Minutes)</name>
+				<translate>Interner Lufttank (5 Minuten)</translate>
+				<altpage>173</altpage>
 			</mod>
 		</mods>
 	</chummer>
@@ -3176,6 +3200,12 @@
 				<name>Kill Code</name>
 				<translate>Lethaler Code</translate>
 				<altcode>KC</altcode>
+			</book>
+			<book>
+				<id>6c97c3e8-8f13-43aa-b692-6218983c9396</id>
+				<name>Hamburg (German-exclusive)</name>
+				<translate>Hamburg (Deutsch-exklusiv)</translate>
+				<altcode>HAMG</altcode>
 			</book>
 		</books>
 	</chummer>
@@ -38769,6 +38799,48 @@
 				<translate>Eurocopter FC</translate>
 				<altpage>219</altpage>
 			</vehicle>
+			<vehicle translated="True">
+				<id>18f41586-7f0f-4ca1-8881-eccdabc3351d</id>
+				<name>MK R/evolution</name>
+				<translate>MK R/evolution</translate>
+				<altpage>174</altpage>
+			</vehicle>
+			<vehicle translated="True">
+				<id>79bf8059-3014-48f8-9bb0-ac3f81b732c3</id>
+				<name>MCT Guppy</name>
+				<translate>MCT Guppy</translate>
+				<altpage>173</altpage>
+			</vehicle>
+			<vehicle translated="True">
+				<id>89251727-a573-4624-96db-697883f3643f</id>
+				<name>Proteus Nachtaal</name>
+				<translate>Proteus Nachtaal</translate>
+				<altpage>173</altpage>
+			</vehicle>
+			<vehicle translated="True">
+				<id>9a2a8c39-e618-4feb-b779-bc8f30fa76e6</id>
+				<name>Evo Barrakuda</name>
+				<translate>Evo Barrakuda</translate>
+				<altpage>173</altpage>
+			</vehicle>
+			<vehicle translated="True">
+				<id>e5108247-0d43-486e-8d6a-2075b02f0681</id>
+				<name>Vulkan Delfin RQ-11</name>
+				<translate>Vulkan Delfin RQ-11</translate>
+				<altpage>175</altpage>
+			</vehicle>
+			<vehicle translated="True">
+				<id>94318a48-9f0d-4c9b-ac3e-9e35d31ffb08</id>
+				<name>MK Harbor Sentry</name>
+				<translate>MK Harbor Sentry</translate>
+				<altpage>176</altpage>
+			</vehicle>
+			<vehicle translated="True">
+				<id>b6cb1444-1e8b-4285-be64-a5fee0ac3d34</id>
+				<name>Yongkang Water Spirit</name>
+				<translate>Yongkang Water Spirit</translate>
+				<altpage>177</altpage>
+			</vehicle>
 		</vehicles>
 		<mods>
 			<mod>
@@ -43335,6 +43407,18 @@
 				<name>Renraku/Ingram Supermach 200</name>
 				<translate>Renraku/Ingram Supermach 200</translate>
 				<altpage>139</altpage>
+			</weapon>
+			<weapon translated="True">
+				<id>787627c8-a2c4-47c1-9f3e-dd96ebfadf29</id>
+				<name>Elektro-Angel</name>
+				<translate>Elektro-Angel</translate>
+				<altpage>172</altpage>
+			</weapon>
+			<weapon translated="True">
+				<id>1a329276-af02-4911-a600-387291465201</id>
+				<name>Elektro-Netz</name>
+				<translate>Elektro-Netz</translate>
+				<altpage>172</altpage>
 			</weapon>
 		</weapons>
 		<accessories>


### PR DESCRIPTION
I've got the equipment set up to a stage where it can be merged. But there are three things I can't solve (I would fix it as soon as I knew what to do):

1. The MK R/Evolution (an amphibious motorbike) has a handling value of '4(2)/4', whereas the description says "values before the slash for motorbike mode (in brackets offroad), behind it for jetski mode". This is not shown in the Chummer with '4(2)/4', but with '0/4' (but I can't fix that). What should I do to ensure that this information is at least approximately correct?

2. There is always a section gears in the XML data of the vehicles, which always shows rating and maxrating under sensor array. To the rating I have always deposited the sensor value and with maxrating also. But the last value is certainly wrong. What is the right value?

3. The Yongkang Water Spirit has 1-6 seats (there are three types: 6 seats, 3 seats for trolls and 1 front-seat bench plus a large cargo space). ‘1-6‘ is not shown so maybe I should put three different variantes as vehicles?

To compare details I put a screenshot of added things below.

![gear](https://user-images.githubusercontent.com/43168497/47877507-56b5b680-de1c-11e8-9572-ba30aba8d85c.png)