### PR TITLE
Added zeros in powers.xml

### DIFF
--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -24,7 +24,7 @@
     <power>
       <id>8caaadf4-75b4-4535-928a-5648d395c13a</id>
       <name>Adrenaline Boost</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
@@ -40,7 +40,7 @@
       <source>SR5</source>
       <page>309</page>
       <action>Simple</action>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -57,7 +57,7 @@
     <power>
       <id>ddcca815-d6fe-41ed-b174-2e7255320f17</id>
       <name>Attribute Boost</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>4</limit>
       <source>SR5</source>
@@ -75,12 +75,12 @@
     <power>
       <id>76337564-7688-497f-84f9-302c6ece10fe</id>
       <name>Combat Sense</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -98,12 +98,12 @@
     <power>
       <id>dbf16604-164c-485c-96c8-fe3136cd5caa</id>
       <name>Critical Strike</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -123,7 +123,7 @@
     <power>
       <id>980d6575-c28f-4076-9b36-881cea018335</id>
       <name>Danger Sense</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
@@ -132,12 +132,12 @@
     <power>
       <id>974d2aba-1772-474b-aaff-c84a12766e5f</id>
       <name>Enhanced Perception</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -164,7 +164,7 @@
     <power>
       <id>e009da31-0301-4604-b13f-49b071aa25a1</id>
       <name>Enhanced Accuracy (skill)</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SR5</source>
@@ -179,12 +179,12 @@
     <power>
       <id>75821fb7-a180-4012-aa16-daa92ac3bb63</id>
       <name>Improved Ability (skill)</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>100</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -219,7 +219,7 @@
       <limit>12</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -241,12 +241,12 @@
     <power>
       <id>1fde7231-e5cc-4fa3-a1fe-b80b00212417</id>
       <name>Improved Potential (Social)</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -263,12 +263,12 @@
     <power>
       <id>2a7abc86-aa01-4127-b4b1-f73b49a2b5db</id>
       <name>Improved Potential (Mental)</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -285,12 +285,12 @@
     <power>
       <id>d9b811f4-aa64-46fb-b67d-2995134eda4e</id>
       <name>Improved Potential (Physical)</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>309</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -330,7 +330,7 @@
     <power>
       <id>1376c13b-9a01-4873-b935-5b7d91e03785</id>
       <name>Improved Sense</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SR5</source>
@@ -342,13 +342,13 @@
     <power>
       <id>23636777-44df-44f1-8742-db29dc3c4fdf</id>
       <name>Killing Hands</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>310</page>
       <action>Free</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -369,7 +369,7 @@
     <power>
       <id>f1e8a618-ba12-4972-91f0-974500387893</id>
       <name>Kinesics</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
@@ -381,7 +381,7 @@
     <power>
       <id>ce7df757-792e-4fac-a86e-6b587586deb2</id>
       <name>Light Body</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
@@ -390,7 +390,7 @@
     <power>
       <id>c152dcba-8bb7-4a2a-86bb-6f854ea53b55</id>
       <name>Missile Parry</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
@@ -400,12 +400,12 @@
     <power>
       <id>da5f9389-a5fd-48ed-8825-8852ff5c56a8</id>
       <name>Mystic Armor</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>310</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -421,7 +421,7 @@
     <power>
       <id>98b59b41-6a91-4abc-a6d2-e8debaa3b5aa</id>
       <name>Natural Immunity</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
@@ -440,12 +440,12 @@
     <power>
       <id>545a4bec-c144-42a1-b553-6d6c0c91f07f</id>
       <name>Pain Resistance</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>311</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -468,12 +468,12 @@
     <power>
       <id>4676b6f7-120d-4344-81ac-5922445a521b</id>
       <name>Rapid Healing</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>311</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -490,12 +490,12 @@
     <power>
       <id>82d8c376-7509-468a-be17-8c9cba4c86c4</id>
       <name>Spell Resistance</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>311</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <bonus>
         <spellresistance>Rating</spellresistance>
       </bonus>
