### PR TITLE
Add toxic metamagics

### DIFF
--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -123,6 +123,7 @@
     <category blackmarket="Bioware">Genemods</category>
     <category blackmarket="Bioware">Orthoskin Upgrades</category>
     <category blackmarket="Bioware">Symbionts</category>
+    <category blackmarket="Bioware">Genetic Restoration</category>
   </categories>
   <biowares>
     <!-- Region Shadowrun 5-->
@@ -3082,7 +3083,7 @@
       <name>Revitilization</name>
       <limit>False</limit>
       <category>Genetic Restoration</category>
-      <ess>0</ess>
+      <ess>-0.1</ess>
       <capacity>0</capacity>
       <avail>14</avail>
       <cost>110000</cost>

--- a/Chummer/data/metamagic.xml
+++ b/Chummer/data/metamagic.xml
@@ -140,6 +140,32 @@
     <!-- End Region -->
     <!-- Region Street Grimoire -->
     <metamagic>
+      <id>215dbdc3-b4f5-4ca6-98b1-5d6ea5eb5fda</id>
+      <name>Taint</name>
+      <adept>False</adept>
+      <magician>True</magician>
+      <required>
+        <allof>
+          <metamagic>Paradigm Shift: Toxic</metamagic>
+        </allof>
+      </required>
+      <source>SG</source>
+      <page>87</page>
+    </metamagic>
+    <metamagic>
+      <id>920770d1-a705-4fc9-8814-f3a4a455e8fb</id>
+      <name>Corruption</name>
+      <adept>False</adept>
+      <magician>True</magician>
+      <required>
+        <allof>
+          <metamagic>Paradigm Shift: Toxic</metamagic>
+        </allof>
+      </required>
+      <source>SG</source>
+      <page>87</page>
+    </metamagic>
+    <metamagic>
       <id>9540267c-d53c-4547-9bd2-e1f06723caee</id>
       <name>Sympathetic Linking</name>
       <adept>True</adept>


### PR DESCRIPTION
Corruption and Taint are specific to toxic mages and did not exist in the metamagics table, both are from page 87 in Street Grimoire.