### PR TITLE
Fixed conflicting guid for mentro great mother (SG) and discussion how to handle this mentor.

### DIFF
--- a/Chummer/customdata/German Data Changes/amend_mentors.xml
+++ b/Chummer/customdata/German Data Changes/amend_mentors.xml
@@ -17,11 +17,6 @@
     You can obtain the full source code for Chummer5a at
     https://github.com/chummer5a/chummer5a
 -->
-<!--
-  Hide the German skilljack because it's stupid
-  Set skilljack to flat 0.1 ess and R*1000 cost
-  Set skillwires to R*0.1 ess
--->
 <chummer>
   <mentors>
     <mentor>
@@ -46,6 +41,14 @@
           </bonus>
         </choice>
       </choices>
+    </mentor>
+    <mentor> <!--Great Mother SG-->
+      <id>a23c8a3d-b056-4173-88e4-e73bb64dd731</id>
+      <hide amendoperation="remove" />
+    </mentor>
+    <mentor> <!--Great Mother SASS-->
+      <id>7a837193-2b58-49be-9dbb-c1c0c108ca6e</id>
+      <hide />
     </mentor>
   </mentors>
 </chummer>

--- a/Chummer/customdata/German Data Changes/custom_mentors.xml
+++ b/Chummer/customdata/German Data Changes/custom_mentors.xml
@@ -228,41 +228,5 @@
       <source>SG</source>
       <page>234</page>
     </mentor>
-    <mentor>
-      <id>a23c8a3d-b056-4173-88e4-e73bb64dd731</id>
-      <name>Große Mutter (SG)</name>
-      <advantage>Allgemein: +2 Würfel für Proben auf erste Hilfe</advantage>
-      <disadvantage>Immer wenn ein Anhänger der Großen Mutter absichtlich oder unabsichtlich dem lebensspendenden Wesen der Natur (seiner Auslegung) zuwiderhandelt, erleidet er einen Würfelpoolmodifikator von -1 auf alle Handlungen, bis er seine Zuwiderhandlung wiedergutgemacht hat.</disadvantage>
-      <choices>
-        <choice>
-          <name>+2 to First Aid</name>
-          <bonus>
-            <specificskill>
-              <name>First Aid</name>
-              <bonus>2</bonus>
-            </specificskill>
-          </bonus>
-        </choice>
-        <choice set="2">
-          <name>+2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</name>
-          <bonus>
-            <spellcategory>
-              <name>Health</name>
-              <val>2</val>
-            </spellcategory>
-          </bonus>
-        </choice>
-        <choice set="2">
-          <name>Empathische Heilung gratis</name>
-          <bonus>
-            <specificpower>
-              <name>Empathic Healing</name>
-            </specificpower>
-          </bonus>
-        </choice>
-      </choices>
-      <source>SG</source>
-      <page>232</page>
-    </mentor>
   </mentors>
 </chummer>

--- a/Chummer/customdata/German Data Changes/custom_mentors.xml
+++ b/Chummer/customdata/German Data Changes/custom_mentors.xml
@@ -230,7 +230,7 @@
     </mentor>
 
     <mentor>
-      <id>7a837193-2b58-49be-9dbb-c1c0c108ca6e</id>
+      <id>a23c8a3d-b056-4173-88e4-e73bb64dd731</id>
       <name>Große Mutter (SG)</name>
       <advantage>Allgemein: +2 Würfel für Proben auf erste Hilfe</advantage>
       <disadvantage>Immer wenn ein Anhänger der Großen Mutter absichtlich oder unabsichtlich dem lebensspendenden Wesen der Natur (seiner Auslegung) zuwiderhandelt, erleidet er einen Würfelpoolmodifikator von -1 auf alle Handlungen, bis er seine Zuwiderhandlung wiedergutgemacht hat.</disadvantage>

--- a/Chummer/data/mentors.xml
+++ b/Chummer/data/mentors.xml
@@ -923,9 +923,46 @@
       <source>SG</source>
       <page>86</page>
     </mentor>
