### PR TITLE
Added translation

### DIFF
--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -3219,6 +3219,12 @@
 				<translate>Ätherologie</translate>
 				<altcode>AET</altcode>
 			</book>
+			<book>
+				<id>e65d69fd-8717-4e2b-88b0-73bf7a22bca0</id>
+				<name>No Future</name>
+				<translate>Lifestyle 2080</translate>
+				<altcode>NF</altcode>
+			</book>
 		</books>
 	</chummer>
 	<chummer file="critterpowers.xml">

--- a/Chummer/lang/fr-fr.xml
+++ b/Chummer/lang/fr-fr.xml
@@ -9546,5 +9546,21 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
 			<key>String_ExpenseUpgradedCyberware</key>
 			<text>Cyberware modernisé</text>
 		</string>
+		<string>
+			<key>Message_OrphanedImprovements</key>
+			<text>Il y a des améliorations dans votre fichier de personnages qui ne peuvent pas être assignées. Dans la plupart des cas, il ne devrait pas être risqué de charger ce personnage. Mais vous devez faire une copie de sauvegarde de ce fichier de personnage.\n\nVoulez-vous continuer à charger le personnage et effacer ces améliorations ?</text>
+		</string>
+		<string>
+			<key>MessageTitle_OrphanedImprovements</key>
+			<text>Des améliorations inattribuables sont présentes</text>
+		</string>
+		<string>
+			<key>Checkbox_Wireless</key>
+			<text>WiFi activé</text>
+		</string>
+		<string>
+			<key>String_Wireless</key>
+			<text>WiFi</text>
+		</string>
 	</strings>
 </chummer>


### PR DESCRIPTION
As title for 'No Future' in German will be 'Lifestyle 2080' last one is used in translation file
Also strings for WiFi and orphaned improvements are translated to French