### PR TITLE
Changes to character sheets

### DIFF
--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -17856,9 +17856,6 @@
     <Content Include="sheets\de-de\Spirits and Sprites.xsl">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <Content Include="sheets\de-de\xs.Chummer5CSS.xslt">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
     <Content Include="sheets\de-de\xz.language.xslt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
@@ -18084,9 +18081,6 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="sheets\pt-br\Vehicles.xsl">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </Content>
-    <Content Include="sheets\pt-br\xs.Chummer5CSS.xslt">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="sheets\pt-br\xz.language.xslt">

--- a/Chummer/sheets/Calendar set.xslt
+++ b/Chummer/sheets/Calendar set.xslt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- Calendar -->
-<!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -23,45 +23,7 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
-        <style type="text/css">
-            * {
-            font-family: 'courier new', tahoma, 'trebuchet ms', arial;
-            font-size: 10pt;
-            margin: 0;
-            vertical-align: top;
-            }
-            html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .tablestyle {
-            border-collapse: collapse;
-            border-color: #1c4a2d;
-            border-style: solid;
-            border-width: 0.5mm;
-            cellpadding: 2;
-            cellspacing: 0;
-            width: 100%;
-            }
-            th {
-            text-align: center;
-            text-decoration: underline;
-            }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
-          }
-        </style>
+        <xsl:call-template name="Chummer5CSS" />
       </head>
 
       <body>

--- a/Chummer/sheets/Commlinks set.xslt
+++ b/Chummer/sheets/Commlinks set.xslt
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- Character sheet for Commlinks based on the ones created by ChinaGreenElvis -->
-<!-- Created by Keith Rudolph, krudolph@gmail.com -->
-<!-- Version -500 -->
+<!-- Commlinks List -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -25,48 +24,25 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
+        <xsl:call-template name="Chummer5CSS" />
+<!-- ** Override default style type definitions ** -->
         <style type="text/css">
-            * {
-            font-family: segoe condensed, tahoma, trebuchet ms, arial;
-            font-size: 8pt;
-            margin: 0;
-            text-align: left;
-            }
-            html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .commlinkcategory {
-            font-family: segoe condensed, tahoma, trebuchet ms, arial;
-            font-size: 8pt;
-            text-align: right;
-            }
-            .tableborder {
-            border: solid 2px #1c4a2d;
-            border-collapse: collapse;
-            padding: 5px;
-            }
-            .block {
-            page-break-inside: avoid;
-            }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
+          * {
+          font-family: segoe, tahoma, 'trebuchet ms', arial;
+          font-size: 8pt;
           }
-          .block {
-            bottom-padding: 0.75;
-            page-break-inside: avoid !important;
-            margin: 4px 0 4px 0;  /* to keep the page break from cutting too close to the text in the div */
+        </style>
+<!-- ** Additional style type definitions ** -->
+        <style type="text/css">
+          .tableborder {
+          border: solid 2px #1c4a2d;
+          border-collapse: collapse;
+          padding: 5px;
+          }
+          .commlinkcategory {
+          font-family: segoe condensed, tahoma, trebuchet ms, arial;
+          font-size: 8pt;
+          text-align: right;
           }
         </style>
       </head>

--- a/Chummer/sheets/Contacts set.xslt
+++ b/Chummer/sheets/Contacts set.xslt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!-- Contacts List -->
-<!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -22,68 +22,20 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
-        <style type="text/css">
-            * {
-            font-family: 'courier new', tahoma, 'trebuchet ms', arial;
-            font-size: 10pt;
-            margin: 0;
-            text-align: center;
-            vertical-align: top;
-            }
-            html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .tablestyle {
-            border-collapse: collapse;
-            border-color: #1c4a2d;
-            border-style: solid;
-            border-width: 0.5mm;
-            width: 100%;
-            }
-            .upper {
-            text-transform: uppercase;
-            }
-            .title {
-            font-weight: bold;
-            text-transform: uppercase;
-            }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
-          }
-        </style>
+        <xsl:call-template name="Chummer5CSS" />
       </head>
 
       <body>
         <div id="ContactsBlock">
           <table class="tablestyle">
             <tr class="title" style="font-weight: bold; text-decoration: underline;">
-              <td width="25%" style="text-align: left">
+              <th width="25%" style="text-align: left">
                 <xsl:value-of select="$lang.Name"/>
-              </td>
-              <td width="25%">
-                <xsl:value-of select="$lang.Location"/>
-              </td>
-              <td width="25%">
-                <xsl:value-of select="$lang.Archetype"/>
-              </td>
-              <td width="15%">
-                <xsl:value-of select="$lang.Connection"/>
-              </td>
-              <td width="10%">
-                <xsl:value-of select="$lang.Loyalty"/>
-              </td>
+              </th>
+              <th width="25%"><xsl:value-of select="$lang.Location"/></th>
+              <th width="25%"><xsl:value-of select="$lang.Archetype"/></th>
+              <th width="15%"><xsl:value-of select="$lang.Connection"/></th>
+              <th width="10%"><xsl:value-of select="$lang.Loyalty"/></th>
             </tr>
             <xsl:call-template name="Contacts"/>
           </table>

--- a/Chummer/sheets/Dossier set.xslt
+++ b/Chummer/sheets/Dossier set.xslt
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Dossier character summary sheet -->
-<!-- Created by Jeff Halket, modified by Keith Rudolph, krudolph@gmail.com -->
-<!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
   <xsl:include href="xt.PreserveHtml.xslt"/>
@@ -23,56 +22,11 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
+        <xsl:call-template name="Chummer5CSS" />
+<!-- ** Override default style type definitions ** -->
         <style type="text/css">
