### PR TITLE
Vehicle tree view functionality

### DIFF
--- a/Chummer/Character Creation/frmCreate.Designer.cs
+++ b/Chummer/Character Creation/frmCreate.Designer.cs
@@ -11681,7 +11681,6 @@ namespace Chummer
             this.treVehicles.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
             treeNode24});
             this.treVehicles.ShowNodeToolTips = true;
-            this.treVehicles.ShowRootLines = false;
             this.treVehicles.Size = new System.Drawing.Size(295, 590);
             this.treVehicles.TabIndex = 30;
             this.treVehicles.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treVehicles_AfterSelect);

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -2970,7 +2970,6 @@ namespace Chummer
             XmlDocument objXmlDocument = XmlManager.Load("vehicles.xml");
 
             XmlNode objXmlVehicle = objXmlDocument.SelectSingleNode("/chummer/vehicles/vehicle[id = \"" + frmPickVehicle.SelectedVehicle + "\"]");
-
             Vehicle objVehicle = new Vehicle(CharacterObject);
             objVehicle.Create(objXmlVehicle);
             // Update the Used Vehicle information if applicable.
@@ -7550,16 +7549,20 @@ namespace Chummer
 
         private void treVehicles_ItemDrag(object sender, ItemDragEventArgs e)
         {
-            if (treVehicles.SelectedNode != null && treVehicles.SelectedNode.Level > 1)
+            // Determine if this is a piece of Gear or a Vehicle. If not, don't let the user drag it.
+            if (treVehicles.SelectedNode?.Tag is Gear)
             {
-                // Determine if this is a piece of Gear. If not, don't let the user drag the Node.
-                if (treVehicles.SelectedNode?.Tag is Gear)
-                {
-                    _eDragButton = e.Button;
-                    _blnDraggingGear = true;
-                    _intDragLevel = treVehicles.SelectedNode.Level;
-                    DoDragDrop(e.Item, DragDropEffects.Move);
-                }
+                _eDragButton = e.Button;
+                _blnDraggingGear = true;
+                _intDragLevel = treVehicles.SelectedNode.Level;
+                DoDragDrop(e.Item, DragDropEffects.Move);
+            }
+            if (treVehicles.SelectedNode?.Tag is Vehicle)
+            {
+                _eDragButton = e.Button;
+                _blnDraggingGear = false;
+                _intDragLevel = treVehicles.SelectedNode.Level;
+                DoDragDrop(e.Item, DragDropEffects.Move);
             }
         }
 
@@ -7587,7 +7590,9 @@ namespace Chummer
             TreeNode objSelected = treVehicles.SelectedNode;
 
             if (!_blnDraggingGear)
+            {
                 CharacterObject.MoveVehicleNode(intNewIndex, nodDestination, objSelected);
+            }
             else
             {
                 if (_eDragButton == MouseButtons.Left)

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -7602,8 +7602,6 @@ namespace Chummer
             }
             else
             {
-                if (_eDragButton == MouseButtons.Left)
-                    return;
                 CharacterObject.MoveVehicleGearParent(nodDestination, objSelected);
             }
 

