### PR TITLE
Added German translation and custom rule/Adjustment to control rig

### DIFF
--- a/Chummer/customdata/German Data Changes - Availability and costs of Chameleon Suit/amend_chameleonsuit_armor.xml
+++ b/Chummer/customdata/German Data Changes - Availability and costs of Chameleon Suit/amend_chameleonsuit_armor.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<chummer>
+  <armors>
+	<armor>
+		<id>aacafde3-ff9a-4de0-85ac-3870645a9197</id>
+		<avail>12R</avail>
+		<cost>4500</cost>		
+	</armor>
+  </armors>
+</chummer>

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -312,7 +312,7 @@
       <category>Headware</category>
       <ess>Rating * 1</ess>
       <capacity>0</capacity>
-      <avail>Rating * 5</avail>
+      <avail>(Rating * 5)R</avail>
       <cost>FixedValues(43000,97000,208000)</cost>
       <source>SR5</source>
       <page>452</page>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -44777,6 +44777,12 @@
 	<chummer file="improvements.xml">
 		<improvements>
 			<improvement>
+				<id>actiondicepool</id>
+				<name>Action Dice-Pool Modifier</name>
+				<translate>Würfelpoolmodifikator für Aktionen</translate>
+				<altpage>Stellt die Anzahl der Kästchen ein, die der Charakter in seinem geistigen Zustandsmonitor hat. Positive Zahlen erhöhen die Anzahl der Kästchen im Zustandsmonitor. Negative Zahlen reduzieren die Anzahl der Kästchen im Zustandsmonitor.</altpage>
+			</improvement>
+			<improvement>
 				<id>specificattribute</id>
 				<name>Attribute</name>
 				<translate>Attribut</translate>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -8508,7 +8508,7 @@
 			<cyberware>
 				<id>4fd033ab-9a43-4ee0-9675-47414af3c8f4</id>
 				<name>Bone Lacing (Plastic)</name>
-				<translate>Kompositknochen (Plastik)</translate>
+				<translate>Kompositknochen (Kunststoff)</translate>
 				<altpage>460</altpage>
 			</cyberware>
 			<cyberware>


### PR DESCRIPTION
- Added German translation for new improvement 'Action Dice-Pool Modifier'
- Adjusted availability for control rig (see SR5 453), see https://github.com/chummer5a/chummer5a/issues/3349
- Added German custom rule for availability and cost of chameleon suit, as these values differ from the English (SR5 436) to the German (German SR5 440) rulebook, see https://github.com/chummer5a/chummer5a/issues/3349