### PR TITLE
Textbox now shows translation of selected improvement.

### DIFF
--- a/Chummer/frmCreateImprovement.Designer.cs
+++ b/Chummer/frmCreateImprovement.Designer.cs
@@ -50,6 +50,7 @@ namespace Chummer
             this.chkFree = new System.Windows.Forms.CheckBox();
             this.tlpMain = new System.Windows.Forms.TableLayoutPanel();
             this.flowLayoutPanel1 = new System.Windows.Forms.FlowLayoutPanel();
+            this.txtTranslateSelection = new System.Windows.Forms.TextBox();
             ((System.ComponentModel.ISupportInitialize)(this.nudVal)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMin)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.nudMax)).BeginInit();
@@ -252,11 +253,12 @@ namespace Chummer
             this.txtSelect.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.tlpMain.SetColumnSpan(this.txtSelect, 2);
-            this.txtSelect.Location = new System.Drawing.Point(107, 56);
+            this.txtSelect.Location = new System.Drawing.Point(107, 189);
             this.txtSelect.Name = "txtSelect";
             this.txtSelect.ReadOnly = true;
             this.txtSelect.Size = new System.Drawing.Size(157, 20);
             this.txtSelect.TabIndex = 5;
+            this.txtSelect.Visible = false;
             // 
             // cmdChangeSelection
             // 
@@ -326,7 +328,6 @@ namespace Chummer
             this.tlpMain.Controls.Add(this.cmdChangeSelection, 3, 2);
             this.tlpMain.Controls.Add(this.lblHelp, 4, 0);
             this.tlpMain.Controls.Add(this.nudMin, 1, 4);
-            this.tlpMain.Controls.Add(this.txtSelect, 1, 2);
             this.tlpMain.Controls.Add(this.cboImprovemetType, 1, 0);
             this.tlpMain.Controls.Add(this.txtName, 1, 1);
             this.tlpMain.Controls.Add(this.nudVal, 1, 3);
@@ -334,6 +335,8 @@ namespace Chummer
             this.tlpMain.Controls.Add(this.lblSelect, 0, 2);
             this.tlpMain.Controls.Add(this.lblVal, 0, 3);
             this.tlpMain.Controls.Add(this.flowLayoutPanel1, 0, 8);
+            this.tlpMain.Controls.Add(this.txtSelect, 1, 7);
+            this.tlpMain.Controls.Add(this.txtTranslateSelection, 1, 2);
             this.tlpMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpMain.Location = new System.Drawing.Point(9, 9);
             this.tlpMain.Name = "tlpMain";
@@ -347,6 +350,9 @@ namespace Chummer
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
+            this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
             this.tlpMain.Size = new System.Drawing.Size(686, 263);
             this.tlpMain.TabIndex = 20;
             // 
@@ -363,6 +369,17 @@ namespace Chummer
             this.flowLayoutPanel1.Name = "flowLayoutPanel1";
             this.flowLayoutPanel1.Size = new System.Drawing.Size(156, 23);
             this.flowLayoutPanel1.TabIndex = 20;
+            // 
+            // txtTranslateSelection
+            // 
+            this.txtTranslateSelection.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tlpMain.SetColumnSpan(this.txtTranslateSelection, 2);
+            this.txtTranslateSelection.Location = new System.Drawing.Point(107, 56);
+            this.txtTranslateSelection.Name = "txtTranslateSelection";
+            this.txtTranslateSelection.ReadOnly = true;
+            this.txtTranslateSelection.Size = new System.Drawing.Size(157, 20);
+            this.txtTranslateSelection.TabIndex = 21;
             // 
             // frmCreateImprovement
             // 
@@ -420,5 +437,6 @@ namespace Chummer
         private System.Windows.Forms.CheckBox chkFree;
         private System.Windows.Forms.TableLayoutPanel tlpMain;
         private System.Windows.Forms.FlowLayoutPanel flowLayoutPanel1;
