### PR TITLE
Fixed Fox

### DIFF
--- a/Chummer/data/mentors.xml
+++ b/Chummer/data/mentors.xml
@@ -2551,7 +2551,7 @@
       <id>50b20b8c-8cf4-4b92-95ea-b0c8bbf560b0</id>
       <name>Fox</name>
       <advantage>All: +2 dice pool modifier for tests using the Perception skill.</advantage>
-      <disadvantage>If Fox fights, it'll fight to kill. A follower of this mentor spirit must make a Willpower + Charisma (3) Test to spare a bettered foe.</disadvantage>
+      <disadvantage>If Fox fights, it'll fight to kill. A follower of this mentor spirit must make a Willpower + Intuition (3) Test to spare an overpowered foe.</disadvantage>
       <bonus>
         <specificskill>
           <name>Perception</name>


### PR DESCRIPTION
Amended text to the disadvantage of the mentor spirit 'Fox' (taken from German rule book SAG 121, see https://github.com/chummer5a/chummer5a/issues/3985)