### PR TITLE
Fixed non-selectable custom rules vor German Data Changes

### DIFF
--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -543,6 +543,15 @@
     <Content Include="customdata\Flashback System Enables Cyberzombies\amend_cyberware.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="customdata\German Data Changes - Availability and costs of Chameleon Suit\amend_chameleonsuit_armor.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="customdata\German Data Changes - Quality Karma Costs\amend_costs_qualities.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+     <Content Include="customdata\German Data Changes - Rigger 5 Mods - Dodge Rhino\amend_vehicles.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="customdata\German Data Changes - Reduced Weapon Mount Prices\amend_vehicles.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Chummer/customdata/German Data Changes - Availability and costs of Chameleon Suit/amend_chameleonsuit_armor.xml
+++ b/Chummer/customdata/German Data Changes - Availability and costs of Chameleon Suit/amend_chameleonsuit_armor.xml
@@ -21,8 +21,8 @@
   <armors>
 	<armor>
 		<id>aacafde3-ff9a-4de0-85ac-3870645a9197</id>
-		<avail>12R</avail>
-		<cost>4500</cost>		
+		<avail amendoperation="replace">12R</avail>
+		<cost amendoperation="replace">4500</cost>		
 	</armor>
   </armors>
 </chummer>

--- a/Chummer/customdata/German Data Changes - Commanding Voice and Authoritative Tone are equal/amend_powers.xml
+++ b/Chummer/customdata/German Data Changes - Commanding Voice and Authoritative Tone are equal/amend_powers.xml
@@ -18,7 +18,7 @@
     https://github.com/chummer5a/chummer5a
 -->
 <chummer>
-<!-- Authoritatative Tone (SG 170) and Commanding Voice (SS 191) are different powers according to English source books. -->
+<!-- Authoritative Tone (SG 170) and Commanding Voice (SS 191) are different powers according to English source books. -->
 <!-- According to German rules both spells are identical (named 'Gebieterischer Ton'), but differ from the English attributes. -->
     <powers>
 		<!-- Begin Street Grimoire: Authoritative Tone, in German: 'Gebieterischer Ton' -->

--- a/Chummer/customdata/German Data Changes - Quality Karma Costs/amend_costs_qualities.xml
+++ b/Chummer/customdata/German Data Changes - Quality Karma Costs/amend_costs_qualities.xml
@@ -21,11 +21,11 @@
     <qualities>
         <quality>
             <id>bfb6b16b-d2b1-4b28-af37-e011d016da37</id>
-            <karma>7</karma>
+            <karma amendoperation="replace">7</karma>
         </quality>
         <quality>
             <id>c724871b-6ae9-43fe-a0ae-83b0afcd4123</id>
-            <karma>7</karma>
+            <karma amendoperation="replace">7</karma>
         </quality>
     </qualities>
 </chummer>

--- a/Chummer/customdata/German Data Changes - Rigger 5 Mods - Dodge Rhino/amend_vehicles.xml
+++ b/Chummer/customdata/German Data Changes - Rigger 5 Mods - Dodge Rhino/amend_vehicles.xml
@@ -21,7 +21,7 @@
   <vehicles>
     <vehicle>
       <id>945d3c12-d119-4441-a6f5-d69c6317aff2</id>
-      <body>17</body>
+      <body amendoperation="replace">17</body>
     </vehicle>
   </vehicles>
 </chummer>


### PR DESCRIPTION
- added 'amendoperation'-tag to non-selectable custom rules 'German Data Changes ...'
- verified content and added missing custom rules 'German Data Changes ...' to 'Chummer.csproj'