### PR TITLE
Fixed an issue, where the PDF offset setting would reset

### DIFF
--- a/Chummer/frmOptions.cs
+++ b/Chummer/frmOptions.cs
@@ -458,7 +458,8 @@ namespace Chummer
                 bool blnOldLoading = _blnLoading;
                 _blnLoading = true;
                 txtPDFLocation.Text = string.Empty;
-                nudPDFOffset.Value = 0;
+                nudPDFOffset.Enabled = false;
+                nudPDFOffset.Enabled = true;
                 _blnLoading = blnOldLoading;
                 txtPDFLocation.Text = objSource.Path;
                 nudPDFOffset.Value = objSource.Offset;


### PR DESCRIPTION
Fixes #3180 

I think the problem was that `nudPDFOffset.Value` was being set to 0, which would trigger the `nudPDFOffset_ValueChanged` and 0 would be stored as a setting.

I don't know exactly what the purpose of `_blnLoading` is in that case, but disabling and enabling the number box seems to not interfere with the previous functionality, and the issue is now gone.