-            * {
-            font-family: 'courier new', tahoma, 'trebuchet ms', arial;
-            font-size: 9pt;
-            margin: 0;
-            vertical-align: top;
-            }
-            html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .label {
-            font-weight: bold;
-            width: 15%;
-            }
-            .mugshot {
-            width: auto;
-            max-width: 100%;
-            object-fit: scale-down;
-            image-rendering: optimizeQuality;
-            }
-            @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-            .mugshot {
-            width: 100%;
-            max-width: inherit;
-            object-fit: scale-down;
-            }
-            }
-        </style>
-        <!--[if IE]
-        <style type="text/css">
-        .mugshot {
-          width: 100%;
-          max-width: inherit;
-          object-fit: scale-down;
-          }
-        </style>
-        -->
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.5in;
+          * {
+          font-size: 9pt;
           }
         </style>
       </head>

--- a/Chummer/sheets/Expenses set.xslt
+++ b/Chummer/sheets/Expenses set.xslt
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Expenses -->
-<!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -24,47 +24,7 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
-        <style type="text/css">
-            * {
-            font-family: 'courier new', tahoma, 'trebuchet ms', arial;
-            font-size: 10pt;
-            margin: 0;
-            vertical-align: top;
-            }
-            html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .tablestyle {
-            border-collapse: collapse;
-            border-color: #1c4a2d;
-            border-style: solid;
-            border-width: 0.5mm;
-            cellpadding: 2;
-            cellspacing: 0;
-            width: 100%;
-            }
-            .upper {
-            text-transform: uppercase;
-            }
-            th {
-            text-decoration: underline;
-            }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
-          }
-        </style>
+        <xsl:call-template name="Chummer5CSS" />
       </head>
 
       <body>

--- a/Chummer/sheets/Fancy Blocks set.xslt
+++ b/Chummer/sheets/Fancy Blocks set.xslt
@@ -486,7 +486,7 @@
   <xsl:template name="print_attributes">
     <table class="stats general">
       <tr><td colspan="4"><div class="bigheader">[<xsl:value-of select="$lang.Attributes" />]</div></td></tr>
-      <xsl:if test="attributes/attributecategory">
+      <xsl:if test="attributes/attribute[name_english = 'BOD' and (../attributecategory_english != metatypecategory)]">
         <tr>
           <td style="white-space: nowrap;">
             <xsl:value-of select="$lang.CurrentForm" />

--- a/Chummer/sheets/Formatted Text-Only set.xslt
+++ b/Chummer/sheets/Formatted Text-Only set.xslt
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Formatted Text-Only Character Sheet -->
-<!-- Created by Adam Schmidt, srchummer5@gmail.com -->
-<!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -24,21 +23,7 @@
             <head>
                 <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
               <meta charset="UTF-8" />
-                <style type="text/css">
-                    * {
-                        font-family: 'courier new', courier;
-                        font-size: 9pt;
-                    }
-        </style>
-         <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
-          }
-        </style>
+              <xsl:call-template name="Chummer5CSS" />
            </head>
             <body>
         == <xsl:value-of select="$lang.PersonalData"/> ==
@@ -213,7 +198,7 @@
                 <br/>
                 <br/>== <xsl:value-of select="$lang.Attributes"/> ==
                 <br/>
-              <xsl:if test="attributes/attributecategory">
+              <xsl:if test="attributes/attribute[name_english = 'BOD' and (../attributecategory_english != metatypecategory)]">
                 <xsl:value-of select="$lang.CurrentForm"/>: <xsl:value-of select="attributes/attributecategory"/><br/>
               </xsl:if>
         <xsl:variable name="tBOD1">
@@ -719,10 +704,21 @@
         <xsl:value-of select="name"/>
         <xsl:if test="spec != ''"> (<xsl:value-of select="spec"/>) </xsl:if>
       </xsl:variable>
-      <xsl:call-template name="fnx-pad-r">
-        <xsl:with-param name="string" select="$snme"/>
-        <xsl:with-param name="length" select="40"/>
-      </xsl:call-template>
+      <xsl:choose>
+        <xsl:when test="string-length($snme) &gt; 29">
+          <xsl:value-of select="$snme"/>
+		  <br/>
+          <xsl:call-template name="fnx-repeat">
+            <xsl:with-param name="count" select="30"/>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="fnx-pad-r">
+            <xsl:with-param name="string" select="$snme"/>
+            <xsl:with-param name="length" select="30"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:choose>
         <xsl:when test="isnativelanguage = 'True'">
           <xsl:value-of select="$lang.Native"/>
@@ -1228,7 +1224,7 @@
         <br/>
         <xsl:call-template name="fnx-pad-r">
           <xsl:with-param name="string" select="date"/>
-          <xsl:with-param name="length" select="20"/>
+          <xsl:with-param name="length" select="22"/>
         </xsl:call-template>
         <xsl:call-template name="fnx-pad-l">
           <xsl:with-param name="string" select="amount"/>
@@ -1246,7 +1242,7 @@
         <br/>
         <xsl:call-template name="fnx-pad-r">
           <xsl:with-param name="string" select="date"/>
-          <xsl:with-param name="length" select="20"/>
+          <xsl:with-param name="length" select="22"/>
         </xsl:call-template>
         <xsl:call-template name="fnx-pad-l">
           <xsl:with-param name="string" select="amount"/>

--- a/Chummer/sheets/Game Master Summary set.xslt
+++ b/Chummer/sheets/Game Master Summary set.xslt
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Game Master character summary sheet -->
-<!-- Created by Keith Rudolph, krudolph@gmail.com -->
-<!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -22,28 +21,12 @@
         <title><xsl:value-of select="$TitleName"/></title>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
+        <xsl:call-template name="Chummer5CSS" />
+<!-- ** Override default style type definitions ** -->
         <style type="text/css">
