### PR TITLE
[WIP] Fixes #3894 - Only Use Highest Foci Bonus For Spells

### DIFF
--- a/Chummer/Backend/Uniques/Spell.cs
+++ b/Chummer/Backend/Uniques/Spell.cs
@@ -852,6 +852,7 @@ namespace Chummer
                         // We need to do some checking to make sure this is the most powerful foci before we add it in
                         if (objImprovement.ImproveSource == Improvement.ImprovementSource.Gear )
                         {
+                            // we are returning either the original improvement, null or a newly instantiated improvement
                             Improvement? bestFocus = CompareFocusPower(objImprovement);
                             if (bestFocus is Improvement)
                             {


### PR DESCRIPTION
Hi! I saw this was open and thought I would take a stab at fixing it. This is the first time I've done anything with .NET, so please let me know if this is the wildly wrong approach. I'll try to comment the PR where I have questions or I think I'm doing anything especially strange. 

This checks on calculating the spell dice poll to see if the character has other bonded foci, and if so, if any of them are power foci that are added to the base MAG score. If there are any power foci with a value higher than the specialized focus, it just skips adding in the specialized focuses value. 

If there is a power focus but the highest value one is below the rating of the specialized focus, it gives a bonus for the specialized focus that is the diff of the power focus - specialized focus. My current approach to doing that is almost certainly non-standard. 