### PR TITLE
NecroSummoningRitual

### DIFF
--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -4731,17 +4731,9 @@
       <bonus>
         <addspirit>
             <spirit>Carcass Spirit</spirit>
-        </addspirit>
-        <addspirit>
             <spirit>Corpse Spirit</spirit>
-        </addspirit>
-        <addspirit>
             <spirit>Rot Spirit</spirit>
-        </addspirit>
-        <addspirit>
             <spirit>Palefire Spirit</spirit>
-        </addspirit>
-        <addspirit>
             <spirit>Detritus Spirit</spirit>
         </addspirit>
       </bonus>


### PR DESCRIPTION
Fixes #3882. Completed.

Fixes the Selection of spirit types for the Necro Summoning Ritual.

Now one spirit type can be selected manually.