### PR TITLE
Added MCT/Winchester-Grenade from SL

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -17908,7 +17908,6 @@
       <cost>5000</cost>
     </gear>
     <!-- End Region -->
-    <!-- End Region -->
     <!-- Region Street Lethal -->
     <gear>
       <id>be56ed13-cff0-47a8-b6ba-556f2313f64f</id>
@@ -17929,6 +17928,17 @@
       <page>46</page>
       <avail>15R</avail>
       <cost>1000</cost>
+    </gear>
+    <gear>
+      <id>2790877a-046e-4c93-be2d-1053fbafd6c0</id>
+      <name>Minigrenade: MCT/Winchester-Howe Hornet Direct-Fire</name>
+      <category>Ammunition</category>
+      <rating>0</rating>
+      <source>SL</source>
+      <page>132</page>
+      <avail>16F</avail>
+      <addweapon>Minigrenade: MCT/Winchester-Howe Hornet Direct-Fire</addweapon>
+      <cost>400</cost>
     </gear>
     <!-- End Region -->
     <!-- Region Kill Code -->

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -14167,6 +14167,27 @@
         <spec>Grenade Launchers</spec>
         <useskill>Heavy Weapons</useskill>
     </weapon>
+    <weapon>
+      <id>c92b23e2-9b75-4590-99b2-b3c80048fdc2</id>
+      <name>Minigrenade: MCT/Winchester-Howe Hornet Direct-Fire</name>
+      <category>Gear</category>
+      <type>Ranged</type>
+      <conceal>-2</conceal>
+      <accuracy>0</accuracy>
+      <reach>0</reach>
+      <damage>Special</damage>
+      <ap>-</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <avail>16F</avail>
+      <cost>400</cost>
+      <source>SL</source>
+      <page>132</page>
+      <range>Grenade Launchers</range>
+      <spec>Grenade Launcher</spec>
+      <useskill>Heavy Weapons</useskill>
+    </weapon>
     <!-- End Region -->
     <!-- Region Hamburg -->    
 	<weapon>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -14167,27 +14167,6 @@
         <spec>Grenade Launchers</spec>
         <useskill>Heavy Weapons</useskill>
     </weapon>
-    <weapon>
-      <id>c92b23e2-9b75-4590-99b2-b3c80048fdc2</id>
-      <name>Minigrenade: MCT/Winchester-Howe Hornet Direct-Fire</name>
-      <category>Gear</category>
-      <type>Ranged</type>
-      <conceal>-2</conceal>
-      <accuracy>0</accuracy>
-      <reach>0</reach>
-      <damage>Special</damage>
-      <ap>-</ap>
-      <mode>0</mode>
-      <rc>0</rc>
-      <ammo>0</ammo>
-      <avail>16F</avail>
-      <cost>400</cost>
-      <source>SL</source>
-      <page>132</page>
-      <range>Grenade Launchers</range>
-      <spec>Grenade Launcher</spec>
-      <useskill>Heavy Weapons</useskill>
-    </weapon>
     <!-- End Region -->
     <!-- Region Hamburg -->    
 	<weapon>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -18685,6 +18685,12 @@
 				<translate>Manafäule</translate>
 				<altpage>163</altpage>
 			</gear>
+			<gear>
+				<id>2790877a-046e-4c93-be2d-1053fbafd6c0</id>
+				<name>Minigrenade: MCT/Winchester-Howe Hornet Direct-Fire</name>
+				<translate>Minigranate: MCT/Winchester-Howe Hornet</translate>
+				<altpage>139</altpage>
+			</gear>
 		</gears>
 	</chummer>
 	<chummer file="lifestyles.xml">


### PR DESCRIPTION
Added missing Minigrenade from SL (should finally fix https://github.com/chummer5a/chummer5a/issues/3254 since the three weapons have already been added with https://github.com/chummer5a/chummer5a/pull/3248/commits/9e2623eab9670f1264ce6ebc91572d2792d72b86 )