+        private System.Windows.Forms.TextBox txtTranslateSelection;
     }
 }

--- a/Chummer/frmCreateImprovement.cs
+++ b/Chummer/frmCreateImprovement.cs
@@ -234,39 +234,38 @@ namespace Chummer
                     }
                     break;
                 case "SelectSpecialAttribute":
-                {
-                    // TODO: Fix formatting
-                    List<string> lstAbbrevs = new List<string>(Backend.Attributes.AttributeSection.AttributeStrings);
-                    lstAbbrevs.RemoveAll(x => Backend.Attributes.AttributeSection.PhysicalAttributes.Contains(x) || Backend.Attributes.AttributeSection.MentalAttributes.Contains(x));
-                    lstAbbrevs.Remove("ESS");
-                    /*
-                    if (!_objCharacter.MAGEnabled)
                     {
-                        lstAbbrevs.Remove("MAG");
-                        lstAbbrevs.Remove("MAGAdept");
+                        List<string> lstAbbrevs = new List<string>(Backend.Attributes.AttributeSection.AttributeStrings);
+                        lstAbbrevs.RemoveAll(x => Backend.Attributes.AttributeSection.PhysicalAttributes.Contains(x) || Backend.Attributes.AttributeSection.MentalAttributes.Contains(x));
+                        lstAbbrevs.Remove("ESS");
+                        /*
+                        if (!_objCharacter.MAGEnabled)
+                        {
+                            lstAbbrevs.Remove("MAG");
+                            lstAbbrevs.Remove("MAGAdept");
+                        }
+                        else if (!_objCharacter.IsMysticAdept || !_objCharacter.Options.MysAdeptSecondMAGAttribute)
+                            lstAbbrevs.Remove("MAGAdept");
+
+                        if (!_objCharacter.RESEnabled)
+                            lstAbbrevs.Remove("RES");
+                        if (!_objCharacter.DEPEnabled)
+                            lstAbbrevs.Remove("DEP");
+                            */
+                        frmSelectAttribute frmPickAttribute = new frmSelectAttribute(lstAbbrevs.ToArray())
+                        {
+                            Description = LanguageManager.GetString("Title_SelectAttribute", GlobalOptions.Language)
+                        };
+
+                        frmPickAttribute.ShowDialog(this);
+
+                        if (frmPickAttribute.DialogResult == DialogResult.OK)
+                        {
+                            txtSelect.Text = frmPickAttribute.SelectedAttribute;
+                            txtTranslateSelection.Text = TranslateField(_strSelect, frmPickAttribute.SelectedAttribute);
+                        }
+
                     }
-                    else if (!_objCharacter.IsMysticAdept || !_objCharacter.Options.MysAdeptSecondMAGAttribute)
-                        lstAbbrevs.Remove("MAGAdept");
-
-                    if (!_objCharacter.RESEnabled)
-                        lstAbbrevs.Remove("RES");
-                    if (!_objCharacter.DEPEnabled)
-                        lstAbbrevs.Remove("DEP");
-                        */
-                    frmSelectAttribute frmPickAttribute = new frmSelectAttribute(lstAbbrevs.ToArray())
-                    {
-                        Description = LanguageManager.GetString("Title_SelectAttribute", GlobalOptions.Language)
-                    };
-
-                    frmPickAttribute.ShowDialog(this);
-
-                    if (frmPickAttribute.DialogResult == DialogResult.OK)
-                    {
-                        txtSelect.Text = frmPickAttribute.SelectedAttribute;
-                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickAttribute.SelectedAttribute);
-                    }
-                        
-                }
                     break;
                 case "SelectSkill":
                     {

--- a/Chummer/frmCreateImprovement.cs
+++ b/Chummer/frmCreateImprovement.cs
@@ -77,8 +77,13 @@ namespace Chummer
                     nudVal.Value = _objEditImprovement.CustomId == "specificattribute" ? _objEditImprovement.Augmented : _objEditImprovement.Value;
                 }
                 chkApplyToRating.Checked = chkApplyToRating.Visible && _objEditImprovement.AddToRating;