@@ -508,7 +508,7 @@
       <limit>1</limit>
       <source>SR5</source>
       <page>311</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -522,12 +522,12 @@
     <power>
       <id>71692391-e01f-4902-98f0-abbbf5431680</id>
       <name>Voice Control</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>20</limit>
       <source>SR5</source>
       <page>311</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -548,13 +548,13 @@
     <power>
       <id>bfd1e09c-5765-423b-b079-f5d8e794485a</id>
       <name>Wall Running</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SR5</source>
       <page>311</page>
       <action>Simple</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -570,12 +570,12 @@
     <power>
       <id>0099ad65-bcc1-47a5-a241-02f621e7c33a</id>
       <name>Analytics</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>169</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -589,7 +589,7 @@
     <power>
       <id>870edcf8-cb19-4e15-948c-1b3bf80ac651</id>
       <name>Animal Empathy</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -610,7 +610,7 @@
       <source>SG</source>
       <page>169</page>
       <action>Simple</action>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -629,7 +629,7 @@
       <source>SG</source>
       <page>169</page>
       <action>Complex</action>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires />
       <required>
         <oneof>
@@ -640,12 +640,12 @@
     <power>
       <id>f3df89bb-71f6-41d8-a86d-4bde1ab74352</id>
       <name>Blind Fighting</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>169</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -659,7 +659,7 @@
     <power>
       <id>42baa818-50ca-4c6b-b316-780a51df9c97</id>
       <name>Cloak</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -676,7 +676,7 @@
       <limit>1</limit>
       <source>SG</source>
       <page>169</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -727,7 +727,7 @@
     <power>
       <id>5f1ebcd8-9571-4716-b7fd-ec674306b833</id>
       <name>Authoritative Tone</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -753,7 +753,7 @@
       <source>SG</source>
       <page>170</page>
       <action>Interrupt</action>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -772,7 +772,7 @@
       <source>SG</source>
       <page>170</page>
       <action>Complex</action>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <bonus>
         <addweapon>
           <name>Elemental Body</name>
@@ -788,13 +788,13 @@
     <power>
       <id>3d27c3bb-9cca-45c2-b8b1-6225a236069b</id>
       <name>Elemental Strike</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SG</source>
       <page>170</page>
       <action>Simple</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -815,13 +815,13 @@
     <power>
       <id>eb323003-4112-42ad-955a-00211e43e6d1</id>
       <name>Elemental Weapon</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SG</source>
       <page>170</page>
       <action>Simple</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -836,18 +836,18 @@
     <power>
       <id>6680b68d-77df-4fe4-a722-30464dd3c646</id>
       <name>Empathic Healing</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>171</page>
       <action>Special</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>fbd06bae-b3ba-4514-8d90-870eff1c336b</id>
       <name>Facial Sculpt</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -863,7 +863,7 @@
     <power>
       <id>438fb5de-9c09-4421-a6a8-c3d68ba8aada</id>
       <name>Flexibility</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -873,7 +873,7 @@
     <power>
       <id>88bf5626-6cf8-4dcc-bfc0-8abc889cdf4e</id>
       <name>Freefall</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -882,7 +882,7 @@
     <power>
       <id>c59c1bb0-9b3e-41be-9079-8982b451fe45</id>
       <name>Hang Time</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -899,34 +899,34 @@
     <power>
       <id>da59618c-059d-4cc5-adb5-c61e6049378c</id>
       <name>Inertia Strike</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
       <action>Free</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>830de0b7-8d83-467b-91e4-ce10081838b0</id>
       <name>Keratin Control</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>1</page>
       <action>Free</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>e1e242c3-cb63-476f-9868-90c311b36383</id>
       <name>Kinesics Mastery</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -945,7 +945,7 @@
     <power>
       <id>44f0bbba-184a-4e76-93de-19862ac6607b</id>
       <name>Linguistics</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -962,17 +962,17 @@
       <limit>1</limit>
       <source>SG</source>
       <page>1</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
     </power>
     <power>
       <id>d20f0441-a290-4732-829f-3138d446aad4</id>
       <name>Magic Sense</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -985,22 +985,22 @@
     <power>
       <id>2149818a-22b0-4267-83d6-7b3c27d4ee69</id>
       <name>Melanin Control</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>ecd611b4-dda6-4683-b7a9-850a469a3274</id>
       <name>Metabolic Control</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1019,7 +1019,7 @@
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1039,12 +1039,12 @@
     <power>
       <id>930ace31-a2a2-4616-8dfb-1074e4be76c9</id>
       <name>Motion Sense</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>172</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1064,7 +1064,7 @@
       <limit>1</limit>
       <source>SG</source>
       <page>173</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1077,7 +1077,7 @@
     <power>
       <id>1ec402f1-6139-4f94-8e86-92aa463bf536</id>
       <name>Nimble Fingers</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -1105,12 +1105,12 @@
       <limit>1</limit>
       <source>SG</source>
       <page>173</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
     </power>
     <power>
       <id>70311f5c-a019-47b9-be21-e9a8d270e32e</id>
       <name>Penetrating Strike</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -1123,23 +1123,23 @@
     <power>
       <id>941225f2-148b-484e-a2b2-0a32cc7debe1</id>
       <name>Plague Cloud</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>173</page>
       <action>Free</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>832a418d-4d55-433c-8230-4b04f05ba6d9</id>
       <name>Rapid Draw</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>173</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1152,13 +1152,13 @@
     <power>
       <id>11f3fa59-e06d-4816-87a9-b74664d1ae9a</id>
       <name>Riposte</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>174</page>
       <action>Interrupt</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>c0d647dd-4f66-42a6-9040-202b1bba4b71</id>
