### PR TITLE
 #3576 Setting to choose which Internet Explorer version will be emulated for previewing charsheets

### DIFF
--- a/Chummer/Classes/clsOptions.cs
+++ b/Chummer/Classes/clsOptions.cs
@@ -174,7 +174,7 @@ namespace Chummer
         private static string _strDefaultCharacterSheet = DefaultCharacterSheetDefaultValue;
         private static bool _blnDatesIncludeTime = true;
         private static bool _blnPrintToFileFirst;
-        private static int _intEmulatedBrowserVersion;
+        private static int _intEmulatedBrowserVersion = 8;
         private static bool _lifeModuleEnabled;
         private static bool _blnDronemods;
         private static bool _blnDronemodsMaximumPilot;

--- a/Chummer/Classes/clsOptions.cs
+++ b/Chummer/Classes/clsOptions.cs
@@ -174,6 +174,7 @@ namespace Chummer
         private static string _strDefaultCharacterSheet = DefaultCharacterSheetDefaultValue;
         private static bool _blnDatesIncludeTime = true;
         private static bool _blnPrintToFileFirst;
+        private static int _intEmulatedBrowserVersion;
         private static bool _lifeModuleEnabled;
         private static bool _blnDronemods;
         private static bool _blnDronemodsMaximumPilot;
@@ -407,6 +408,9 @@ namespace Chummer
             // Whether or not printouts should be sent to a file before loading them in the browser. This is a fix for getting printing to work properly on Linux using Wine.
             LoadBoolFromRegistry(ref _blnPrintToFileFirst, "printtofilefirst");
 
+            // Which version of the Internet Explorer's rendering engine will be emulated for rendering the character view.
+            LoadInt32FromRegistry(ref _intEmulatedBrowserVersion, "emulatedbrowserversion");
+
             // Default character sheet.
             LoadStringFromRegistry(ref _strDefaultCharacterSheet, "defaultsheet");
             if(_strDefaultCharacterSheet == "Shadowrun (Rating greater 0)")
@@ -634,6 +638,15 @@ namespace Chummer
         }
 
         /// <summary>
+        /// Which version of the Internet Explorer's rendering engine will be emulated for rendering the character view. Defaults to 8
+        /// </summary>
+        public static int EmulatedBrowserVersion
+        {
+            get => _intEmulatedBrowserVersion;
+            set => _intEmulatedBrowserVersion = value;
+        }
+
+        /// <summary>
         /// Omae user name.
         /// </summary>
         public static string OmaeUserName
@@ -782,6 +795,7 @@ namespace Chummer
             get => _strPDFParameters;
             set => _strPDFParameters = value;
         }
+
         /// <summary>
         /// List of SourcebookInfo.
         /// </summary>

--- a/Chummer/frmOptions.Designer.cs
+++ b/Chummer/frmOptions.Designer.cs
@@ -60,7 +60,6 @@ namespace Chummer
             this.lblPDFParametersLabel = new System.Windows.Forms.Label();
             this.cboPDFParameters = new Chummer.ElasticComboBox();
             this.txtPDFAppPath = new System.Windows.Forms.TextBox();
-			this.nudBrowserVersion = new System.Windows.Forms.NumericUpDown();
             this.grpSelectedSourcebook = new System.Windows.Forms.GroupBox();
             this.tlpSelectedSourcebook = new Chummer.BufferedTableLayoutPanel();
             this.txtPDFLocation = new System.Windows.Forms.TextBox();
@@ -91,6 +90,8 @@ namespace Chummer
             this.lstGlobalSourcebookInfos = new System.Windows.Forms.ListBox();
             this.imgLanguageFlag = new System.Windows.Forms.PictureBox();
             this.chkEnablePlugins = new System.Windows.Forms.CheckBox();
+            this.nudBrowserVersion = new System.Windows.Forms.NumericUpDown();
+            this.lblBrowserVersion = new System.Windows.Forms.Label();
             this.tabCharacterOptions = new System.Windows.Forms.TabPage();
             this.tlpCharacterOptions = new Chummer.BufferedTableLayoutPanel();
             this.treSourcebook = new System.Windows.Forms.TreeView();
