### PR TITLE
Amend custom rule for commanding voice

### DIFF
--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -1972,7 +1972,7 @@
     <Content Include="customdata\Education Qualities Apply Karma Discount in Create Mode\amend_qualities.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="customdata\German Data Changes - Commanding Voice in Street Grimoire\amend_commandingvoice_powers.xml">
+    <Content Include="customdata\German Data Changes - Commanding Voice and Authoritative Tone are equal\amend_powers.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="customdata\German Data Changes - Commlink App Prices\amend_commlinkappsprices_gear.xml">

--- a/Chummer/customdata/German Data Changes - Commanding Voice and Authoritative Tone are equal/amend_powers.xml
+++ b/Chummer/customdata/German Data Changes - Commanding Voice and Authoritative Tone are equal/amend_powers.xml
@@ -18,11 +18,24 @@
     https://github.com/chummer5a/chummer5a
 -->
 <chummer>
+<!-- Authoritatative Tone (SG 170) and Commanding Voice (SS 191) are different powers according to English source books. -->
+<!-- According to German rules both spells are identical (named 'Gebieterischer Ton'), but differ from the English attributes. -->
     <powers>
+		<!-- Begin Street Grimoire: Authoritative Tone, in German: 'Gebieterischer Ton' -->
         <power>
+			<id>5f1ebcd8-9571-4716-b7fd-ec674306b833</id>
+			<points amendoperation="replace">0.25</points>
+		</power>
+		<!-- End Street Griomiore: Authoritative Tone -->
+		<!-- Begin Stolen Souls: Commanding Voice, in German: 'Gebieterischer Ton' -->
+		<power>
             <id>9fd628cc-dd06-435c-80d3-5261e7e5b1e5</id>
-            <source>SG</source>
-            <page>199</page>
+			<points amendoperation="replace">0.25</points>
+			<levels amendoperation="replace">True</levels>
+			<action amendoperation="remove" />
+			<maxlevels amendoperation="addnode">3</maxlevels>
+			<adeptway amendoperation="replace">0.25</adeptway>      
         </power>
+		<!-- End Stolen Souls: Commanding Voice -->
     </powers>
 </chummer>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -24920,7 +24920,7 @@
 				<id>5f1ebcd8-9571-4716-b7fd-ec674306b833</id>
 				<name>Authoritative Tone</name>
 				<translate>Gebieterischer Ton</translate>
-				<altpage>207</altpage>
+				<altpage>199</altpage>
 			</power>
 			<power translated="True">
 				<id>deec22db-cf2c-47b6-ac34-95a13bcd0bf8</id>
@@ -25315,7 +25315,7 @@
 			<power translated="True">
 				<id>9fd628cc-dd06-435c-80d3-5261e7e5b1e5</id>
 				<name>Commanding Voice</name>
-				<translate>Befehlsstimme</translate>
+				<translate>Gebieterischer Ton</translate>
 				<altpage>207</altpage>
 			</power>
 			<power>


### PR DESCRIPTION
German custom rule for 'Commanding Voice' was completely rewritten
- 'Commanding Voice' (SS 191) and 'Authoritative Tone' (SG 170) are both translated as 'Gebieterischer Ton' (power is identical / one and the same according to German rule books)
- as there are two rule books with this power mentioned both powers got the same translation (changed translation 'Befehlsstimme' to 'Gebieterischer Ton')
- fixed wrong page for German 'Authoritative Tone' (changed '207' to '199')
- added or replaced values for both powers to meet German rules
- changed name of the rule from 'German Data Changes - Commanding Voice in Street Grimoire' to 'German Data Changes - Commanding Voice and Authoritative Tone are equal' to better describe its effect
- changed path in 'Chummer.csproj' so that compilation for changed rule will hopefully not fail again (as some days ago)