-            * {
+          * {
             font-family: tahoma, 'trebuchet ms', arial;
             font-size: 8pt;
-            margin: 0;
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .indent {
-            padding-left: 0.5em;
-            }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
           }
         </style>
       </head>
@@ -375,7 +358,7 @@
                               (<xsl:for-each select="armormods/armormod">
                                 <xsl:sort select="name" />
                                 <xsl:value-of select="name" />
-                                <xsl:if test="rating != 0"><xsl:text> </xsl:text><xsl:value-of select="rating"/></xsl:if>
+                                <xsl:if test="rating != 0">&#160;<xsl:value-of select="rating"/></xsl:if>
                                 <xsl:if test="position() != last()">, </xsl:if>
                               </xsl:for-each>)
                             </td>
@@ -391,7 +374,7 @@
                                 <xsl:sort select="name" />
                                 <xsl:value-of select="name" />
                                 <xsl:if test="extra != ''"> (<xsl:value-of select="extra" />)</xsl:if>
-                                <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/> <xsl:value-of select="rating" /></xsl:if>
+                                <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating" /></xsl:if>
                                 <xsl:if test="qty &gt; 1"> ×<xsl:value-of select="qty" /></xsl:if>
                                 <xsl:if test="children/gear">
                                   (<xsl:for-each select="children/gear">
@@ -426,11 +409,10 @@
                   <xsl:sort select="name" />
                   <xsl:value-of select="name" />
                   <xsl:if test="martialarttechniques/martialarttechnique">
-                  (
-                  <xsl:for-each select="martialarttechniques/martialarttechnique">
-                    <xsl:value-of select="." /><xsl:if test="position() != last()">, </xsl:if>
-                  </xsl:for-each>
-                  )
+                   (<xsl:for-each select="martialarttechniques/martialarttechnique">
+                      <xsl:value-of select="name" />
+					  <xsl:if test="position() != last()">, </xsl:if>
+                    </xsl:for-each>)
                   </xsl:if>
                 </xsl:for-each></p>
               </xsl:if>

--- a/Chummer/sheets/Notes set.xslt
+++ b/Chummer/sheets/Notes set.xslt
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Character notes -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.fnxTests.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
@@ -36,12 +37,6 @@
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
         <xsl:call-template name="Chummer5CSS" />
-<!-- ** Override default style type definitions ** -->
-        <style type="text/css">
-          * {
-          font-size: 10pt;
-          }
-        </style>
       </head>
 
       <body>
@@ -390,10 +385,10 @@
               </tr>
               <xsl:for-each select="//gears/gear[(iscommlink = 'True' and (notes != '' or //notes != '')) or //*[iscommlink = 'True']/notes != '']">
                 <xsl:sort select="name"/>
-                  <xsl:call-template name="gearnotes">
-                    <xsl:with-param name="excludeCommlinks" select="False"/>
-                    <xsl:with-param name="level" select="0"/>
-                  </xsl:call-template>
+                <xsl:call-template name="gearnotes">
+                  <xsl:with-param name="excludeCommlinks" select="False"/>
+                  <xsl:with-param name="level" select="0"/>
+                </xsl:call-template>
               </xsl:for-each>
             </table>
           </div>
@@ -498,9 +493,9 @@
     </xsl:if>
     <xsl:for-each select="children/cyberware[notes != '' or //*[iscommlink != 'True']/notes != '']">
       <xsl:sort select="name"/>
-        <xsl:call-template name="cybernotes">
-            <xsl:with-param name="level" select="$level + 1"></xsl:with-param>
-        </xsl:call-template>
+      <xsl:call-template name="cybernotes">
+        <xsl:with-param name="level" select="$level + 1"></xsl:with-param>
+      </xsl:call-template>
     </xsl:for-each>
     <xsl:for-each select="gears/gear[iscommlink != 'True' and (notes != '' or //*[iscommlink != 'True']/notes != '')]">
       <xsl:sort select="name"/>
@@ -551,16 +546,16 @@
         <td/>
       </tr>
       <xsl:if test="notes != ''">
-          <tr>
-              <xsl:if test="position() mod 2 != 1">
-                  <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-              </xsl:if>
-              <td colspan="100" style="padding: 0 4%; text-align: justify;">
-                  <xsl:call-template name="PreserveLineBreaks">
-                      <xsl:with-param name="text" select="notes"/>
-                  </xsl:call-template>
-              </td>
-          </tr>
+        <tr>
+          <xsl:if test="position() mod 2 != 1">
+            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+          </xsl:if>
+          <td colspan="100" style="padding: 0 4%; text-align: justify;">
+            <xsl:call-template name="PreserveLineBreaks">
+              <xsl:with-param name="text" select="notes"/>
+            </xsl:call-template>
+          </td>
+        </tr>
       </xsl:if>
       <xsl:for-each select="gears/gear[iscommlink != 'True' and (notes != '' or //*[iscommlink != 'True']/notes != '')]">
         <xsl:sort select="name"/>
@@ -584,7 +579,7 @@
   </xsl:template>
 
   <xsl:template name="weaponnotes">
-    <xsl:param name="level"/>
+      <xsl:param name="level"/>
     <tr style="text-align: left" valign="top">
       <xsl:if test="position() mod 2 != 1"><xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute></xsl:if>
       <td style="padding: 0 {$level * 2}%;">
@@ -620,14 +615,14 @@
       </tr>
       <xsl:if test="notes != ''">
         <tr>
-            <xsl:if test="position() mod 2 != 1">
-                <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
-            </xsl:if>
-            <td colspan="100" style="padding: 0 {($level + 2) * 2}%; text-align: justify;">
-                <xsl:call-template name="PreserveLineBreaks">
-                    <xsl:with-param name="text" select="notes"/>
-                </xsl:call-template>
-            </td>
+          <xsl:if test="position() mod 2 != 1">
+            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+          </xsl:if>
+          <td colspan="100" style="padding: 0 {($level + 2) * 2}%; text-align: justify;">
+            <xsl:call-template name="PreserveLineBreaks">
+              <xsl:with-param name="text" select="notes"/>
+            </xsl:call-template>
+          </td>
         </tr>
       </xsl:if>
       <xsl:for-each select="gears/gear[iscommlink != 'True' and (notes != '' or //*[iscommlink != 'True']/notes != '')]">
@@ -654,7 +649,7 @@
   <xsl:template name="gearnotes">
     <xsl:param name="level"/>
     <xsl:param name="excludeCommlinks"/>
-    <!--
+<!--
     <xsl:choose>
       <xsl:when test="location = ''" />
       <xsl:when test="position() = 1 or location != preceding-sibling::gear[1]/location">

--- a/Chummer/sheets/Notes.xsl
+++ b/Chummer/sheets/Notes.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Notes set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
 
   <!-- Set global variables -->
   <xsl:variable name="ProduceNotes" select="true()"/>

--- a/Chummer/sheets/Shadowrun 5 (Base Skills grouped by Category).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Base Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 (Core Skills grouped by Category).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Core Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 (Core).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Core).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 (Skills by Rating within Category).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Skills by Rating within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 (Skills grouped by Rating).xsl
+++ b/Chummer/sheets/Shadowrun 5 (Skills grouped by Rating).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Shadowrun 5 set.xslt
+++ b/Chummer/sheets/Shadowrun 5 set.xslt
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Character sheet based on the Shadowrun 5th Edition Character Sheet -->
 <!-- Created by Keith Rudolph, krudolph@gmail.com -->
-<!-- Version -496 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.fnxTests.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
@@ -61,6 +61,29 @@
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
         <xsl:call-template name="Chummer5CSS" />
+<!-- ** Override default style type definitions ** -->
+        <style type="text/css">
+          * {
+          font-family: segoe, tahoma, 'trebuchet ms', arial;
+          font-size: 8.25pt;
+        </style>
+<!-- ** Additional style type definitions ** -->
+        <style type="text/css">
+          }
+          .mugshot {
+          width: auto;
+          max-width: 100%;
+          object-fit: scale-down;
+          image-rendering: optimizeQuality;
+          }
+          @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
+          .mugshot {
+          width: 100%;
+          max-width: inherit;
+          object-fit: scale-down;
+          image-rendering: optimizeQuality;
+          }
+        </style>
       </head>
       <body>
         <div class="block" style="width: 100%; text-align: center; vertical-align: center; border-bottom: thick solid #1c4a2d; margin: 0; padding-top: 0.9em; padding-bottom: 0.1em; font-weight: bold; font-variant: small-caps; font-size: 17pt; letter-spacing: 0.05em; text-shadow: 0 0 0.05em #fffff, 0 0 0.1em #1c4a2d;">
@@ -444,7 +467,7 @@
               </tr>
               <tr>
                 <xsl:choose>
-                  <xsl:when test="attributes/attributecategory">
+                  <xsl:when test="attributes/attribute[name_english = 'BOD' and (../attributecategory_english != metatypecategory)]">
                     <td width="75%" colspan="3" class="attributecell">
                       <p>
                         <xsl:value-of select="$lang.CurrentForm"/>: <xsl:value-of select="attributes/attributecategory"/>

--- a/Chummer/sheets/Shadowrun 5.xsl
+++ b/Chummer/sheets/Shadowrun 5.xsl
@@ -2,9 +2,8 @@
 <!-- Character sheet with skills listed alphabetically -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:import href="xz.language.xslt"/>
-  
+
   <xsl:import href="Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/Spirits and Sprites set.xslt
+++ b/Chummer/sheets/Spirits and Sprites set.xslt
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- Contacts List -->
-<!-- Version -500 -->
+<!-- Spirits and Sprites List -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xs.TitleName.xslt"/>
 
@@ -24,52 +24,7 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
-        <style type="text/css">
-            * {
-            font-family: 'courier new', tahoma, 'trebuchet ms', arial;
-            font-size: 10pt;
-            margin: 0;
-            text-align: center;
-            vertical-align: top;
-            }
-            html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-            }
-            body {
-            color-adjust: exact !important;
-            -webkit-print-color-adjust: exact !important;
-            print-color-adjust: exact !important;
-            }
-            .tablestyle {
-            border-collapse: collapse;
-            border-color: #1c4a2d;
-            border-style: solid;
-            border-width: 0.5mm;
-            width: 100%;
-            }
-            .upper {
-            text-transform: uppercase;
-            }
-            .title {
-            font-weight: bold;
-            text-transform: uppercase;
-            }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
-          }
-          .block {
-            bottom-padding: 0.75;
-            page-break-inside: avoid !important;
-            margin: 4px 0 4px 0;  /* to keep the page break from cutting too close to the text in the div */
-          }
-        </style>
+        <xsl:call-template name="Chummer5CSS" />
       </head>
 
       <body>

