### PR TITLE
Adjusted data entries

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -15417,7 +15417,7 @@
       <category>Nanogear</category>
       <rating>0</rating>
       <source>CF</source>
-      <page>152</page>
+      <page>154</page>
       <avail>10</avail>
       <cost>250</cost>
     </gear>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -11177,7 +11177,7 @@
       <damage>7P</damage>
       <ap>-</ap>
       <mode>SA/BF/FA</mode>
-      <rc>1</rc>
+      <rc>0</rc>
       <ammo>24(c)</ammo>
       <avail>15F</avail>
       <cost>1500</cost>
@@ -11217,7 +11217,7 @@
       <damage>7P</damage>
       <ap>-</ap>
       <mode>SA/BF/FA</mode>
-      <rc>1</rc>
+      <rc>0</rc>
       <ammo>24(c)</ammo>
       <avail>15F</avail>
       <cost>2000</cost>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -13486,7 +13486,7 @@
       <mode>SA</mode>
       <rc>0</rc>
       <ammo>6(m)x2</ammo>
-      <avail>12F</avail>
+      <avail>12R</avail>
       <cost>2000</cost>
       <source>SL</source>
       <page>39</page>


### PR DESCRIPTION
- adjusted rc-values for 'Glock MP Custodes (MPV)' and 'Glock MP Custodes (MPK)' to '0' so that it is '1(2)' with added bonuses from accessories
- adjusted page for 'Universal Sealant' (see https://github.com/chummer5a/chummer5a/issues/3379)