### PR TITLE
Deleted unused and redundant translation entries

### DIFF
--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -28459,13 +28459,6 @@
                 <translate>Natürliche Waffe: Tritt (Zentaur)</translate>
                 <altpage>81</altpage>
             </quality>
-            <quality translated="True">
-                <id>244dea68-fe8b-4532-954a-4ff2f78952f8</id>
-                <name>Magic Sense</name>
-                <source>SG</source>
-                <translate>Magiegespühr</translate>
-                <altpage>203</altpage>
-            </quality>
             <quality>
                 <id>efc80d70-30ec-4460-bddb-f6006333dd3b</id>
                 <name>Natural Weapon: Bite (Naga)</name>
@@ -28820,7 +28813,7 @@
                 <id>912bef16-2f72-45e2-95bb-96ef7eea4811</id>
                 <name>Magic Sense</name>
                 <source>RF</source>
-                <translate>Magiegespür</translate>
+                <translate>Magiegespür (Metagenetisch)</translate>
                 <altpage>93</altpage>
             </quality>
             <quality>

--- a/Chummer/lang/fr-fr_data.xml
+++ b/Chummer/lang/fr-fr_data.xml
@@ -31344,12 +31344,6 @@
                 <altnameonpage></altnameonpage>
             </quality>
             <quality translated="True">
-                <id>244dea68-fe8b-4532-954a-4ff2f78952f8</id>
-                <name>Magic Sense</name>
-                <translate>Sens magique</translate>
-                <altpage>172</altpage>
-            </quality>
-            <quality translated="True">
                 <id>efc80d70-30ec-4460-bddb-f6006333dd3b</id>
                 <name>Natural Weapon: Bite (Naga)</name>
                 <translate>Arme naturelle : Morsure (Naga)</translate>

--- a/Chummer/lang/ja-jp_data.xml
+++ b/Chummer/lang/ja-jp_data.xml
@@ -28677,12 +28677,6 @@
                 <altpage>105</altpage>
             </quality>
             <quality>
-                <id>244dea68-fe8b-4532-954a-4ff2f78952f8</id>
-                <name>Magic Sense</name>
-                <translate>Magic Sense</translate>
-                <altpage>172</altpage>
-            </quality>
-            <quality>
                 <id>efc80d70-30ec-4460-bddb-f6006333dd3b</id>
                 <name>Natural Weapon: Bite (Naga)</name>
                 <translate>Natural Weapon: Bite (Naga)</translate>

--- a/Chummer/lang/pt-br_data.xml
+++ b/Chummer/lang/pt-br_data.xml
@@ -24185,12 +24185,6 @@
                 <altpage>105</altpage>
             </quality>
             <quality>
-                <id>244dea68-fe8b-4532-954a-4ff2f78952f8</id>
-                <name>Magic Sense</name>
-                <translate>Magic Sense</translate>
-                <altpage>172</altpage>
-            </quality>
-            <quality>
                 <id>efc80d70-30ec-4460-bddb-f6006333dd3b</id>
                 <name>Natural Weapon: Bite (Naga)</name>
                 <translate>Natural Weapon: Bite (Naga)</translate>


### PR DESCRIPTION
It seems like an old ID was still present in some language file and this caused problems at least if Chummer was on Ger.
It wasn't used in any data file and the translation was redundant.

This fixes the first issue of #4376 