--- a/Chummer/sheets/Text-Only set.xslt
+++ b/Chummer/sheets/Text-Only set.xslt
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <!-- Text-Only Character Sheet -->
-<!-- Created by Keith Rudolph, krudolph@gmail.com -->
-<!-- Version -497 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:msxsl="urn:schemas-microsoft-com:xslt">
+  <xsl:include href="xs.Chummer5CSS.xslt"/>
   <xsl:include href="xs.fnx.xslt"/>
   <xsl:include href="xt.MovementRate.xslt"/>
   <xsl:include href="xt.PreserveHtml.xslt"/>
@@ -23,26 +22,7 @@
       <head>
         <meta http-equiv="x-ua-compatible" content="IE=Edge"/>
         <meta charset="UTF-8" />
-        <style type="text/css">
-          * {
-            font-family: 'courier new', courier;
-            font-size: 9pt;
-            margin: 0;
-          }
-          html {
-            height: 100%;
-            margin: 0px;  /* this affects the margin on the html before sending to printer */
-          }
-        </style>
-        <style media="print">
-           @page {
-            size: auto;
-            margin-top: 0.5in;
-            margin-left: 0.5in;
-            margin-right: 0.5in;
-            margin-bottom: 0.75in;
-          }
-        </style>
+        <xsl:call-template name="Chummer5CSS" />
       </head>
 
       <body>
