### PR TITLE
Added German translation and ejection seat from R5G

### DIFF
--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -12807,6 +12807,36 @@
       </required>
     </mod>
     <!-- End Region -->
+	<!-- Region Rigger 5.0 German -->
+    <mod>
+      <id>3433b962-0ed6-49e9-9807-0a160642ae91</id>
+      <name>Ejection seat</name>
+      <page>171</page>
+      <source>R5G</source>
+      <avail>8R</avail>
+      <category>Cosmetic</category>
+      <cost>750</cost>
+      <rating>0</rating>
+      <slots>1</slots>
+      <required>
+        <vehicledetails>
+          <OR>
+            <category>Bikes</category>
+            <category>Cars</category>
+            <category>Trucks</category>
+            <category>Municipal/Construction</category>
+            <category>Corpsec/Police/Military</category>
+            <category>Boats</category>
+            <category>Submarines</category>
+            <category>Fixed-Wing Aircraft</category>
+            <category>LTAV</category>
+            <category>Rotorcraft</category>
+            <category>VTOL/VSTOL</category>
+          </OR>
+        </vehicledetails>
+      </required>
+    </mod>
+    <!-- End Region -->
   </mods>
   <!-- Region Vehicle Mounts -->
   <weaponmounts>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -12814,7 +12814,7 @@
       <page>171</page>
       <source>R5G</source>
       <avail>8R</avail>
-      <category>Cosmetic</category>
+      <category>Protection</category>
       <cost>750</cost>
       <rating>0</rating>
       <slots>1</slots>

--- a/Chummer/lang/de-de.xml
+++ b/Chummer/lang/de-de.xml
@@ -9674,5 +9674,17 @@
 			<key>Message_InvalidPowerPoints</key>
 			<text>{0} über den maximalen Adeptenkraftpunkte ({1})</text>
 		</string>
+		<string>
+			<key>Label_RatingFormat</key>
+			<text>{0}:</text>
+		</string>
+		<string>
+			<key>Rating_LengthInCmBy10</key>
+			<text>Länge (cm)x10</text>
+		</string>
+		<string>
+			<key>Rating_Meters</key>
+			<text>Meter</text>
+		</string>
 	</strings>
 </chummer>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -41137,6 +41137,12 @@
 				<translate>Daihatsu-Caterpillar Horseman Frachtmodul</translate>
 				<altpage>43</altpage>
 			</mod>
+			<mod>
+				<id>3433b962-0ed6-49e9-9807-0a160642ae91</id>
+				<name>Ejection seat</name>
+				<translate>Schleudersitz</translate>
+				<altpage>171</altpage>
+			</mod>
 		</mods>
 		<weaponmounts>
 			<weaponmount translated="True">


### PR DESCRIPTION
Added missing German translations and 'ejection seat' from German Rigger 5.0 (see https://github.com/chummer5a/chummer5a/issues/3884 ).

As you can only select it if 'Rigger 5.0 German exclusive content' is selected as source book, no custom rule has been added (either you use the additional German rules with ejection seat or you do not use it and have no ejection seat).