-                if (txtSelect.Visible)
+                if (txtTranslateSelection.Visible)
+                {
                     txtSelect.Text = _objEditImprovement.ImprovedName;
+                    // get the selection type of improvement and generate translation
+                    XmlNode objFetchNode = _objDocument.SelectSingleNode("/chummer/improvements/improvement[id = \"" + cboImprovemetType.SelectedValue + "\"]/fields/field");
+                    txtTranslateSelection.Text = TranslateField(objFetchNode.InnerText, _objEditImprovement.ImprovedName);
+                }
             }
             cboImprovemetType.EndUpdate();
         }
@@ -113,6 +118,7 @@ namespace Chummer
             lblSelect.Visible = false;
             txtSelect.Visible = false;
             txtSelect.Text = string.Empty;
+            txtTranslateSelection.Text = string.Empty;
             cmdChangeSelection.Visible = false;
             _strSelect = string.Empty;
 
@@ -149,7 +155,7 @@ namespace Chummer
                             if (objNode.InnerText.StartsWith("Select"))
                             {
                                 lblSelect.Visible = true;
-                                txtSelect.Visible = true;
+                                txtTranslateSelection.Visible = true;
                                 cmdChangeSelection.Visible = true;
                                 _strSelect = objNode.InnerText;
                             }
@@ -189,7 +195,10 @@ namespace Chummer
                         frmPickAttribute.ShowDialog(this);
 
                         if (frmPickAttribute.DialogResult == DialogResult.OK)
+                        {
                             txtSelect.Text = frmPickAttribute.SelectedAttribute;
+                            txtTranslateSelection.Text = TranslateField(_strSelect, frmPickAttribute.SelectedAttribute);
+                        }
                     }
                     break;
                 case "SelectMentalAttribute":
@@ -202,7 +211,10 @@ namespace Chummer
                         frmPickAttribute.ShowDialog(this);
 
                         if (frmPickAttribute.DialogResult == DialogResult.OK)
+                        {
                             txtSelect.Text = frmPickAttribute.SelectedAttribute;
+                            txtTranslateSelection.Text = TranslateField(_strSelect, frmPickAttribute.SelectedAttribute);
+                        }
                     }
                     break;
                 case "SelectPhysicalAttribute":
@@ -215,11 +227,15 @@ namespace Chummer
                         frmPickAttribute.ShowDialog(this);
 
                         if (frmPickAttribute.DialogResult == DialogResult.OK)
+                        {
                             txtSelect.Text = frmPickAttribute.SelectedAttribute;
+                            txtTranslateSelection.Text = TranslateField(_strSelect, frmPickAttribute.SelectedAttribute);
+                        }
                     }
                     break;
                 case "SelectSpecialAttribute":
                 {
+                    // TODO: Fix formatting
                     List<string> lstAbbrevs = new List<string>(Backend.Attributes.AttributeSection.AttributeStrings);
                     lstAbbrevs.RemoveAll(x => Backend.Attributes.AttributeSection.PhysicalAttributes.Contains(x) || Backend.Attributes.AttributeSection.MentalAttributes.Contains(x));
                     lstAbbrevs.Remove("ESS");
@@ -245,7 +261,11 @@ namespace Chummer
                     frmPickAttribute.ShowDialog(this);
 
                     if (frmPickAttribute.DialogResult == DialogResult.OK)
+                    {
                         txtSelect.Text = frmPickAttribute.SelectedAttribute;
+                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickAttribute.SelectedAttribute);
+                    }
+                        
                 }
                     break;
                 case "SelectSkill":
@@ -257,7 +277,10 @@ namespace Chummer
                         frmPickSkill.ShowDialog(this);
 
                         if (frmPickSkill.DialogResult == DialogResult.OK)