@@ -174,39 +154,57 @@
           <br/>== <xsl:value-of select="$lang.DerivedAttributes"/> ==
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.Essence,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="26"/>
             </xsl:call-template>
             <xsl:value-of select="totaless"/>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.Initiative,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="init"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="init"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.RiggerInitiative,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="riggerinit"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="riggerinit"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.AstralInitiative,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="astralinit"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="astralinit"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.MatrixAR,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-          <xsl:value-of select="matrixarinit"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="matrixinit"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.MatrixCold,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-          <xsl:value-of select="matrixcoldinit"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="matrixcoldinit"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.MatrixHot,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-          <xsl:value-of select="matrixhotinit"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="matrixhotinit"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <xsl:variable name="PhysicalTrackTitle">
             <xsl:choose>
               <xsl:when test="physicalcmiscorecm = 'True'">
@@ -219,9 +217,12 @@
           </xsl:variable>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($PhysicalTrackTitle,': ')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="physicalcm"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="physicalcm"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
           <br/>
           <xsl:choose>
             <xsl:when test="physicalcmiscorecm != 'True' or stuncmismatrixcm = 'True'">
@@ -237,44 +238,58 @@
               </xsl:variable>
               <xsl:call-template name="fnx-pad-r">
                 <xsl:with-param name="string" select="concat($StunTrackTitle,': ')"/>
-                <xsl:with-param name="length" select="40"/>
+                <xsl:with-param name="length" select="25"/>
               </xsl:call-template>
-              <xsl:value-of select="stuncm"/>
+              <xsl:call-template name="fnx-pad-l">
+                <xsl:with-param name="string" select="stuncm"/>
+                <xsl:with-param name="length" select="2"/>
+              </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
               <xsl:call-template name="fnx-pad-r">
                 <xsl:with-param name="string" select="' '"/>
-                <xsl:with-param name="length" select="40"/>
+                <xsl:with-param name="length" select="25"/>
               </xsl:call-template>
               <xsl:value-of select="stuncm"/>
             </xsl:otherwise>
           </xsl:choose>
           <br/>
           <br/>== <xsl:value-of select="$lang.Limits"/> ==
-          <xsl:call-template name="limitmodifiersphys"/>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.Physical,':')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="limitphysical"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="limitphysical"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
             <xsl:call-template name="limitmodifiersphys"/>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.Mental,':')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="limitmental"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="limitmental"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
             <xsl:call-template name="limitmodifiersment"/>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.Social,':')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="limitsocial"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="limitsocial"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
             <xsl:call-template name="limitmodifierssoc"/>
           <br/><xsl:call-template name="fnx-pad-r">
               <xsl:with-param name="string" select="concat($lang.Astral,':')"/>
-              <xsl:with-param name="length" select="40"/>
+              <xsl:with-param name="length" select="25"/>
             </xsl:call-template>
-            <xsl:value-of select="limitastral"/>
+            <xsl:call-template name="fnx-pad-l">
+              <xsl:with-param name="string" select="limitastral"/>
+              <xsl:with-param name="length" select="2"/>
+            </xsl:call-template>
             <xsl:call-template name="limitmodifiersast"/>
 
           <br/>
@@ -496,22 +511,39 @@
         <xsl:value-of select="name"/>
         <xsl:if test="spec != ''"> (<xsl:value-of select="spec"/>) </xsl:if>
       </xsl:variable>
-      <xsl:call-template name="fnx-pad-r">
-        <xsl:with-param name="string" select="$snme"/>
-        <xsl:with-param name="length" select="40"/>
-      </xsl:call-template>
+      <xsl:choose>
+        <xsl:when test="string-length($snme) &gt; 29">
+          <xsl:value-of select="$snme"/>
+		  <br/>
+          <xsl:call-template name="fnx-repeat">
+            <xsl:with-param name="count" select="30"/>
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:call-template name="fnx-pad-r">
+            <xsl:with-param name="string" select="$snme"/>
+            <xsl:with-param name="length" select="30"/>
+          </xsl:call-template>
+        </xsl:otherwise>
+      </xsl:choose>
       <xsl:choose>
         <xsl:when test="isnativelanguage = 'True'">
           <xsl:value-of select="$lang.Native"/>
         </xsl:when>
         <xsl:otherwise>
-          <xsl:value-of select="$lang.Base"/>:
-          <xsl:value-of select="base"/>
+          <xsl:value-of select="$lang.Rtg"/>:
+          <xsl:call-template name="fnx-pad-l">
+            <xsl:with-param name="string" select="base + karma"/>
+            <xsl:with-param name="length" select="2"/>
+          </xsl:call-template>
           <xsl:call-template name="fnx-repeat">
-            <xsl:with-param name="count" select="10"/>
+            <xsl:with-param name="count" select="3"/>
           </xsl:call-template>
           <xsl:value-of select="$lang.Pool"/>:
-          <xsl:value-of select="total"/>
+          <xsl:call-template name="fnx-pad-l">
+            <xsl:with-param name="string" select="total"/>
+            <xsl:with-param name="length" select="2"/>
+          </xsl:call-template>
           <xsl:if test="spec != '' and exotic = 'False'">
             (<xsl:value-of select="specializedrating"/>)
           </xsl:if>
@@ -541,7 +573,7 @@
           <xsl:if test="role != ''">
             <xsl:value-of select="role"/>
           </xsl:if>
-          (<xsl:value-of select="connection"/>, <xsl:value-of select="loyalty"/>)
+          (<xsl:value-of select="connection"/>,<xsl:value-of select="loyalty"/>)
         </xsl:otherwise>
       </xsl:choose>
     </xsl:for-each>
@@ -575,7 +607,7 @@
       <xsl:sort select="name"/>
       <br/><xsl:value-of select="name"/>
         <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-        <xsl:if test="rating &gt; 0"> <xsl:value-of select="$lang.Rating"/>: <xsl:value-of select="rating"/></xsl:if>
+        <xsl:if test="rating &gt; 0">&#160;<xsl:value-of select="$lang.Rating"/>: <xsl:value-of select="rating"/></xsl:if>
     </xsl:for-each>
   </xsl:template>
 
