### PR TITLE
Some Ger Translation fixing, weapon data fixing and custom data fixing.

### DIFF
--- a/Chummer/customdata/German Data Changes - Spell Parameter Changes/amend_spells.xml
+++ b/Chummer/customdata/German Data Changes - Spell Parameter Changes/amend_spells.xml
@@ -18,18 +18,10 @@
     https://github.com/chummer5a/chummer5a
 -->
 <chummer>
-    <qualities>
-        <quality>
-            <id>bfb6b16b-d2b1-4b28-af37-e011d016da37</id>
-            <karma>7</karma>
-        </quality>
-        <quality>
-            <id>c724871b-6ae9-43fe-a0ae-83b0afcd4123</id>
-            <karma>7</karma>
-        </quality>
-        <quality>
-            <id>b5f6d958-2563-431b-a7a4-a9028a9f0277</id>
-            <karma>3</karma>
-        </quality>
-    </qualities>
+    <spells>
+        <spell>
+            <id>621b881e-5486-4dcb-a26e-2ad66bba09e8</id>
+            <dv>F-2</dv>
+        </spell>
+    </spells>
 </chummer>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -5012,7 +5012,8 @@
       <category>Shotguns</category>
       <type>Ranged</type>
       <conceal>6</conceal>
-      <accuracy>5</accuracy>
+      <!-- accuracy is 5, but this includes the trigger removal, so it must one lower -->
+      <accuracy>4</accuracy>
       <reach>0</reach>
       <damage>12P</damage>
       <ap>-1</ap>
@@ -11331,7 +11332,8 @@
       <category>Machine Pistols</category>
       <type>Ranged</type>
       <conceal>0</conceal>
-      <accuracy>5</accuracy>
+      <!-- accuracy is 5, but this includes the trigger removal, so it must one lower -->
+      <accuracy>4</accuracy>
       <reach>0</reach>
       <damage>7P</damage>
       <ap>-</ap>

--- a/Chummer/lang/de-de.xml
+++ b/Chummer/lang/de-de.xml
@@ -5471,7 +5471,7 @@
         </string>
         <string>
             <key>Checkbox_Option_AlternateMetatypeAttributeKarma</key>
-            <text>Die gesteigerten Werte von Metamenschen kosten in der Bauphase Punkte</text>
+            <text>Attribut Metatypminimum immer als 1 annehmen zur Berechnung von Karma kosten</text>
         </string>
         <string>
             <key>Checkbox_Transgenic</key>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -37400,7 +37400,7 @@
             <spell>
                 <id>621b881e-5486-4dcb-a26e-2ad66bba09e8</id>
                 <name>Turn To Goo</name>
-                <translate>Schleimverwandlung</translate>
+                <translate>Versteinern</translate>
                 <altpage>131</altpage>
             </spell>
             <spell translated="True">


### PR DESCRIPTION
The spell "turn to goo" was translated to "Schleimverwandlung" but is actually called "Versteinerung" in the German Street Grimoir.

The quality "Agile Defender" (Ger: Kreuzfeuer p. 127) has a Karma cost of 3 in the German version, which was added to the "German Data Changes - Quality Karma Costs".

The spell "turn to goo" has a DV of -2 instead of +3 in the German version (Ger: Straßengrimoire p. 133). This was introduced in the new "German Data Changes - Spell Parameter Changes" custom data folder.

Because the stat blocks in the rulebooks always assume all standard accessories are equip the actual precision of weapons with trigger removal is one lower.
This was already done for some weapons, e.g. the HK Urban Striker, but not for the Walther P118 (RG) and the Cavalier Arms Falchion (GH3).

P.s. If I made an mistake while creating this pull request I'm sorry, this is the first time of doing it at all and I'm not very experienced in using Git. Any corrections / tips in that regard are very welcome

