### PR TITLE
BMP accessories

### DIFF
--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -4703,6 +4703,7 @@ namespace Chummer
                 WeaponAccessory objAccessory = new WeaponAccessory(CharacterObject);
                 objAccessory.Create(objXmlWeapon, frmPickWeaponAccessory.SelectedMount, frmPickWeaponAccessory.SelectedRating);
                 objAccessory.Parent = objWeapon;
+                objAccessory.DiscountCost = frmPickWeaponAccessory.BlackMarketDiscount;
 
                 if (frmPickWeaponAccessory.FreeCost)
                 {
@@ -5112,6 +5113,7 @@ namespace Chummer
                 WeaponAccessory objAccessory = new WeaponAccessory(CharacterObject);
                 objAccessory.Create(objXmlWeapon, frmPickWeaponAccessory.SelectedMount, frmPickWeaponAccessory.SelectedRating);
                 objAccessory.Parent = objWeapon;
+                objAccessory.DiscountCost = frmPickWeaponAccessory.BlackMarketDiscount;
 
                 if (frmPickWeaponAccessory.FreeCost)
                 {

--- a/Chummer/Selection Forms/frmSelectGear.cs
+++ b/Chummer/Selection Forms/frmSelectGear.cs
@@ -159,7 +159,7 @@ namespace Chummer
             // Select the first Category in the list.
             if (!string.IsNullOrEmpty(s_StrSelectCategory))
                 cboCategory.SelectedValue = s_StrSelectCategory;
-            if (cboCategory.SelectedIndex == -1)
+            if (cboCategory.SelectedIndex == -1 && cboCategory.Items.Count > 0)
                 cboCategory.SelectedIndex = 0;
             else
                 RefreshList(cboCategory.SelectedValue?.ToString());

--- a/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
+++ b/Chummer/Selection Forms/frmSelectWeaponAccessory.cs
@@ -579,6 +579,9 @@ namespace Chummer
                     // Apply any markup.
                     decCost *= 1 + (nudMarkup.Value / 100.0m);
 
+                    if (chkBlackMarketDiscount.Checked)
+                        decCost *= 0.9m;
+
                     lblCost.Text = decCost.ToString(_objCharacter.Options.NuyenFormat, GlobalOptions.CultureInfo) + '¥';
                     lblTest.Text = _objCharacter.AvailTest(decCost, lblAvail.Text);
                 }


### PR DESCRIPTION
Lets weapon accessories benefit from the black market pipeline if it's active for weapons. The discount code was there, it just wasn't being set for accessories.

Also prevented the crash from issue #3251. The underlying issue sees to be related to add on categories not being populated in data, but with this we won't crash if the gear selection dropdown can't find any categories.