+    <!--Great Mother from the German SG-->
+    <mentor>
+      <id>a23c8a3d-b056-4173-88e4-e73bb64dd731</id>
+      <name>Great Mother</name>
+      <advantage>All: +2 for all First Aid tests</advantage>
+      <disadvantage>Whenever a follower of the Great Mother harms a live giving creature, he suffers a -1 penalty on all actions until he made reparations for his mistake.</disadvantage>
+      <name>+2 dice to First Aid</name>
+      <bonus>
+        <specificskill>
+          <name>First Aid</name>
+          <bonus>2</bonus>
+        </specificskill>
+      </bonus>
+      <choices>
+        <choice>
+          <name>Magicians: +2 for health spells, preparations, and spell rituals.</name>
+          <bonus>
+            <spellcategory>
+              <name>Health</name>
+              <val>2</val>
+            </spellcategory>
+          </bonus>
+        </choice>
+        <choice>
+          <name>Adepts: Gain Empathic Healing for free.</name>
+          <bonus>
+            <specificpower>
+              <name>Empathic Healing</name>
+            </specificpower>
+          </bonus>
+        </choice>
+      </choices>
+      <hide />
+      <source>SG</source>
+      <page>232</page>
+    </mentor>
+    <!--Great Mother from SASS-->
     <mentor>
       <id>7a837193-2b58-49be-9dbb-c1c0c108ca6e</id>
-      <name>Great Mother (SASS)</name>
+      <name>Great Mother</name>
       <advantage>All: +2 to First Aid or Medicine Tests</advantage>
       <disadvantage>Followers of the Great Mother are lovers and healers, not fighters. As a result, they suffer a –1 dice pool modifier for any combat-related actions (using a combat skill, or casting a spell from the Combat category).</disadvantage>
       <choices>
@@ -948,7 +985,7 @@
           </bonus>
         </choice>
         <choice set="2">
-          <name>Magician: +2 dice for Health spells</name>
+          <name>Magician: +2 dice for Health spells, preparations and rituals</name>
           <bonus>
             <spellcategory>
               <name>Health</name>
@@ -2097,7 +2134,7 @@
     </mentor>
     <mentor>
       <id>4d15a346-8f27-42c5-be8c-33a7bd56067d</id>
-      <name>Great Mother</name>
+      <name>Great Mother (alt)</name>
       <advantage>All: When not in an urban area, gain +1 to any skill test with skills in the Outdoors skill group.</advantage>
       <disadvantage>Treat any background count due to pollution or twisted element as twice the actual rating.</disadvantage>
       <choices>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -21542,71 +21542,26 @@
                 <altdisadvantage>Wenn jemand eindringlich um Hilfe bittet, kann ein Anhänger des Feuerbringers diese nicht verweigern, wenn ihm keine Probe auf Charisma + Willenskraft (3) gelingt.</altdisadvantage>
                 <altpage>321</altpage>
             </mentor>
-            <mentor translated="True">
-                <id>7a837193-2b58-49be-9dbb-c1c0c108ca6e</id>
-                <name>Great Mother (SASS)</name>
-                <translate>Große Mutter (SASS)</translate>
+          <!--Great mother from SG-->
+            <mentor>
+                <id>a23c8a3d-b056-4173-88e4-e73bb64dd731</id>
+                <name>Great Mother</name>
+                <translate>Große Mutter</translate>
+                <name>+2 dice to First Aid</name>
+                <translate>+2 Würfel für Erste Hilfe Proben</translate>
                 <choices>
-                    <choice>
-                        <name>+2 to First Aid</name>
-                        <translate>+2 Würfel für Proben auf Erste Hilfe</translate>
-                    </choice>
-                    <choice>
-                        <name>+2 to Medicine</name>
-                        <translate>+2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice set="2">
-                        <name>Magician: +2 dice for Health spells</name>
-                        <translate>Zauberer: +2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice set="2">
-                        <name>Adept: 1 free level of Rapid Healing</name>
-                        <translate>Adept: Empathische Heilung gratis</translate>
-                    </choice>
-                    <choice>
-                        <name>+2 to First Aid</name>
-                        <translate>+2 Würfel für Proben auf Erste Hilfe</translate>
-                    </choice>
-                    <choice>
-                        <name>+2 to Medicine</name>
-                        <translate>+2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice set="2">
-                        <name>Magician: +2 dice for Health spells</name>
-                        <translate>Zauberer: +2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice set="2">
-                        <name>Adept: 1 free level of Rapid Healing</name>
-                        <translate>Adept: Empathische Heilung gratis</translate>
-                    </choice>
-                    <choice>
-                        <name>+2 to First Aid</name>
-                        <translate>+2 Würfel für Proben auf Erste Hilfe</translate>
-                    </choice>
-                    <choice>
-                        <name>+2 to Medicine</name>
-                        <translate>+2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice set="2">
-                        <name>Magician: +2 dice for Health spells</name>
-                        <translate>Zauberer: +2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice set="2">
-                        <name>Adept: 1 free level of Rapid Healing</name>
-                        <translate>Adept: Empathische Heilung gratis</translate>
-                    </choice>
-                    <choice>
-                        <name>Magician: +2 for health spells, preparations, and spell rituals.</name>
-                        <translate>Zauberer: +2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung</translate>
-                    </choice>
-                    <choice>
-                        <name>Adept: Gain Empathic Healing for free.</name>
-                        <translate>Adept: Empathische Heilung gratis</translate>
-                    </choice>
+                  <choice>
+                    <name>Magicians: +2 for health spells, preparations, and spell rituals.</name>
+                    <translate>Zauberer: +2 Würfel für Zauber, Rituale und Alchemistische Erzeugnisse der Kategorie Heiilung</translate>
+                  </choice>
+                  <choice>
+                    <name>Adepts: Gain Empathic Healing for free.</name>
+                    <translate>Adepten: Erhalte Empatische Heilung Gratis</translate>
+                  </choice>
                 </choices>
                 <altadvantage>Allgemein: +2 Würfel für Proben auf Erste Hilfe</altadvantage>