@@ -315,6 +316,7 @@ namespace Chummer
             this.grpCharacterDefaults.SuspendLayout();
             this.tableLayoutPanel7.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.imgLanguageFlag)).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudBrowserVersion)).BeginInit();
             this.tabCharacterOptions.SuspendLayout();
             this.tlpCharacterOptions.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.nudNuyenDecimalsMinimum)).BeginInit();
@@ -547,7 +549,6 @@ namespace Chummer
             this.tlpGlobal.Controls.Add(this.lblPDFParametersLabel, 1, 18);
             this.tlpGlobal.Controls.Add(this.cboPDFParameters, 2, 18);
             this.tlpGlobal.Controls.Add(this.txtPDFAppPath, 2, 19);
-			this.tlpGlobal.Controls.Add(this.nudBrowserVersion, 2, 20);
             this.tlpGlobal.Controls.Add(this.grpSelectedSourcebook, 1, 20);
             this.tlpGlobal.Controls.Add(this.cboLanguage, 3, 0);
             this.tlpGlobal.Controls.Add(this.cboSheetLanguage, 3, 1);
@@ -567,6 +568,8 @@ namespace Chummer
             this.tlpGlobal.Controls.Add(this.lstGlobalSourcebookInfos, 0, 1);
             this.tlpGlobal.Controls.Add(this.imgLanguageFlag, 2, 0);
             this.tlpGlobal.Controls.Add(this.chkEnablePlugins, 4, 6);
+            this.tlpGlobal.Controls.Add(this.nudBrowserVersion, 3, 15);
+            this.tlpGlobal.Controls.Add(this.lblBrowserVersion, 1, 15);
             this.tlpGlobal.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpGlobal.Location = new System.Drawing.Point(9, 9);
             this.tlpGlobal.Name = "tlpGlobal";
@@ -922,27 +925,6 @@ namespace Chummer
             this.txtPDFAppPath.TabIndex = 10;
             this.txtPDFAppPath.TextChanged += new System.EventHandler(this.OptionsChanged);
             // 
-			// nudBrowserVersion
-			//
-			this.nudBrowserVersion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.tlpGlobal.SetColumnSpan(this.nudBrowserVersion, 3);
-			this.nudBrowserVersion.Location = new System.Drawing.Point(467, 469);
-			this.nudBrowserVersion.Minimum = new decimal(new int[] {
-            8,
-            0,
-            0,
-            0});
-			this.nudBrowserVersion.Maximum = new decimal(new int[] {
-            11,
-            0,
-            0,
-            0});
-			this.nudBrowserVersion.Name = "nudBrowserVersion";
-			this.nudBrowserVersion.Size = new System.Drawing.Size(36, 20);
-			this.nudBrowserVersion.TabIndex = 26;
-			this.nudBrowserVersion.ValueChanged += new System.EventHandler(this.nudBrowserVersion_ValueChanged);
-			// 
             // grpSelectedSourcebook
             // 
             this.grpSelectedSourcebook.AutoSize = true;
@@ -1394,6 +1376,43 @@ namespace Chummer
             this.chkEnablePlugins.Text = "Enable Plugins (experimental)";
             this.chkEnablePlugins.UseVisualStyleBackColor = true;
             this.chkEnablePlugins.CheckedChanged += new System.EventHandler(this.chkEnablePlugins_CheckedChanged);