@@ -584,7 +616,7 @@
       <xsl:sort select="name"/>
       <br/><xsl:value-of select="name"/>
         <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-        <xsl:if test="rating &gt; 0"> <xsl:value-of select="$lang.Rating"/>: <xsl:value-of select="rating"/></xsl:if>
+        <xsl:if test="rating &gt; 0">&#160;<xsl:value-of select="$lang.Rating"/>: <xsl:value-of select="rating"/></xsl:if>
     </xsl:for-each>
   </xsl:template>
 
@@ -593,7 +625,7 @@
       <xsl:sort select="name"/>
       <br/><xsl:value-of select="name"/>
       <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-      <xsl:if test="rating &gt; 0"> <xsl:value-of select="$lang.Rating"/>: <xsl:value-of select="rating"/></xsl:if>
+      <xsl:if test="rating &gt; 0">&#160;<xsl:value-of select="$lang.Rating"/>: <xsl:value-of select="rating"/></xsl:if>
       <xsl:if test="programoptions/programoption">
         (<xsl:for-each select="programoptions/programoption">
           <xsl:sort select="name"/>
@@ -640,7 +672,7 @@
       <xsl:sort select="name"/>
       <br/><xsl:value-of select="name"/>
         (<xsl:value-of select="baselifestyle"/>)
-        <xsl:value-of select="months"/>&#160;
+        <xsl:value-of select="months"/><xsl:text> </xsl:text>
       <xsl:choose>
         <xsl:when test="increment = 'Day'">
           <xsl:choose>
@@ -689,7 +721,7 @@
         <xsl:if test="children/cyberware">
           <xsl:for-each select="children/cyberware">
             <br/>&#160;&#160;&#160;+ <xsl:value-of select="name"/>
-            <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+            <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
           </xsl:for-each>
         </xsl:if>
     </xsl:for-each>
@@ -741,7 +773,7 @@
       <xsl:value-of select="$lang.DP"/>: <xsl:value-of select="dataprocessing"/>,
       <xsl:value-of select="$lang.FWL"/>: <xsl:value-of select="firewall"/>)
       <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-      <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+      <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
       <xsl:if test="qty &gt; 1"> ×<xsl:value-of select="qty"/></xsl:if>
       <xsl:if test="children/gear">
         <xsl:for-each select="children/gear">
@@ -834,7 +866,7 @@
       <xsl:value-of select="$lang.DP"/>: <xsl:value-of select="dataprocessing"/>,
       <xsl:value-of select="$lang.FWL"/>: <xsl:value-of select="firewall"/>)
       <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-      <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+      <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
       <xsl:if test="qty &gt; 1"> ×<xsl:value-of select="qty"/></xsl:if>
       <xsl:if test="children/gear">
         <xsl:for-each select="children/gear">
@@ -880,7 +912,7 @@
       <xsl:value-of select="$lang.DP"/>: <xsl:value-of select="dataprocessing"/>,
       <xsl:value-of select="$lang.FWL"/>: <xsl:value-of select="firewall"/>)
       <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-      <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+      <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
       <xsl:if test="qty &gt; 1"> ×<xsl:value-of select="qty"/></xsl:if>
       <xsl:if test="children/gear">
         <xsl:for-each select="children/gear">
