### PR TITLE
Add qualities for Dark Terror advanced optional powers for Nosferatu

### DIFF
--- a/Chummer/data/critterpowers.xml
+++ b/Chummer/data/critterpowers.xml
@@ -3865,6 +3865,7 @@
     <power>
       <id>b1cef6fe-aa5f-4b12-a621-a3eb24568dbf</id>
       <name>Mystic Armor (Infected)</name>
+	  <rating>True</rating>
       <category>Paranormal</category>
       <type>M</type>
       <action>Auto</action>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -10590,8 +10590,32 @@
       </required>
       <source>RF</source>
       <page>136</page>
-    </quality>
-    <quality>
+    </quality>	
+	<quality>
+      <id>59d9baa1-6705-49e8-940b-ea42ffc02692</id>
+      <name>Infected Advanced Optional Power: Mimicry</name>
+      <karma>9</karma>
+      <category>Positive</category>
+      <doublecareer>False</doublecareer>
+      <bonus>
+        <critterpowers>
+          <power>Mimicry</power>
+        </critterpowers>
+      </bonus>
+	  <forbidden>
+        <oneof>
+          <critterpower>Mimicry</critterpower>
+        </oneof>
+      </forbidden>
+      <required>
+        <oneof>
+          <quality>Infected: Nosferatu</quality>
+        </oneof>
+      </required>
+      <source>SR5</source>
+      <page>398</page>
+    </quality>    
+	<quality>
       <id>7843087c-30a3-4d87-aaa2-5ebdb90cccd8</id>
       <name>Infected Optional Power: Mist Form</name>
       <karma>12</karma>
@@ -10613,7 +10637,7 @@
       </required>
       <source>RF</source>
       <page>136</page>
-    </quality>
+    </quality>	
     <quality>
       <id>6d9f205e-52a0-4bb2-a4c2-e49232dd8346</id>
       <name>Infected Optional Power: Paralyzing Howl</name>
@@ -10638,6 +10662,30 @@
       <source>RF</source>
       <page>136</page>
     </quality>
+	<quality>
+      <id>8dbc6b92-18a7-4007-b37f-295d21f8ab82</id>
+      <name>Infected Advanced Optional Power: Psychokinesis</name>
+      <karma>9</karma>
+      <category>Positive</category>
+      <doublecareer>False</doublecareer>
+      <bonus>
+        <critterpowers>
+          <power>Psychokinesis</power>
+        </critterpowers>
+      </bonus>
+	  <forbidden>
+        <oneof>
+          <critterpower>Psychokinesis</critterpower>
+        </oneof>
+      </forbidden>
+      <required>
+        <oneof>
+          <quality>Infected: Nosferatu</quality>
+        </oneof>
+      </required>
+      <source>SR5</source>
+      <page>400</page>
+    </quality>    
     <quality>
       <id>311ebb96-bf65-483e-86b7-62702a43aae3</id>
       <name>Infected Optional Power: Regeneration</name>


### PR DESCRIPTION
Add qualities to give Nosferatu PCs access to Mimicry and Psycokinesis. I couldn't get a quality for Infected Mystic Armor to work, although I did add a rating tag. It can already be added via the critter powers tab for appropriate karma.