+            // 
+            // nudBrowserVersion
+            // 
+            this.nudBrowserVersion.Location = new System.Drawing.Point(489, 386);
+            this.nudBrowserVersion.Maximum = new decimal(new int[] {
+            11,
+            0,
+            0,
+            0});
+            this.nudBrowserVersion.Minimum = new decimal(new int[] {
+            8,
+            0,
+            0,
+            0});
+            this.nudBrowserVersion.Name = "nudBrowserVersion";
+            this.nudBrowserVersion.Size = new System.Drawing.Size(101, 20);
+            this.nudBrowserVersion.TabIndex = 54;
+            this.nudBrowserVersion.Value = new decimal(new int[] {
+            8,
+            0,
+            0,
+            0});
+            // 
+            // lblBrowserVersion
+            // 
+            this.lblBrowserVersion.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.lblBrowserVersion.AutoSize = true;
+            this.tlpGlobal.SetColumnSpan(this.lblBrowserVersion, 2);
+            this.lblBrowserVersion.Location = new System.Drawing.Point(304, 389);
+            this.lblBrowserVersion.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
+            this.lblBrowserVersion.Name = "lblBrowserVersion";
+            this.lblBrowserVersion.Size = new System.Drawing.Size(179, 17);
+            this.lblBrowserVersion.TabIndex = 53;
+            this.lblBrowserVersion.Tag = "Label_Options_BrowserVersion";
+            this.lblBrowserVersion.Text = "Browser Engine Version";
             // 
             // tabCharacterOptions
             // 
@@ -4519,6 +4538,7 @@ namespace Chummer
             this.grpCharacterDefaults.PerformLayout();
             this.tableLayoutPanel7.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.imgLanguageFlag)).EndInit();
+            ((System.ComponentModel.ISupportInitialize)(this.nudBrowserVersion)).EndInit();
             this.tabCharacterOptions.ResumeLayout(false);
             this.tabCharacterOptions.PerformLayout();
             this.tlpCharacterOptions.ResumeLayout(false);
@@ -4880,5 +4900,6 @@ namespace Chummer
         private System.Windows.Forms.CheckBox chkIgnoreComplexFormLimit;
         private System.Windows.Forms.CheckBox chkAllowEasterEggs;
         private System.Windows.Forms.NumericUpDown nudBrowserVersion;
+        private System.Windows.Forms.Label lblBrowserVersion;
     }
 }

--- a/Chummer/frmOptions.Designer.cs
+++ b/Chummer/frmOptions.Designer.cs
@@ -60,6 +60,7 @@ namespace Chummer
             this.lblPDFParametersLabel = new System.Windows.Forms.Label();
             this.cboPDFParameters = new Chummer.ElasticComboBox();
             this.txtPDFAppPath = new System.Windows.Forms.TextBox();
+			this.nudBrowserVersion = new System.Windows.Forms.NumericUpDown();
             this.grpSelectedSourcebook = new System.Windows.Forms.GroupBox();
             this.tlpSelectedSourcebook = new Chummer.BufferedTableLayoutPanel();
             this.txtPDFLocation = new System.Windows.Forms.TextBox();
@@ -546,6 +547,7 @@ namespace Chummer
             this.tlpGlobal.Controls.Add(this.lblPDFParametersLabel, 1, 18);
             this.tlpGlobal.Controls.Add(this.cboPDFParameters, 2, 18);
             this.tlpGlobal.Controls.Add(this.txtPDFAppPath, 2, 19);
+			this.tlpGlobal.Controls.Add(this.nudBrowserVersion, 2, 20);
             this.tlpGlobal.Controls.Add(this.grpSelectedSourcebook, 1, 20);
             this.tlpGlobal.Controls.Add(this.cboLanguage, 3, 0);
             this.tlpGlobal.Controls.Add(this.cboSheetLanguage, 3, 1);
@@ -920,6 +922,27 @@ namespace Chummer
             this.txtPDFAppPath.TabIndex = 10;
             this.txtPDFAppPath.TextChanged += new System.EventHandler(this.OptionsChanged);
             // 