@@ -932,7 +964,7 @@
         <xsl:for-each select="children/gear">
           <br/>&#160;&#160;&#160;+ <xsl:value-of select="name"/>
           <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-          <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+          <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
           <xsl:if test="children/gear">
             [<xsl:for-each select="children/gear">
               <xsl:sort select="name"/>
@@ -1015,13 +1047,13 @@
           <xsl:sort select="name"/>
           <br/>&#160;&#160;&#160;+ <xsl:value-of select="name"/>
             <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-            <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+            <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
             <xsl:if test="qty &gt; 1"> ×<xsl:value-of select="qty"/></xsl:if>
             <xsl:if test="children/gear">
               <xsl:for-each select="children/gear">
                 <br/>&#160;&#160;&#160;&#160;&#160;&#160;+ <xsl:value-of select="name"/>
                 <xsl:if test="extra != ''"> (<xsl:value-of select="extra"/>)</xsl:if>
-                <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+                <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
                 <xsl:if test="children/gear">
                   [<xsl:for-each select="children/gear">
                     <xsl:sort select="name"/>
@@ -1060,7 +1092,7 @@
               (<xsl:for-each select="cyberwares/cyberware">
                 <xsl:sort select="name"/>
                 <br/>&#160;&#160;&#160;&#160;&#160;&#160;+ <xsl:value-of select="name"/>
-                <xsl:if test="rating != 0"> <xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
+                <xsl:if test="rating != 0">&#160;<xsl:value-of select="$lang.Rating"/>&#160;<xsl:value-of select="rating"/></xsl:if>
               </xsl:for-each>)
             </xsl:if>
         </xsl:for-each>
@@ -1123,8 +1155,8 @@
       <xsl:sort select="name"/>
       <br/><xsl:value-of select="name"/>
       <xsl:for-each select="martialarttechniques/martialarttechnique">
-        <xsl:sort select="."/>
-        <br/>&#160;&#160;&#160;+ <xsl:value-of select="."/>
+        <xsl:sort select="name"/>
+        <br/>&#160;&#160;&#160;+ <xsl:value-of select="name"/>
       </xsl:for-each>
     </xsl:for-each>
   </xsl:template>
@@ -1134,7 +1166,7 @@
       <br/>
       <xsl:call-template name="fnx-pad-r">
         <xsl:with-param name="string" select="date"/>
-        <xsl:with-param name="length" select="20"/>
+        <xsl:with-param name="length" select="22"/>
       </xsl:call-template>
       <xsl:call-template name="fnx-pad-l">
         <xsl:with-param name="string" select="amount"/>
@@ -1152,7 +1184,7 @@
       <br/>
       <xsl:call-template name="fnx-pad-r">
         <xsl:with-param name="string" select="date"/>
-        <xsl:with-param name="length" select="20"/>
+        <xsl:with-param name="length" select="22"/>
       </xsl:call-template>
       <xsl:call-template name="fnx-pad-l">
         <xsl:with-param name="string" select="amount"/>

--- a/Chummer/sheets/de-de/Notes.xsl
+++ b/Chummer/sheets/de-de/Notes.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Notes set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
 
   <!-- Set global variables -->
   <xsl:variable name="ProduceNotes" select="true()"/>

--- a/Chummer/sheets/de-de/Shadowrun 5 (Base Skills grouped by Category).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Base Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5 (Core Skills grouped by Category).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Core Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5 (Core).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Core).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5 (Skills by Rating within Category).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Skills by Rating within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5 (Skills grouped by Rating).xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5 (Skills grouped by Rating).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/de-de/Shadowrun 5.xsl
+++ b/Chummer/sheets/de-de/Shadowrun 5.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Notes.xsl
+++ b/Chummer/sheets/fr-fr/Notes.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Notes set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
 
   <!-- Set global variables -->
   <xsl:variable name="ProduceNotes" select="true()"/>

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Base Skills grouped by Category).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Base Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Core Skills grouped by Category).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Core Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Core).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Core).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Skills by Rating within Category).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Skills by Rating within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5 (Skills grouped by Rating).xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5 (Skills grouped by Rating).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/fr-fr/Shadowrun 5.xsl
+++ b/Chummer/sheets/fr-fr/Shadowrun 5.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Notes.xsl
+++ b/Chummer/sheets/ja-jp/Notes.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Notes set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
 
   <!-- Set global variables -->
   <xsl:variable name="ProduceNotes" select="true()"/>

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Base Skills grouped by Category).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Base Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Core Skills grouped by Category).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Core Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Core).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Core).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Skills by Rating within Category).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Skills by Rating within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5 (Skills grouped by Rating).xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5 (Skills grouped by Rating).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/ja-jp/Shadowrun 5.xsl
+++ b/Chummer/sheets/ja-jp/Shadowrun 5.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Notes.xsl
+++ b/Chummer/sheets/pt-br/Notes.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Notes set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
 
   <!-- Set global variables -->
   <xsl:variable name="ProduceNotes" select="true()"/>

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Base Skills grouped by Category).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Base Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Core Skills grouped by Category).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Core Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Core).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Core).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Skills by Rating within Category).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Skills by Rating within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5 (Skills grouped by Rating).xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5 (Skills grouped by Rating).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/pt-br/Shadowrun 5.xsl
+++ b/Chummer/sheets/pt-br/Shadowrun 5.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/xs.Chummer5CSS.xslt
+++ b/Chummer/sheets/xs.Chummer5CSS.xslt
@@ -2,34 +2,28 @@
 <!-- CSS stylesheet definitions -->
 
 <!-- These are the common CSS type definitions for the Chummer5a character sheets.
-     They are not used by all the character sheets, just ones that have multiple
-     common definitions such as Notes and the Shadowrun 5* sheets.
 
-     To create a language specific version:
-     1) this member should be copied to the appropriate language sub-folder and changes made.
-     2) The character sheet XSL stylesheets that import these definitions have to be
-        modified, changing the xsl:import statement:
-          from href="../xs.Chummer5CSS.xslt" to href="xs.Chummer5CSS.xslt"
-        (FYI: this tells the processor to import the member from the language sub-folder
-         instead of the parent directory - indicated by the ../ before the member name)
+     They are not used by the Fancy Blocks and Vehicles character sheets - there is so little
+     overlap between those sheets and these common definitions that it is simpler to keep
+	 the separate definitions.
 
-     Changes made to these definitions should also be made to the language specific versions.
-     (Note: currently these are German and Portuguese character sheets.)
+     Note: Individual character sheets may override some of these definitions,
+     e.g. changing font size or font family used, or have additional definitions.
 -->
 
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:msxsl="urn:schemas-microsoft-com:xslt">
   <xsl:template name="Chummer5CSS">
     <style type="text/css">
       * {
-        font-family: segoe, tahoma, 'trebuchet ms', arial;
-        font-size: 8.25pt;
+        font-family: 'courier new', tahoma, 'trebuchet ms', arial;
+        font-size: 10pt;
         margin: 0;
         text-align: left;
         vertical-align: top;
         }
         html {
         height: 100%;
-        margin: 0em;  /* this affects the margin on the html before sending to printer */
+        margin: 0px;  /* this affects the margin on the html before sending to printer */
         }
         body {
         color-adjust: exact !important;
@@ -75,34 +69,11 @@
         }
         .block {
         bottom-padding: 0;
-        page-break-inside: avoid;
+        page-break-inside: avoid !important;
         margin: 1em 0 0 0;  /* to keep the page break from cutting too close to the text in the div */
-        }
-        .mugshot {
-        width: auto;
-        max-width: 100%;
-        object-fit: scale-down;
-        image-rendering: optimizeQuality;
-        }
-        @media screen and (-ms-high-contrast: active), (-ms-high-contrast: none) {
-        .mugshot {
-        width: 100%;
-        max-width: inherit;
-        object-fit: scale-down;
-        image-rendering: optimizeQuality;
         }
       }
     </style>
-    <!--[if IE]
-        <style type="text/css">
-        .mugshot {
-          width: 100%;
-          max-width: inherit;
-          object-fit: scale-down;
-          image-rendering: optimizeQuality;
-          }
-        </style>
-        -->
     <style media="print">
       @page {
       size: auto;
@@ -111,6 +82,26 @@
       margin-right: 0.5in;
       margin-bottom: 0.5in;
       }
+      .block {
+      bottom-padding: 0.75;
+      page-break-inside: avoid !important;
+      margin: 4px 0 4px 0;  /* to keep the page break from cutting too close to the text in the div */
+      }
     </style>
