### PR TITLE
Adjusted BMW M8

### DIFF
--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -993,9 +993,9 @@
     <vehicle>
       <id>116f6efe-2bb0-4fd4-80de-c25d6fa721bd</id>
       <name>BMW M8</name>
-      <page>42</page>
-      <source>SHB</source>
-      <accel>2</accel>
+      <page>56</page>
+      <source>R5G</source>
+      <accel>3</accel>
       <armor>11</armor>
       <avail>10</avail>
       <body>12</body>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -37838,9 +37838,8 @@
 			<vehicle>
 				<id>116f6efe-2bb0-4fd4-80de-c25d6fa721bd</id>
 				<name>BMW M8</name>
-				<source>R5</source>
 				<translate>BMW M8</translate>
-				<altpage>53</altpage>
+				<altpage>56</altpage>
 			</vehicle>
 			<vehicle>
 				<id>2f46305b-6196-43d1-b748-2266c5f1dc08</id>


### PR DESCRIPTION
The vehicle 'BMW M8' is so far listed with 'Source: SHB'. I do not have this source book. However, the vehicle is also included in the German Rigger 5.0  ('R5G') and has almost the same values there. Only the acceleration is slightly higher with '3' instead of '2'.

Since the edition of Rigger 5.0 (in German 'Asphaltkrieger') is from the year 2016, this change could be considered as a correction.

So I suggest to change the source of 'BMW M8' from 'SHB' to 'R5G' (including new page numbers) and adjust the acceleration. Since the vast majority of German users probably owned R5 instead of SHB as their source book, I think this might be a good solution.

If I have missed something in the proposal or if I have made something worse: please let me know or reject the suggestion.