+			// nudBrowserVersion
+			//
+			this.nudBrowserVersion.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.tlpGlobal.SetColumnSpan(this.nudBrowserVersion, 3);
+			this.nudBrowserVersion.Location = new System.Drawing.Point(467, 469);
+			this.nudBrowserVersion.Minimum = new decimal(new int[] {
+            8,
+            0,
+            0,
+            0});
+			this.nudBrowserVersion.Maximum = new decimal(new int[] {
+            11,
+            0,
+            0,
+            0});
+			this.nudBrowserVersion.Name = "nudBrowserVersion";
+			this.nudBrowserVersion.Size = new System.Drawing.Size(36, 20);
+			this.nudBrowserVersion.TabIndex = 26;
+			this.nudBrowserVersion.ValueChanged += new System.EventHandler(this.nudBrowserVersion_ValueChanged);
+			// 
             // grpSelectedSourcebook
             // 
             this.grpSelectedSourcebook.AutoSize = true;
@@ -4856,5 +4879,6 @@ namespace Chummer
         private System.Windows.Forms.Panel panelPluginOption;
         private System.Windows.Forms.CheckBox chkIgnoreComplexFormLimit;
         private System.Windows.Forms.CheckBox chkAllowEasterEggs;
+        private System.Windows.Forms.NumericUpDown nudBrowserVersion;
     }
 }

--- a/Chummer/frmOptions.Designer.cs
+++ b/Chummer/frmOptions.Designer.cs
@@ -1391,7 +1391,7 @@ namespace Chummer
             0,
             0});
             this.nudBrowserVersion.Name = "nudBrowserVersion";
-            this.nudBrowserVersion.Size = new System.Drawing.Size(101, 20);
+            this.nudBrowserVersion.Size = new System.Drawing.Size(40, 20);
             this.nudBrowserVersion.TabIndex = 54;
             this.nudBrowserVersion.Value = new decimal(new int[] {
             8,

--- a/Chummer/frmOptions.cs
+++ b/Chummer/frmOptions.cs
@@ -1151,12 +1151,6 @@ namespace Chummer
             cboPDFParameters.EndUpdate();
         }
 
-
-        private void nudBrowserVersion_ValueChanged(object sender, EventArgs e)
-        {
-            OptionsChanged(sender, e);
-        }
-
         private void SetToolTips()
         {
             const int width = 100;
@@ -1347,7 +1341,6 @@ namespace Chummer
             lstSheetLanguages.Sort(CompareListItems.CompareNames);
 
             return lstSheetLanguages;
-
         }
 
         private void PopulateGlobalOptions()

--- a/Chummer/frmOptions.cs
+++ b/Chummer/frmOptions.cs
@@ -803,6 +803,7 @@ namespace Chummer
             GlobalOptions.DefaultCharacterSheet = cboXSLT.SelectedValue?.ToString() ?? GlobalOptions.DefaultCharacterSheetDefaultValue;
             GlobalOptions.DatesIncludeTime = chkDatesIncludeTime.Checked;
             GlobalOptions.PrintToFileFirst = chkPrintToFileFirst.Checked;
+            GlobalOptions.EmulatedBrowserVersion = decimal.ToInt32(nudBrowserVersion.Value);
             GlobalOptions.PDFAppPath = txtPDFAppPath.Text;
             GlobalOptions.PDFParameters = cboPDFParameters.SelectedValue?.ToString() ?? string.Empty;
             GlobalOptions.LifeModuleEnabled = chkLifeModule.Checked;
@@ -841,6 +842,7 @@ namespace Chummer
                 objRegistry.SetValue("defaultbuildmethod", cboBuildMethod.SelectedValue?.ToString() ?? GlobalOptions.DefaultBuildMethodDefaultValue);
                 objRegistry.SetValue("datesincludetime", chkDatesIncludeTime.Checked.ToString());
                 objRegistry.SetValue("printtofilefirst", chkPrintToFileFirst.Checked.ToString());
+                objRegistry.SetValue("emulatedbrowserversion", nudBrowserVersion.Value.ToString());
                 objRegistry.SetValue("pdfapppath", txtPDFAppPath.Text);
                 objRegistry.SetValue("pdfparameters", cboPDFParameters.SelectedValue.ToString());
                 objRegistry.SetValue("lifemodule", chkLifeModule.Checked.ToString());
@@ -1149,6 +1151,12 @@ namespace Chummer
             cboPDFParameters.EndUpdate();
         }
 
