### PR TITLE
Removing Battle of Manhattan

### DIFF
--- a/Chummer/data/books.xml
+++ b/Chummer/data/books.xml
@@ -148,11 +148,6 @@
       <code>HS</code>
     </book>
     <book>
-      <id>9b88873f-61fa-4419-b733-49b96997bd42</id>
-      <name>Battle Of Manhattan</name>
-      <code>BOM</code>
-    </book>
-    <book>
       <id>2fba52dd-bc97-450f-9d07-e1d86885911d</id>
       <name>The Vladivostok Gauntlet</name>
       <code>TVG</code>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -3088,12 +3088,6 @@
 				<altcode>HS</altcode>
 			</book>
 			<book>
-				<id>9b88873f-61fa-4419-b733-49b96997bd42</id>
-				<name>Battle Of Manhattan</name>
-				<translate>Krieg um Manhattan</translate>
-				<altcode>BOM</altcode>
-			</book>
-			<book>
 				<id>6b37230a-dd55-4c3f-882d-0a1c6324a457</id>
 				<name>Splintered State</name>
 				<translate>Tödliche Fragmente</translate>

--- a/Chummer/lang/fr-fr_data.xml
+++ b/Chummer/lang/fr-fr_data.xml
@@ -3082,12 +3082,6 @@
 				<altcode>HS</altcode>
 			</book>
 			<book>
-				<id>9b88873f-61fa-4419-b733-49b96997bd42</id>
-				<name>Battle Of Manhattan</name>
-				<translate>Battle Of Manhattan</translate>
-				<altcode>BOM</altcode>
-			</book>
-			<book>
 				<id>2fba52dd-bc97-450f-9d07-e1d86885911d</id>
 				<name>The Vladivostok Gauntlet</name>
 				<translate>The Vladivostok Gauntlet</translate>

--- a/Chummer/lang/ja-jp_data.xml
+++ b/Chummer/lang/ja-jp_data.xml
@@ -3093,12 +3093,6 @@
 				<altcode>HS</altcode>
 			</book>
 			<book>
-				<id>9b88873f-61fa-4419-b733-49b96997bd42</id>
-				<name>Battle Of Manhattan</name>
-				<translate>Battle Of Manhattan</translate>
-				<altcode>BOM</altcode>
-			</book>
-			<book>
 				<id>2fba52dd-bc97-450f-9d07-e1d86885911d</id>
 				<name>The Vladivostok Gauntlet</name>
 				<translate>The Vladivostok Gauntlet</translate>

--- a/Chummer/lang/pt-br_data.xml
+++ b/Chummer/lang/pt-br_data.xml
@@ -2980,12 +2980,6 @@
 				<altcode>HS</altcode>
 			</book>
 			<book>
-				<id>9b88873f-61fa-4419-b733-49b96997bd42</id>
-				<name>Battle Of Manhattan</name>
-				<translate>Battle Of Manhattan</translate>
-				<altcode>BOM</altcode>
-			</book>
-			<book>
 				<id>2fba52dd-bc97-450f-9d07-e1d86885911d</id>
 				<name>The Vladivostok Gauntlet</name>
 				<translate>The Vladivostok Gauntlet</translate>


### PR DESCRIPTION
Since no equipment from the adventure book 'Battle of Manhattan' is used in Chummer5a, the book is not required in the list of source books and can be removed.