### PR TITLE
Removing SFM

### DIFF
--- a/Chummer/data/books.xml
+++ b/Chummer/data/books.xml
@@ -178,11 +178,6 @@
       <code>LCD</code>
     </book>
     <book>
-      <id>81c02566-af38-45e3-9e46-3b1d083f84f2</id>
-      <name>Shadows In Focus: San Francisco Metroplex</name>
-      <code>SFM</code>
-    </book>
-    <book>
       <id>ad384a90-33c2-40bd-b128-37117d02f36c</id>
       <name>Shadows In Focus: Metropole</name>
       <code>SFME</code>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -3142,12 +3142,6 @@
 				<altcode>HKS</altcode>
 			</book>
 			<book>
-				<id>81c02566-af38-45e3-9e46-3b1d083f84f2</id>
-				<name>Shadows In Focus: San Francisco Metroplex</name>
-				<translate>Shadows In Focus: San Francisco Metroplex</translate>
-				<altcode>SFM</altcode>
-			</book>
-			<book>
 				<id>ad384a90-33c2-40bd-b128-37117d02f36c</id>
 				<name>Shadows In Focus: Metropole</name>
 				<translate>Shadows In Focus: Metropole</translate>

--- a/Chummer/lang/fr-fr_data.xml
+++ b/Chummer/lang/fr-fr_data.xml
@@ -3118,12 +3118,6 @@
 				<altcode>LCD</altcode>
 			</book>
 			<book>
-				<id>81c02566-af38-45e3-9e46-3b1d083f84f2</id>
-				<name>Shadows In Focus: San Francisco Metroplex</name>
-				<translate>Shadows In Focus : San Francisco Metroplex</translate>
-				<altcode>SFM</altcode>
-			</book>
-			<book>
 				<id>ad384a90-33c2-40bd-b128-37117d02f36c</id>
 				<name>Shadows In Focus: Metropole</name>
 				<translate>Shadows In Focus : Metropole</translate>

--- a/Chummer/lang/ja-jp_data.xml
+++ b/Chummer/lang/ja-jp_data.xml
@@ -3129,12 +3129,6 @@
 				<altcode>LCD</altcode>
 			</book>
 			<book>
-				<id>81c02566-af38-45e3-9e46-3b1d083f84f2</id>
-				<name>Shadows In Focus: San Francisco Metroplex</name>
-				<translate>Shadows In Focus: San Francisco Metroplex</translate>
-				<altcode>SFM</altcode>
-			</book>
-			<book>
 				<id>ad384a90-33c2-40bd-b128-37117d02f36c</id>
 				<name>Shadows In Focus: Metropole</name>
 				<translate>Shadows In Focus: Metropole</translate>

--- a/Chummer/lang/pt-br_data.xml
+++ b/Chummer/lang/pt-br_data.xml
@@ -3016,12 +3016,6 @@
 				<altcode>LCD</altcode>
 			</book>
 			<book>
-				<id>81c02566-af38-45e3-9e46-3b1d083f84f2</id>
-				<name>Shadows In Focus: San Francisco Metroplex</name>
-				<translate>Shadows In Focus: San Francisco Metroplex</translate>
-				<altcode>SFM</altcode>
-			</book>
-			<book>
 				<id>40515dbc-fec6-4530-ba79-959cc8c54c61</id>
 				<name>Cutting Aces</name>
 				<translate>Cutting Aces</translate>


### PR DESCRIPTION
Since no equipment from the book 'Shadows In Focus: San Francisco Metroplex' is used in Chummer5a, the book is not required in the list of source books and can be removed.