--- a/Chummer/Character Creation/frmCreate.cs
+++ b/Chummer/Character Creation/frmCreate.cs
@@ -4017,9 +4017,17 @@ namespace Chummer
 
         private void cmdAddVehicleLocation_Click(object sender, EventArgs e)
         {
+            TaggedObservableCollection<Location> destCollection;
             // Make sure a Vehicle is selected.
-            Vehicle objVehicle = treVehicles.SelectedNode?.Tag as Vehicle;
-            if (!(objVehicle == null || treVehicles.SelectedNode?.Tag == null))
+            if (treVehicles.SelectedNode?.Tag is Vehicle objVehicle)
+            {
+                destCollection = objVehicle.Locations;
+            }
+            else if (treVehicles.SelectedNode?.Tag.ToString() == "Node_SelectedVehicles" || treVehicles.SelectedNode?.Tag == null)
+            {
+                destCollection = CharacterObject.VehicleLocations;
+            }
+            else
             {
                 Program.MainForm.ShowMessageBox(LanguageManager.GetString("Message_SelectVehicleLocation", GlobalOptions.Language), LanguageManager.GetString("MessageTitle_SelectVehicle", GlobalOptions.Language), MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;
@@ -4032,9 +4040,8 @@ namespace Chummer
 
             if (frmPickText.DialogResult == DialogResult.Cancel || string.IsNullOrEmpty(frmPickText.SelectedValue))
                 return;
-            ObservableCollection<Location> lstParent = objVehicle?.Locations ?? CharacterObject.VehicleLocations;
-            Location objLocation = new Location(CharacterObject, lstParent, frmPickText.SelectedValue);
-            lstParent.Add(objLocation);
+            Location objLocation = new Location(CharacterObject, destCollection, frmPickText.SelectedValue);
+            destCollection.Add(objLocation);
 
             IsDirty = true;
         }

--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -6611,13 +6611,18 @@ if (!Utils.IsUnitTest){
             {
                 // Determine if this is a Location.
                 TreeNode nodVehicleNode = nodDestination;
-                do
+                Location objLocation = null;
+                while (nodVehicleNode.Level > 1)
                 {
+                    if (objLocation is null && nodVehicleNode.Tag is Location loc)
+                    {
+                        objLocation = loc;
+                    }
                     nodVehicleNode = nodVehicleNode.Parent;
-                } while(nodVehicleNode.Level > 1);
+                }
 
                 // Determine if this is a Location in the destination Vehicle.
-                if(nodDestination.Tag is Location objLocation)
+                if(nodDestination.Tag is Vehicle objNewVehicle)
                 {
                     // Remove the Gear from the Vehicle.
                     if(objGear.Parent is IHasChildren<Gear> parent)
@@ -6630,7 +6635,12 @@ if (!Utils.IsUnitTest){
                         objOldVehicle.Gear.Remove(objGear);
 
                     // Add the Gear to the Vehicle and set its Location.
-                    objGear.Location = objLocation;
+                    objGear.Parent = objNewVehicle;
+                    objNewVehicle.Gear.Add(objGear);
+                    if (objLocation != null)
+                    {
+                        objLocation.Children.Add(objGear);
+                    }
                 }
             }
         }

--- a/Chummer/frmCareer.Designer.cs
+++ b/Chummer/frmCareer.Designer.cs
@@ -16254,7 +16254,6 @@ namespace Chummer
             this.treVehicles.Nodes.AddRange(new System.Windows.Forms.TreeNode[] {
             treeNode24});
             this.treVehicles.ShowNodeToolTips = true;
-            this.treVehicles.ShowRootLines = false;
             this.treVehicles.Size = new System.Drawing.Size(295, 590);
             this.treVehicles.TabIndex = 30;
             this.treVehicles.AfterSelect += new System.Windows.Forms.TreeViewEventHandler(this.treVehicles_AfterSelect);

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -11305,8 +11305,6 @@ namespace Chummer
             }
             else
             {
-                if (_eDragButton == MouseButtons.Left)
-                    return;
                 CharacterObject.MoveVehicleGearParent(nodDestination, objSelected);
             }
 

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -11259,16 +11259,20 @@ namespace Chummer
 
         private void treVehicles_ItemDrag(object sender, ItemDragEventArgs e)
         {
-            if (treVehicles.SelectedNode != null && treVehicles.SelectedNode.Level > 1)
+            // Determine if this is a piece of Gear or a Vehicle. If not, don't let the user drag it.
+            if (treVehicles.SelectedNode?.Tag is Gear)
             {
-                // Determine if this is a piece of Gear. If not, don't let the user drag the Node.
-                if (treVehicles.SelectedNode?.Tag is Gear)
-                {
-                    _eDragButton = e.Button;
-                    _blnDraggingGear = true;
-                    _intDragLevel = treVehicles.SelectedNode.Level;
-                    DoDragDrop(e.Item, DragDropEffects.Move);
-                }
+                _eDragButton = e.Button;
+                _blnDraggingGear = true;
+                _intDragLevel = treVehicles.SelectedNode.Level;
+                DoDragDrop(e.Item, DragDropEffects.Move);
+            }
+            if (treVehicles.SelectedNode?.Tag is Vehicle)
+            {
+                _eDragButton = e.Button;
+                _blnDraggingGear = false;
+                _intDragLevel = treVehicles.SelectedNode.Level;
+                DoDragDrop(e.Item, DragDropEffects.Move);
             }
         }
 


### PR DESCRIPTION
* Implement dragging vehicles between character locations (the code was there, but you couldn't pick them up for some reason).
* Fix dragging gear between vehicles, whether in sub-locations or not. (Not terribly sure abt this one: does one need to Add gear to a vehicle if it's in a sub-location?)
* Fix being unable to add sub-locations to vehicles in Create mode.

Fixes #4091.