+                        {
                             txtSelect.Text = frmPickSkill.SelectedSkill;
+                            txtTranslateSelection.Text = TranslateField(_strSelect, frmPickSkill.SelectedSkill);
+                        }  
                     }
                     break;
                 case "SelectKnowSkill":
@@ -307,7 +330,10 @@ namespace Chummer
                         frmPickSkill.ShowDialog(this);
 
                         if (frmPickSkill.DialogResult == DialogResult.OK)
+                        {
                             txtSelect.Text = frmPickSkill.SelectedItem;
+                            txtTranslateSelection.Text = TranslateField(_strSelect, frmPickSkill.SelectedItem);
+                        }
                     }
                     break;
                 case "SelectSkillCategory":
@@ -318,7 +344,11 @@ namespace Chummer
                     frmPickSkillCategory.ShowDialog(this);
 
                     if (frmPickSkillCategory.DialogResult == DialogResult.OK)
+                    {
                         txtSelect.Text = frmPickSkillCategory.SelectedCategory;
+                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickSkillCategory.SelectedCategory);
+                    }
+                       
                     break;
                 case "SelectSkillGroup":
                     frmSelectSkillGroup frmPickSkillGroup = new frmSelectSkillGroup
@@ -328,7 +358,11 @@ namespace Chummer
                     frmPickSkillGroup.ShowDialog(this);
 
                     if (frmPickSkillGroup.DialogResult == DialogResult.OK)
+                    {
                         txtSelect.Text = frmPickSkillGroup.SelectedSkillGroup;
+                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickSkillGroup.SelectedSkillGroup);
+                    }
+                        
                     break;
                 case "SelectWeaponCategory":
                     frmSelectWeaponCategory frmPickWeaponCategory = new frmSelectWeaponCategory
@@ -338,7 +372,10 @@ namespace Chummer
                     frmPickWeaponCategory.ShowDialog(this);
 
                     if (frmPickWeaponCategory.DialogResult == DialogResult.OK)
+                    {
                         txtSelect.Text = frmPickWeaponCategory.SelectedCategory;
+                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickWeaponCategory.SelectedCategory);
+                    }
                     break;
                 case "SelectSpellCategory":
                     frmSelectSpellCategory frmPickSpellCategory = new frmSelectSpellCategory
@@ -348,14 +385,20 @@ namespace Chummer
                     frmPickSpellCategory.ShowDialog(this);
 
                     if (frmPickSpellCategory.DialogResult == DialogResult.OK)
+                    {
                         txtSelect.Text = frmPickSpellCategory.SelectedCategory;
+                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickSpellCategory.SelectedCategory);
+                    }                     
                     break;
                 case "SelectAdeptPower":
                     frmSelectPower frmPickPower = new frmSelectPower(_objCharacter);
                     frmPickPower.ShowDialog(this);
 
                     if (frmPickPower.DialogResult == DialogResult.OK)
+                    {
                         txtSelect.Text = XmlManager.Load("powers.xml").SelectSingleNode("/chummer/powers/power[id = \"" + frmPickPower.SelectedPower + "\"]/name")?.InnerText;
+                        txtTranslateSelection.Text = TranslateField(_strSelect, frmPickPower.SelectedPower);
+                    }
                     break;
             }
         }