+<!-- ** remove use of uppercase in titles ** -->
+    <xsl:if test="lang = 'de' or lang = 'pt'">
+      <style type="text/css">
+        * {
+          th {
+          text-align: center;
+          }
+          .title {
+          font-weight: bold;
+          }
+          .upper {
+          }
+        }
+      </style>
+    </xsl:if>
   </xsl:template>
 </xsl:stylesheet>

--- a/Chummer/sheets/zh-cn/Notes.xsl
+++ b/Chummer/sheets/zh-cn/Notes.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Notes set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
 
   <!-- Set global variables -->
   <xsl:variable name="ProduceNotes" select="true()"/>

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Base Skills grouped by Category).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Base Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Core Skills grouped by Category).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Core Skills grouped by Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Core).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Core).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Skills by Rating greater 0 within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Skills by Rating within Category).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Skills by Rating within Category).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Skills grouped by Rating greater 0).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByRating.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5 (Skills grouped by Rating).xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5 (Skills grouped by Rating).xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
 
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedByPool.xslt"/>
 
   <!-- Set global control variables -->

--- a/Chummer/sheets/zh-cn/Shadowrun 5.xsl
+++ b/Chummer/sheets/zh-cn/Shadowrun 5.xsl
@@ -4,7 +4,6 @@
   <xsl:import href="xz.language.xslt"/>
   
   <xsl:import href="../Shadowrun 5 set.xslt"/>
-  <xsl:import href="../xs.Chummer5CSS.xslt"/>
   <xsl:import href="../xs.SkillsGroupedAssorted.xslt"/>
 
   <!-- Set global control variables -->


### PR DESCRIPTION
There were several sets of changes loaded to pull #4308 but only the last set were added to Chummer. This pull applies the missing changes.

**Character sheets css definitions file**
The main update in the original pull was standardization of the css definitions in the character sheets.

Several years ago there was a request to prevent column heading being in uppercase for German versions of the Chummer 5* character sheets. This was done by moving the definitions to a separate xslt file for each language folder, without uppercase for the German and Portuguese versions. Since then several changes were made in the base version (used just for the US sheets) that were not applied to the separate language versions.

My original intention was to use a single version of the css definitions file for all languages except for German and Portuguese, minimizing the number of css files that needed to be maintained. Delnar Ersike indicated that template overrides could be used to change css definitions. So I added overrides for German and Portuguese to prevent uppercase folding meaning only one css definitions file is now needed.

In addition Delnar suggested the css file could be used in the other character sheets, as many of the sheets have the same values. I renamed the "Shadowrun 5 set CSS.xslt" file as "xs.Chummer5CSS.xslt" to show it is for general use not just the Shadowrun 5* sheets. Some of the character sheets override default values such as font size.

The common definitions file is not used by the Fancy Blocks and Vehicles sheets because there is so little overlap of the css definitions.

**Calender sheet**
Added use of common css file definition.

**Commlinks sheet**
Added use of common css file definition.

**Contacts sheet**
1) Added use of common css file definition.
2) Correctly set column headings formats for Contact archetype information.

**Dossier sheet**
Added use of common css file definition.

**Expenses sheet**
1) Added use of common css file definition.
2) Adjusted positioning of "Total" to better fit the column

**Fancy Blocks sheet**
Only show "Current Form" box for a shapeshifter when a shifted form is being displayed.

**Formatted Text-Only sheet**
1) Added use of common css file definition.
2) Only show "Current Form" box for a shapeshifter when a shifted form is being displayed.
3) Split skill name line if the length of name pushes the values out of position.
4) Corrected formatting of Attributes spacing when enhanced values are present.
5) Correct expenses amount columns to line up values.
6) Adjusted double space between literal and value for various fields.
7) Print appropriate literal for Tradition or Stream depending on the type of character.
8) In various places the "Rating" literal and value were printed without a space. Corrected.

**Game Master Summary sheet**
1) Added use of common css file definition.
2) Correct display of Martial Arts technique to just the name instead of the entire node.

**Notes sheet**
1) Added use of common css file definition.
2) Reviewed character file to identify as many notes nodes as possible.
Added sections to the Notes sheet to display these notes:

Powers
Martial Arts and any maneuvers
Cyber/bioware
Armor
Melee and Ranged Weapons
Gear
Devices
Programs

Thanks to Delnar Ersike for determining how to display notes from nested items beyond immediate children (a gear item can have sub-items that can also have sub-items, any of which can have notes).

**Shadowrun 5 character sheets**
1) Added use of common css file definition.
2) Modified printing of notes for martial Arts and maneuvers to match Notes sheet.
3) Modified the formatting of Ranged Weapons table to show the quantity of thrown weapons (from Gear) instead of the Ammo fixed amount of 1 (issue #3861).
4) Only show "Current Form" box for a shapeshifter when a shifted form is being displayed.
5) Removed display of notes from the Gear columns - even small notes can mess with the layout of the columns. These notes have been added to the Notes sheet.
Note: This includes notes from devices, that are already displayed in the Devices section.
6) Modified display of Armor list to separate Equipped and other into separate blocks.
7) Sort the list of weapons by Location (similar to the way gear is displayed).

**Sprites and Spirts sheet**
Added use of common css file definition.

**Text-Only character sheet**
1) Added use of common css file definition.
2) Split skill name line if the length of name pushes the values out of position.
3) Sheet originally printed the Base value of skill but missed the Karma amount. Changed the literal to "Rtg" and added the Base and karma values together.
4) In various places the "Rating" literal and value were printed without a space. Corrected.

**Vehicles sheet**
The formatting of the Ranged Weapons section to show the quantity instead of Ammo instead of a fixed amount of 1 has been added automatically as the sheet uses the common ranged weapons formatting file.

**other changes**
xs.fnx.xslt - modified to correctly process leading zeroes and decimals.

Created xt.MartialArts.xslt to format notes from Martial Arts and any maneuvers. This is used by the Notes and Shadowrun 5* sheets.

xs.RangedWeapons.xslt - this is where the changes to the display of Thrown Weapons have been made. This is used by the Shadowrun 5* and Vehicles sheets.