### PR TITLE
German translation

### DIFF
--- a/Chummer/lang/de-de.xml
+++ b/Chummer/lang/de-de.xml
@@ -260,7 +260,7 @@
 		</string>
 		<string>
 			<key>Label_AP</key>
-			<text>PB:</text>
+			<text>DK:</text>
 		</string>
 		<string>
 			<key>Label_Ammo</key>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -30065,8 +30065,8 @@
 			<quality>
 				<id>5c49d5e2-ca52-406e-a532-8d4d148ea825</id>
 				<name>Hair Trigger</name>
-				<translate>Hair Trigger</translate>
-				<altpage>166</altpage>
+				<translate>⁦Virtuellkinetischer Blitz</translate>
+				<altpage>167</altpage>
 			</quality>
 			<quality translated="True">
 				<id>31e3097d-68c4-4140-969d-91bd43612afd</id>


### PR DESCRIPTION
Added translation for ‘hair trigger‘ (BTB)
Changed translation of ‘AP‘ from ‘PB‘ to ‘DK‘ as used in latest source books