### PR TITLE
Fixes to German translation

### DIFF
--- a/Chummer/lang/de-de.xml
+++ b/Chummer/lang/de-de.xml
@@ -6525,7 +6525,7 @@
 		</string>
 		<string>
 			<key>Checkbox_Options_DatesIncludeTime</key>
-			<text>Unkosten mit Zeitangabe anzeigen.</text>
+			<text>Zu Ausgaben soll die Uhrzeit angezeigt werden</text>
 		</string>
 		<!-- Version 455 -->
 		<string>

--- a/Chummer/sheets/de-de/xz.language.xslt
+++ b/Chummer/sheets/de-de/xz.language.xslt
@@ -118,7 +118,7 @@
   <xsl:variable name="lang.Health"    select="'Heilung'"/>
   <xsl:variable name="lang.Heavy"    select="'Schwer'"/>
   <xsl:variable name="lang.Height"    select="'Größe'"/>
-  <xsl:variable name="lang.hit"      select="'hit'"/>
+  <xsl:variable name="lang.hit"      select="'Erfolg'"/>
   <xsl:variable name="lang.Illusion"    select="'Illusion'"/>
   <xsl:variable name="lang.Implant"    select="'Implantat'"/>
   <xsl:variable name="lang.Indirect"      select="'Indirekt'"/>


### PR DESCRIPTION
Replacing 'Unkosten ...' with a more accurate translation and adding translation to 'Hits' in the character sheet