### PR TITLE
Minor data file additions and corrections

### DIFF
--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -1858,6 +1858,9 @@
     <Content Include="customdata\Education Qualities Apply Karma Discount in Create Mode\amend_qualities.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="customdata\Exclude German sourcebooks\amend_german_books.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="customdata\Hand-Based Cyberware Can Go Anywhere\amend_cyberware.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Chummer/customdata/Exclude German sourcebooks/amend_german_books.xml
+++ b/Chummer/customdata/Exclude German sourcebooks/amend_german_books.xml
@@ -17,62 +17,8 @@
     You can obtain the full source code for Chummer5a at
     https://github.com/chummer5a/chummer5a
 -->
-<chummer>
+<chummer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema books.xsd">
   <books>
-    <!-- Region Specifically excluded (designated as Optional) -->
-    <book>
-      <name>Bullets &amp; Bandages</name>
-      <hide />
-    </book>
-    <!-- End Region -->
-    <!-- Region Specifically excluded (not intended for Missions play) -->
-    <book>
-      <name>Splintered State</name>
-      <hide />
-    </book>
-    <book>
-      <name>Bloody Business</name>
-      <hide />
-    </book>
-    <book>
-      <name>Shadows In Focus: Sioux Nation: Counting Coup</name>
-      <hide />
-    </book>
-    <book>
-      <name>Dark Terrors</name>
-      <hide />
-    </book>
-<!--
-    Note: These books are excluded but have no rules/equipment that need to be supported in Chummer5a 
-
-          Serrated Edge, Denver Adventure 1
-          False Flag, Denver Adventure 1
-          Battle of Manhattan
-          Shadows In Focus: Sioux Nation: Starving the Masses
--->
-    <!-- End Region -->
-    <!-- Region Equipment/rules specifically excluded by Missions FAQ -->
-    <book>
-      <name>Data Trails (Dissonant Echoes)</name>
-      <hide />
-    </book>
-    <!-- End Region -->
-    <!-- Region Not specifically included in Missions FAQ -->
-    <book>
-      <name>Hong Kong Sourcebook</name>
-      <hide />
-    </book>
-    <book>
-      <name>Shadowrun 2050 (5th Edition)</name>
-      <hide />
-    </book>
-    <book>
-      <name>No Future</name>
-      <!-- Note: this is for 6e -->
-      <hide />
-    </book>
-    <!-- End Region -->
-    <!-- Region German (not specifically included in Missions FAQ) -->
     <book>
       <name>Shadowrun 5th Edition (German-exclusive Content)</name>
       <hide />
@@ -117,6 +63,5 @@
       <name>Datapuls Verschlusssache (German-exclusive)</name>
       <hide />
     </book>
-    <!-- End Region -->
   </books>
 </chummer>

--- a/Chummer/customdata/SR Missions 1.4 Neotokyo/amend_qualities.xml
+++ b/Chummer/customdata/SR Missions 1.4 Neotokyo/amend_qualities.xml
@@ -19,9 +19,11 @@
 -->
 <chummer>
   <qualities>
+    <!--Region Run Faster Positive Qualities-->
     <quality>
       <name>Made Man</name>
       <hide />
     </quality>
+    <!-- End Region-->
   </qualities>
 </chummer>

--- a/Chummer/customdata/SR Missions 1.4 Rules/amend_qualities.xml
+++ b/Chummer/customdata/SR Missions 1.4 Rules/amend_qualities.xml
@@ -18,24 +18,8 @@
     https://github.com/chummer5a/chummer5a
 -->
 <chummer>
-  <!--Region Shadowrun Core Positive Qualities -->
   <qualities>
-    <quality>
-      <name>Deus Vult!</name>
-      <hide />
-    </quality>
-    <quality>
-      <name>My Country, Right or Wrong</name>
-      <hide />
-    </quality>
-    <quality>
-      <name>Brand Loyalty (Manufacturer)</name>
-      <hide />
-    </quality>
-    <quality>
-      <name>Brand Loyalty (Product)</name>
-      <hide />
-    </quality>
+    <!-- Region Shadowrun Core Positive Qualities -->
     <quality>
       <name>Bad Rep</name>
       <hide />