-                <altdisadvantage>Anhänger der Großen Mutter sind Liebhaber und Heiler, keine Kämpfer. Dadurch leiden sie unter einem –1 Würfel-Pool Modifikator für alle Aktionen, die mit Kämpfen in Verbindung stehen (Kampffertigkeit, oder einen Zauberspruch aus der Kategorie Kampf).</altdisadvantage>
-                <altpage>33</altpage>
+                <altdisadvantage>Immer wenn ein Anhänger der Großen Mutter absichtlich oder unabsichtlich dem lebensspendenden Wesen der Natur (seiner Auslegung) zuwiderhandelt, erleidet er einen Würfelpoolmodifikator von -1 auf alle Handlungen, bis er seine Zuwiderhandlung wiedergutgemacht hat.</altdisadvantage>
+                <altpage>232</altpage>
             </mentor>
             <mentor>
                 <id>a1faab23-0214-4c83-96ac-d5bb71d4aebb</id>
@@ -23084,17 +23039,18 @@
                 <altdisadvantage> Ratte ist von Natur aus ein Einzelgänger. Daher fällt es ihr manchmal schwer, anderen zu vertrauen. In Verbindung mit ihrer Intoleranz gegenüber Inkompetent könnte das in einem Team problematisch werden. Anhänger von Ratte können anderen nur durch Teamworkproben helfen oder von ihnen Hilfe erhalten, wenn sie diesen Personen vertrauen. Wenn sie diesen Personen vertrauen, dieses Vertrauen aber durch Verrat oder Inkompetenz missbraucht wird, muss ihnen zukünftig immer eine Probe auf Charisma + Willenskraft (4) gelingen, um mit dieser Person bei einer Teamworkprobe zusammenzuarbeiten.</altdisadvantage>
                 <altpage>99</altpage>
             </mentor>
+          <!--Great Mother from Forbidden Arcana-->
             <mentor>
                 <id>4d15a346-8f27-42c5-be8c-33a7bd56067d</id>
-                <name>Great Mother</name>
-                <translate>Große Mutter</translate>
+                <name>Great Mother (alt)</name>
+                <translate>Große Mutter (alt)</translate>
                 <altadvantage>Allgemein: Außerhalb urbaner Bereiche +1 Würfel auf alle Proben mit Fertigkeiten aus der Fertigkeitsgruppe Natur</altadvantage>
                 <altdisadvantage>Sämtliche Hintergrundstrahlung wegen Verschmutzung oder verdorbener Umgebung wirkt mit ihrer doppelten Stufe.</altdisadvantage>
                 <altpage>94</altpage>
                 <choices>
                     <choice>
                         <name>Magician: +2 for health spells, preparations, and spell rituals.</name>
-                        <translate>Zauberer: + Würfel für Zauber, Alchemische Erzeugnisse und Rituale der Kategorie Heilung</translate>
+                        <translate>Zauberer: +2 Würfel für Zauber, Alchemische Erzeugnisse und Rituale der Kategorie Heilung</translate>
                     </choice>
                     <choice>
                         <name>Adept: Gain Empathic Healing for free.</name>
@@ -23102,7 +23058,36 @@
                     </choice>
                 </choices>
             </mentor>