+
+        private void nudBrowserVersion_ValueChanged(object sender, EventArgs e)
+        {
+            OptionsChanged(sender, e);
+        }
+
         private void SetToolTips()
         {
             const int width = 100;
@@ -1357,6 +1365,7 @@ namespace Chummer
             chkDronemods.Checked = GlobalOptions.Dronemods;
             chkDronemodsMaximumPilot.Checked = GlobalOptions.DronemodsMaximumPilot;
             chkPrintToFileFirst.Checked = GlobalOptions.PrintToFileFirst;
+            nudBrowserVersion.Value = GlobalOptions.EmulatedBrowserVersion;
             txtPDFAppPath.Text = GlobalOptions.PDFAppPath;
             txtCharacterRosterPath.Text = GlobalOptions.CharacterRosterPath;
             chkHideCharacterRoster.Checked = GlobalOptions.HideCharacterRoster;

--- a/Chummer/frmViewer.cs
+++ b/Chummer/frmViewer.cs
@@ -79,14 +79,14 @@ namespace Chummer
             RegistryKey objRegistry = Registry.CurrentUser.CreateSubKey("Software\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION");
             if (objRegistry != null)
             {
-                objRegistry.SetValue(AppDomain.CurrentDomain.FriendlyName, 0x1F40, RegistryValueKind.DWord);
+                objRegistry.SetValue(AppDomain.CurrentDomain.FriendlyName, GlobalOptions.EmulatedBrowserVersion * 1000, RegistryValueKind.DWord);
                 objRegistry.Close();
             }
 
             objRegistry = Registry.CurrentUser.CreateSubKey("Software\\WOW6432Node\\Microsoft\\Internet Explorer\\Main\\FeatureControl\\FEATURE_BROWSER_EMULATION");
             if (objRegistry != null)
             {
-                objRegistry.SetValue(AppDomain.CurrentDomain.FriendlyName, 0x1F40, RegistryValueKind.DWord);
+                objRegistry.SetValue(AppDomain.CurrentDomain.FriendlyName, GlobalOptions.EmulatedBrowserVersion * 1000, RegistryValueKind.DWord);
                 objRegistry.Close();
             }
 

--- a/Chummer/lang/de-de.xml
+++ b/Chummer/lang/de-de.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!--This file is part of Chummer5a.
 
     Chummer5a is free software: you can redistribute it and/or modify
@@ -6572,6 +6572,10 @@
 			<key>Checkbox_Option_PrintToFileFirst</key>
 			<text>Linux Druckfehler-Fix nutzen</text>
 		</string>
+		<string>
+      <key>Label_Options_BrowserVersion</key>
+      <text>Internet-Explorer-Version für Vorschau</text>
+    </string>
 		<string>
 			<key>Checkbox_Aerodynamic</key>
 			<text>Aerodynamisch</text>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -7765,6 +7765,10 @@ Only one attribute may be at its Maximum value during character creation.</text>
       <text>Apply Linux printing fix</text>
     </string>
     <string>
+      <key>Label_Options_BrowserVersion</key>
+      <text>Preview uses Internet Explorer version</text>
+    </string>
+    <string>
       <key>Label_Options_EssenceDecimals</key>
       <text>Number of decimal places to round Essence to:</text>
     </string>


### PR DESCRIPTION
Implements variant 1 I proposed in #3576 (ie. a global setting which IE version should be emulated), in the form of an updown box for choosing the version between 8 and 11

- Defaults to 8, which is the previously hardcoded value. If the user doesn't want to use a custom sheet utilizing more modern browser features, nothing changes and nothing has to be changed.

- There are [other values](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/general-info/ee330730(v=vs.85)#browser_emulation) for FEATURE_BROWSER_EMULATION besides the straight 8000, 9000, 10000, and 11000, but those are only dealing with HTML documents without a valid DOCTYPE.

- The box is under the "Linux print fix" checkbox since that seemed to be thematically closest