@@ -1168,7 +1168,7 @@
       <limit>1</limit>
       <source>SG</source>
       <page>174</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1187,12 +1187,12 @@
       <limit>1</limit>
       <source>SG</source>
       <page>174</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
     </power>
     <power>
       <id>24bc482d-9ce3-4d0a-bd43-31311b6716d6</id>
       <name>Spirit Claw</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -1202,13 +1202,13 @@
     <power>
       <id>6145977c-5825-4358-b0db-1d189cd9d402</id>
       <name>Spirit Ram</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>174</page>
       <action>Simple</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1221,7 +1221,7 @@
     <power>
       <id>02eb1616-9361-47a8-acc8-030566d9a0ea</id>
       <name>Stillness</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -1231,7 +1231,7 @@
     <power>
       <id>772e0298-8abf-42b7-9734-359cadcb8d1e</id>
       <name>Sustenance</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -1240,7 +1240,7 @@
     <power>
       <id>bf425bd4-f112-4218-b729-2e8bb32f3b2b</id>
       <name>Temperature Tolerance</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SG</source>
@@ -1253,12 +1253,12 @@
     <power>
       <id>61406917-9d88-440f-a756-16bdf6ffb37e</id>
       <name>Three-Dimensional Memory</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SG</source>
       <page>175</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <adeptwayrequires>
         <required>
           <oneof>
@@ -1273,13 +1273,13 @@
     <power>
       <id>6ed1a784-1097-4db8-b179-e4198493c2f0</id>
       <name>Toxic Strike</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SG</source>
       <page>176</page>
       <action>Simple</action>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
       <bonus>
         <selecttext />
       </bonus>
@@ -1294,12 +1294,12 @@
     <power>
       <id>0f0a55a8-5c39-4568-a15d-219b3664b10f</id>
       <name>Feign Illness</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>BB</source>
       <page>22</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>ca35c065-86ab-4aa8-a52f-ae37cc69648c</id>
@@ -1309,7 +1309,7 @@
       <limit>1</limit>
       <source>BB</source>
       <page>22</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
     </power>
     <power>
       <id>d890df94-b4f0-4b56-8289-7e1cfac2a95d</id>
@@ -1319,14 +1319,14 @@
       <limit>1</limit>
       <source>BB</source>
       <page>22</page>
-      <adeptway>.5</adeptway>
+      <adeptway>0.5</adeptway>
     </power>
     <!-- End Region -->
     <!-- Region Stolen Souls -->
     <power>
       <id>b6982580-fb86-4ac8-9312-98459ecbe811</id>
       <name>Light Touch</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>100</limit>
       <source>SS</source>
@@ -1335,7 +1335,7 @@
     <power>
       <id>60ac2e3a-d24a-459c-b8a4-cf648f0de447</id>
       <name>Mimic</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>6</limit>
       <source>SS</source>
