### PR TITLE
Fixed double use of guid 'd2a1cc9b-72e3-49df-957c-8ed6fb47a813'

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -17920,7 +17920,7 @@
       <cost>750</cost>
     </gear>
     <gear>
-      <id>d2a1cc9b-72e3-49df-957c-8ed6fb47a813</id>
+      <id>fb7465a7-4691-4647-a82c-a7b486fab34a</id>
       <name>Narcojet Dazzler</name>
       <category>Survival Gear</category>
       <rating>0</rating>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -18391,7 +18391,7 @@
 				<altpage>59</altpage>
 			</gear>
 			<gear translated="True">
-				<id>d2a1cc9b-72e3-49df-957c-8ed6fb47a813</id>
+				<id>fb7465a7-4691-4647-a82c-a7b486fab34a</id>
 				<name>Narcojet Dazzler</name>
 				<translate>Narcojet Dazzler</translate>
 				<altpage>46</altpage>

--- a/Chummer/lang/fr-fr_data.xml
+++ b/Chummer/lang/fr-fr_data.xml
@@ -18407,7 +18407,7 @@
 				<altpage>48</altpage>
 			</gear>
 			<gear>
-				<id>d2a1cc9b-72e3-49df-957c-8ed6fb47a813</id>
+				<id>fb7465a7-4691-4647-a82c-a7b486fab34a</id>
 				<name>Narcojet Dazzler</name>
 				<translate>Éblouisseur Narcoject</translate>
 				<altpage>46</altpage>


### PR DESCRIPTION
Same GUID was used for 'Narcojet Dazzler' (gear) and 'Additional Clip/Magazine' (weapon)