@@ -65,17 +49,41 @@
       <hide />
     </quality>
     <quality>
-      <name>Earther</name>
-      <hide />
-    </quality>
-    <quality>
       <name>Unsteady Hands</name>
       <hide />
     </quality>
-    <!--Region Sail Away, Sweet Sister Positive Qualities -->
+    <!-- End Region-->
+    <!-- Region Assassin's Positive Qualities -->
+    <quality>
+      <name>Deus Vult!</name>
+      <hide />
+    </quality>
+    <quality>
+      <name>My Country, Right or Wrong</name>
+      <hide />
+    </quality>
+    <!-- End Region-->
+    <!-- Region Run & Gun Positive Qualities -->
+     <quality>
+      <name>Brand Loyalty (Manufacturer)</name>
+      <hide />
+    </quality>
+    <quality>
+      <name>Brand Loyalty (Product)</name>
+      <hide />
+    </quality>
+    <!-- End Region-->
+    <!-- Region Run & Gun Negative Qualities -->
+    <quality>
+      <name>Earther</name>
+      <hide />
+    </quality>
+    <!-- End Region-->
+    <!-- Region Sail Away, Sweet Sister Positive Qualities -->
+    <!-- (excluded because of newer versions in Run Faster) -->
     <quality>
       <id>4e2ddf3d-802f-4206-85ce-81f1defa528f</id>
-      <!--College Education -->
+      <!-- College Education -->
       <hide />
     </quality>
     <quality>
@@ -83,8 +91,7 @@
       <hide />
     </quality>
     <!-- End Region-->
-    <!--Region Run Faster -->
-    <!--Region Run Faster Positive Qualities -->
+    <!-- Region Run Faster Positive Qualities -->
     <quality>
       <name>Changeling (Class I SURGE)</name>
       <hide />
@@ -134,7 +141,7 @@
       <hide />
     </quality>
     <!-- End Region-->
-    <!--Region Run Faster Negative Qualities -->
+    <!-- Region Run Faster Negative Qualities -->
     <quality>
       <name>Amnesia (Surface Loss)</name>
       <hide />
@@ -350,9 +357,7 @@
       <hide />
     </quality>
     <!-- End Region -->
-    <!-- End Region -->
-    <!-- Region Data Trails-->
-    <!--Region Data Trails Positive Qualities -->
+    <!-- Region Data Trails Positive Qualities -->
     <quality>
       <name>Online Fame</name>
       <hide />
@@ -366,7 +371,7 @@
       </required>
     </quality>
     <!-- End Region -->
-    <!--Region Data Trails Negative Qualities -->
+    <!-- Region Data Trails Negative Qualities -->
     <quality>
       <name>Curiosity Killed the Cat</name>
       <hide />
@@ -388,10 +393,8 @@
       <hide />
     </quality>
     <!-- End Region -->
-    <!-- End Region -->
-    <!-- Region Chrome Flesh -->
-    <!--Region Chrome Flesh Positive Qualities -->
-	<quality>
+    <!-- Region Chrome Flesh Positive Qualities -->
+    <quality>
       <name>Better to be Feared Than Loved</name>
       <hide />
     </quality>
@@ -400,7 +403,7 @@
       <karma>20</karma>
     </quality>
     <!-- End Region -->
-    <!--Region Chrome Flesh Negative Qualities -->
+    <!-- Region Chrome Flesh Negative Qualities -->
     <quality>
       <name>Blank Slate</name>
       <hide />
@@ -418,22 +421,17 @@
       <hide />
     </quality>
     <!-- End Region -->
-    <!-- End Region -->
-    <!-- Region Hard Targets -->
     <!-- Region Hard Targets Negative Qualities-->
     <quality>
       <name>Code of Honor: Avenging Angel</name>
       <hide />
     </quality>
     <!-- End Region -->
