### PR TITLE
Added a missing translation tag for adept power source label.

### DIFF
--- a/Chummer/Selection Forms/frmSelectPower.Designer.cs
+++ b/Chummer/Selection Forms/frmSelectPower.Designer.cs
@@ -139,6 +139,7 @@ namespace Chummer
             this.lblSourceLabel.Name = "lblSourceLabel";
             this.lblSourceLabel.Size = new System.Drawing.Size(44, 13);
             this.lblSourceLabel.TabIndex = 4;
+            this.lblSourceLabel.Tag = "Label_Source";
             this.lblSourceLabel.Text = "Source:";
             // 
             // txtSearch


### PR DESCRIPTION
Solves #3207 