-            <mentor>
+          <!--Great Mother from SASS-->
+          <mentor>
+            <id>7a837193-2b58-49be-9dbb-c1c0c108ca6e</id>
+            <name>Great Mother</name>
+            <translate>Große Mutter</translate>
+            <altadvantage>Allgemein: 2+ Würfel auf Erste Hilfe oder Medizin</altadvantage>
+            <altdisadvantage>Anhänger der Großen Mutter sind liebende und keine Kämpfer. Deswegen erhalten sie -1 Würfel für alle Kampf Aktionen (Benutzung einer Kampffertigkeit oder verwendung eines Zaubers der Kategorie Kampf)</altdisadvantage>
+            <choices>
+              <choice>
+                <name>+2 to First Aid</name>
+                <translate>+2 Würfel auf Erste Hilfe</translate>
+              </choice>
+              <choice>
+                <name>+2 to Medicine</name>
+                <translate>+2 Würfel auf Medizin</translate>
+              </choice>
+              <choice set="2">
+                <name>Magician: +2 dice for Health spells, preparations and rituals</name>
+                <translate>Zauberer: +2 Würfel für Zauber, Rituale und Alchemische Erzeugnisse der Kategorie Heilung
+                </translate>
+              </choice>
+              <choice set="2">
+                <name>Adept: 1 free level of Rapid Healing</name>
+                <translate>Adepten: Erhalte eine Stuffe der Kraft Schnellheilung gratis</translate>
+              </choice>
+            </choices>
+
+
+          </mentor>
+          <mentor>
                 <id>7397da6e-29b8-400f-9708-c99bd04d5c07</id>
                 <name>Guanyin</name>
                 <translate>Guanyin</translate>


### PR DESCRIPTION
This Pull request contains the mentioned conflicting UID and is meant to discuss how this weird mentor spirit should be handled.


Following are the copy and pastes @DelnarErsike and my comments over in #4408

---
 **Joschi original description of e699b25**
The German Street Grim has the mentor "Große Mutter" (Great Mother). It is nearly identical to the one that is present in SASS, but not completely.

Since it is functionally a bit different and it's very unclear if they are meant as the same, adding it as another custom Mentor was the easiest way to include it, without having to make a rules call.

--- 
**Delnar**
Uh... what is that fix in commit e699b25, @JoschiGrey?

You do realize that that results in two different "Great Mother" entries when using the German Data Changes, correct? One will be called "Great Mother" and the other will be called "Große Mutter (SG)"? This kind of duplication is exactly what that German Data Changes ruleset is meant to eliminate (as opposed to the previous solution of just adding fake sourcebooks that only contain German data).

--------
**Joschi**
The German Street Grim implements a "Great Mother (Große Mutter)", which is not present in the English book.
It gives +2 on first aid, 2+ on health spells and "Empathic Healing".
The drawback translates More or Less to: "If you hurt a lifegiving being you receive -1 on everything until you repent".

This book was released in 2015.

The English enhanced fiction novel "Sail Away, Sweet Sister" (SASS) introduced the Mentor Spirit "Great Mother"
It's description is nearly identical to the German SG Great Mother. With some key differences.
You choose between +2 on First aid or Medicine, you get +2 on health spells and you get "Rapid Healing".
The drawback gives -1 to all combat actions.

This book was released 2019 (and as it seems only in English)

Then there are the Great Mothers (FA) from the forbidden arcana which are identical in German and English.
They give +1 on Nature skills outside of urban areas, +2 on health spells and "Empathic Healing".
The drawback doubles background count from pollution or twisted elements.

Both got published 2017.

Now we got 3 Versions of "Great Mother" that all probably refer to the same mentor spirit to manage.

We could treat the FA one as an stealth errata for the German Great Mother (SG)
and the SASS version as an stealth errata to the English FA.

But what takes precedent as an German Data Change?
Does the German one supersede the later published English version?

Are those even stealth errata to the respective earlier published versions or did Catalyst just fuck up with SASS and Pegasus just translated the "new" FA mentor to German without realizing, they implemented this Mentor earlier.

At the moment the normal mentor.xml contains Great Mother (FA) and Great Mother (SASS).
And I added the GM(SG) that way we don't have to decide, which version is correct.

I agree this is a bit dumb, because we now got 3 versions of the Great Mother all with slightly different rules, from 3 different books if you use the German Data Changes.

Btw. I just realized the GM(SG) has the same ID as the GM(SASS) this has to be fixed. I'm sorry about that. I can open a Pull Request for that as soon as we figured this out. This branch already got a new ID.