-    <!-- End Region -->
-    <!-- Region Rigger 5.0-->
-    <!-- Region Negative Qualities -->
+    <!-- Region Rigger 5.0 Negative Qualities -->
     <quality>
       <name>Too Much Data</name>
       <hide />
     </quality>
-    <!-- End Region -->
     <!-- End Region -->
     <!-- Region Howling Shadows -->
     <quality>
@@ -457,16 +455,13 @@
       <hide />
     </quality>
     <!-- End Region -->
-    <!-- Region Cutting Aces -->
-    <!-- Region Negative Qualities -->
+    <!-- Region Cutting Aces Negative Qualities -->
     <quality>
       <name>Alpha Junkie</name>
       <hide />
     </quality>
     <!-- End Region -->
-    <!-- End Region -->
-    <!-- Region Forbidden Arcana -->
-    <!-- Region Mastery Qualities -->
+    <!-- Region Forbidden Arcana Mastery Qualities -->
     <quality>
       <name>Barehanded Adept</name>
       <hide />
@@ -599,7 +594,6 @@
       <name>Crystalline Vision</name>
       <hide />
     </quality>
-    <!-- End Region -->
     <!-- End Region -->
   </qualities>
 </chummer>

--- a/Chummer/customdata/SR Missions 1.4 Rules/amend_weapons.xml
+++ b/Chummer/customdata/SR Missions 1.4 Rules/amend_weapons.xml
@@ -21,11 +21,22 @@
   <weapons>
     <weapon>
       <id>40bf3eed-b239-4521-ac1d-80a4e472451e</id>
+      <!--Ultimax Rain Forest Carbine-->
       <accuracy>5</accuracy>
       <damage>11P</damage>
       <ap>-2</ap>
       <mode>SA/BF</mode>
       <avail>8R</avail>
+    </weapon>
+    <weapon>
+      <id>21fb8d4f-5958-4fd9-996f-7e88ee0282c2</id>
+      <!--Microwave Gun, High Frequency-->
+      <hide />
+    </weapon>
+    <weapon>
+      <id>10fb69db-efd0-4f63-80a7-bda5ef0480a4</id>
+      <!--Microwave Gun, Low Frequency-->
+      <hide />
     </weapon>
   </weapons>
 </chummer>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -5310,8 +5310,8 @@
       <key>Label_FiringMode</key>
       <text>Firing Mode:</text>
     </string>
-    <!-- Region Firing Mode Enums-->
     <!-- End Region -->
+    <!-- Region Firing Mode Enums-->
     <string>
       <key>Enum_Skill</key>
       <text>Character Skill</text>
@@ -5981,7 +5981,7 @@
     <string>
       <key>Tip_OtherCareerKarma</key>
       <text>The amount of Karma the character has accumulated over their career.</text>
-    </string>s
+    </string>
     <!-- End Region-->
     <!-- Region Condition Monitor Tab -->
     <string>


### PR DESCRIPTION
**data -> books**
Added explanation about omitted books
Lines 247/252 - spacing at start of lines

**customdata -> Exclude German sourcebooks (new)**
German sourcebooks are already excluded by the SR Missions ruleset.
This new Custom Data Directory allows German sourcebooks to be excluded separately from the Missions rules.

**customdata -> SR Missions 1.4 Neotokyo -> amend_qualities**
Added comments showing sourcebook

**customdata -> SR Missions 1.4 Rules -> amend_books**
Added additional German sourcebooks - German sourcebooks are excluded under Missions rules

**customdata -> SR Missions 1.4 Rules -> amend_qualities**
Rearranged qualities by sourcebook

**customdata -> SR Missions 1.4 Rules -> amend_weapons**
Hide Microwave Guns - they are not permitted in Missions (SRM Combined FAQ Section 14: Lockdown and Counting Coup)

**lang -> en-us**
Lines 5313/5314 - swapped comments to correctly identify the previous region end and new region start
Line 5984 - removed extraneous "s" after </string>