### PR TITLE
Addition to custom rule for German Yamaha Kaburaya

### DIFF
--- a/Chummer/customdata/German Data Changes - Yamaha Kaburaya/amend_kaburaya_vehicles.xml
+++ b/Chummer/customdata/German Data Changes - Yamaha Kaburaya/amend_kaburaya_vehicles.xml
@@ -1,10 +1,29 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<!-- Changes the Yamaha Kaburaya's Acceleration from 3 to 4. -->
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<!-- Changes the Yamaha Kaburaya's Acceleration from 3 to 4 and cost from 17000 to 8500 (see German R5 49 and German R5 189). -->
 <chummer>
   <vehicles>
     <vehicle>
       <id>006ea45a-cc35-496c-8d01-94eb64d8febb</id>
-      <accel>4</accel>
+      <accel amendoperation="replace">4</accel>
+      <cost amendoperation="replace">8500</cost>
     </vehicle>
   </vehicles>
 </chummer>


### PR DESCRIPTION
Besides the acceleration, the costs for the motorbike 'Yamaha Kaburaya' are also different according to German rules. Since this is mentioned not only once but twice and is not mentioned in any errata thread in German forums, this adjustment seems to be intentional. The custom rule has been modified to include both.

Licence text has been added.