@@ -1356,7 +1356,7 @@
     <power>
       <id>89f8d4a8-a769-4a3c-9009-f0371e42daf8</id>
       <name>Demara</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1366,7 +1366,7 @@
     <power>
       <id>57e7de72-6155-486b-9269-caebedfb34fe</id>
       <name>Eidetic Sense Memory</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1376,7 +1376,7 @@
     <power>
       <id>51755f26-c5d4-461d-bd59-496a45b03e6b</id>
       <name>Enthralling Performance</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>100</limit>
       <source>SSP</source>
@@ -1386,7 +1386,7 @@
     <power>
       <id>df257b19-9ef7-4f0b-9aaa-4dbc43372431</id>
       <name>Heightened Concentration</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1404,7 +1404,7 @@
     <power>
       <id>d75638f3-be99-4f65-b61f-ea8b4b249f92</id>
       <name>Indomitable Will</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1413,7 +1413,7 @@
     <power>
       <id>bde8c111-b429-4283-87ca-9d3a2afc0215</id>
       <name>Iron Gut</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1425,7 +1425,7 @@
     <power>
       <id>bee8413d-ad32-4c0b-998e-b38f2728d417</id>
       <name>Iron Lungs</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1437,7 +1437,7 @@
     <power>
       <id>ad169692-909f-4945-a3b8-fc0d19e2ed28</id>
       <name>Iron Will</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1450,7 +1450,7 @@
     <power>
       <id>489a28c7-c4a2-4071-9f5a-35c0e333f589</id>
       <name>Keratin Control</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1471,7 +1471,7 @@
     <power>
       <id>29761d0e-072e-48a9-afc6-6154af8b2262</id>
       <name>Maintain Warmth</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1480,7 +1480,7 @@
     <power>
       <id>35a76113-84fb-4f9d-b47d-f7fb491e6285</id>
       <name>Memory Displacement</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1490,7 +1490,7 @@
     <power>
       <id>57cea4cd-754b-4fcd-8711-75721b1edc15</id>
       <name>Piercing Senses</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1561,7 +1561,7 @@
     <power>
       <id>79eda3bf-f81b-4db7-9cb9-d22255c99e12</id>
       <name>Rooting</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>SSP</source>
@@ -1604,17 +1604,17 @@
     <power>
       <id>9646a0b8-ab39-4499-85cf-1ffd9983d0a5</id>
       <name>Adept Accident</name>
-      <points>.5</points>
+      <points>0.5</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>HT</source>
       <page>190</page>
-      <adeptway>.25</adeptway>
+      <adeptway>0.25</adeptway>
     </power>
     <power>
       <id>c2ea9046-647d-4104-871a-24b3ee1fecfa</id>
       <name>Focused Archery</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>HT</source>
@@ -1624,7 +1624,7 @@
     <power>
       <id>857fcf19-78ce-427a-a1e8-077e52aab759</id>
       <name>Kiai</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>HT</source>
@@ -1652,7 +1652,7 @@
     <power>
       <id>18da4f2f-f813-4d17-8b7b-29b2751e9cfa</id>
       <name>Precision Throwing</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>HT</source>
@@ -1689,7 +1689,7 @@
     <power>
       <id>7a5084df-b4d2-4f2a-84aa-43627f43c240</id>
       <name>Lie Detector</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>1</limit>
       <source>CA</source>
@@ -1701,7 +1701,7 @@
     <power>
       <id>e2b791c0-54ef-4843-ab70-12a08767699a</id>
       <name>Osmosis</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>True</levels>
       <limit>6</limit>
       <source>CA</source>
@@ -1715,7 +1715,7 @@
     <power>
       <id>93b7663e-30da-468b-83cf-dc07439bcae2</id>
       <name>Ventriloquism</name>
-      <points>.25</points>
+      <points>0.25</points>
       <levels>False</levels>
       <limit>1</limit>
       <source>CA</source>


### PR DESCRIPTION
In other languages than English (e.g. French and German) '0.5' is written '0,5' (comma instead of point).

As written '.5' for needed power points is more confusing than '0.5' (at first glance it seems cutted off) I added zeros to all 'points'- and 'adeptway'-values.