### PR TITLE
Allows to select corruption for Elder God mages

### DIFF
--- a/Chummer/data/metamagic.xml
+++ b/Chummer/data/metamagic.xml
@@ -162,9 +162,10 @@
       <adept>False</adept>
       <magician>True</magician>
       <required>
-        <allof>
+        <oneof>
           <metamagic>Paradigm Shift: Toxic</metamagic>
-        </allof>
+          <tradition>Elder God</tradition>
+        </oneof>
       </required>
       <source>SG</source>
       <page>87</page>


### PR DESCRIPTION
#4385 

Just allows the Metamagic to be chosen by mages with the tradition "Elder God".

It actually is forced by the tradition to choose this Metamagic as it's first, but I'm not aware of an framework
for this right now.