@@ -368,7 +411,7 @@ namespace Chummer
         private void AcceptForm()
         {
             // Make sure a value has been selected if necessary.
-            if (txtSelect.Visible && string.IsNullOrEmpty(txtSelect.Text))
+            if (txtTranslateSelection.Visible && string.IsNullOrEmpty(txtSelect.Text))
             {
                 MessageBox.Show(LanguageManager.GetString("Message_SelectItem", GlobalOptions.Language), LanguageManager.GetString("MessageTitle_SelectItem", GlobalOptions.Language), MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
@@ -463,6 +506,58 @@ namespace Chummer
             else {Utils.BreakIfDebug();}
 
             DialogResult = DialogResult.OK;
+        }
+
+        /// <summary>
+        /// Returns a current language translation given an improvement name.
+        /// </summary>
+        /// <param name="strImprovementType"> The selector for the target translation. Often just _strSelect. </param>
+        /// <param name="strToTranslate"> The string which to translate. Usually name. Guid in the case of adept powers.</param>
+        /// <returns></returns>
+        private string TranslateField(string strImprovementType, string strToTranslate)
+        {
+            XmlNode objXmlNode;
+            switch (strImprovementType)
+            {
+                case "SelectAttribute":
+                case "SelectPhysicalAttribute":
+                case "SelectMentalAttribute":
+                case "SelectSpecialAttribute":
+                    return strToTranslate == "MAGAdept"
+                    ? LanguageManager.GetString("String_AttributeMAGShort", GlobalOptions.Language) + " (" + LanguageManager.GetString("String_DescAdept", GlobalOptions.Language) + ')'
+                    : LanguageManager.GetString("String_Attribute" + strToTranslate + "Short", GlobalOptions.Language);
+
+                case "SelectSkill":
+                    objXmlNode = XmlManager.Load("skills.xml").SelectSingleNode("/chummer/skills/skill[name = \"" + strToTranslate + "\"]");
+                    return objXmlNode.SelectSingleNode("translate")?.InnerText ?? objXmlNode.SelectSingleNode("name").InnerText;
+
+                case "SelectKnowSkill":
+                    objXmlNode = XmlManager.Load("skills.xml").SelectSingleNode("/chummer/knowledgeskills/skill[name = \"" + strToTranslate + "\"]");
+                    return objXmlNode.SelectSingleNode("translate")?.InnerText ?? objXmlNode.SelectSingleNode("name").InnerText;
+
+                case "SelectSkillCategory":
+                    objXmlNode = XmlManager.Load("skills.xml").SelectSingleNode("/chummer/categories/category[. = \"" + strToTranslate + "\"]");
+                    return objXmlNode.Attributes?["translate"]?.InnerText ?? objXmlNode.SelectSingleNode(".").InnerText;
+
+                case "SelectSkillGroup":
+                    objXmlNode = XmlManager.Load("skills.xml").SelectSingleNode("/chummer/skillgroups/name[. = \"" + strToTranslate + "\"]");
+                    return objXmlNode.Attributes?["translate"]?.InnerText ?? objXmlNode.SelectSingleNode(".").InnerText;
+
+                case "SelectWeaponCategory":
+                    objXmlNode = XmlManager.Load("weapons.xml").SelectSingleNode("/chummer/categories/category[. = \"" + strToTranslate + "\"]");
+                    return objXmlNode.Attributes?["translate"]?.InnerText ?? objXmlNode.SelectSingleNode(".").InnerText;
+
+                case "SelectSpellCategory":
+                    objXmlNode = XmlManager.Load("spells.xml").SelectSingleNode("/chummer/categories/category[. = \"" + strToTranslate + "\"]");
+                    return objXmlNode.Attributes?["translate"]?.InnerText ?? objXmlNode.SelectSingleNode(".").InnerText;
+
+                case "SelectAdeptPower":
+                    objXmlNode = XmlManager.Load("powers.xml").SelectSingleNode("/chummer/powers/power[id = \"" + strToTranslate + "\" or name = \"" + strToTranslate + "\"]");
+                    return objXmlNode.SelectSingleNode("translate")?.InnerText ?? objXmlNode.SelectSingleNode("name").InnerText;
+
+                default:
+                    return strToTranslate;
+            }
         }
         #endregion
 


### PR DESCRIPTION
Fixes #3224 

The solution is a bit hacky in the sense that I added another TextBox (`txtTranslateSelection`), which would show the translation. The original `txtSelect` is set to invisible and moved lower in the frame, but is still updated, as the handling of the improvements relies on the English value of that TextBox.