### PR TITLE
Selection of the lifestyle for starting  nuyen calc is now possible.

### DIFF
--- a/Chummer/Backend/Equipment/Lifestyle.cs
+++ b/Chummer/Backend/Equipment/Lifestyle.cs
@@ -91,6 +91,7 @@ namespace Chummer.Backend.Equipment
         private int _intSortOrder;
         private readonly Character _objCharacter;
 
+
         private string _strCity;
         private string _strDistrict;
         private string _strBorough;
@@ -1104,6 +1105,11 @@ namespace Chummer.Backend.Equipment
             }
             return _objCachedMyXmlNode;
         }
+
+        /// <summary>
+        /// Calculates the Expected Value of an Lifestyle at chargen under the assumption that the average value was rolled
+        /// </summary>
+        public decimal ExpectedValue => _intDice * (decimal)3.5 * _decMultiplier;
 
         public string City
         {

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -23,6 +23,7 @@ Application Changes:
 - Added the ability to specify a city, district, and borough for a lifestyle.
 - If a character sheet is printed/exported in a language other than the one with which Chummer is being used, Chummer now attemtps to translate the names of gear, vehicle, and weapon locations.
 - Generating character sheets in languages where commas are used as decimal separators and/or periods are used as number group separators no longer sometimes causes the generator to stall out and silently crash. Fixes #4415.
+- You can now select which lifestly to use for starting nuyen calculation.
 
 Data Changes:
 - Consolidated all German Data Changes custom data and all German-exclusive content of sourcebooks printed in English into a single German Data Changes c.ustom data folder.

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -23,7 +23,7 @@ Application Changes:
 - Added the ability to specify a city, district, and borough for a lifestyle.
 - If a character sheet is printed/exported in a language other than the one with which Chummer is being used, Chummer now attemtps to translate the names of gear, vehicle, and weapon locations.
 - Generating character sheets in languages where commas are used as decimal separators and/or periods are used as number group separators no longer sometimes causes the generator to stall out and silently crash. Fixes #4415.
-- You can now select which lifestly to use for starting nuyen calculation.
+- You can now select which lifestyle to use for starting nuyen calculation.
 
 Data Changes:
 - Consolidated all German Data Changes custom data and all German-exclusive content of sourcebooks printed in English into a single German Data Changes c.ustom data folder.

--- a/Chummer/frmLifestyleNuyen.Designer.cs
+++ b/Chummer/frmLifestyleNuyen.Designer.cs
@@ -37,6 +37,7 @@ namespace Chummer
             this.nudDiceResult = new Chummer.NumericUpDownEx();
             this.tlpMain = new Chummer.BufferedTableLayoutPanel(this.components);
             this.cboSelectLifestyle = new Chummer.ElasticComboBox();
+            this.lblSelectLifestyle = new System.Windows.Forms.Label();
             ((System.ComponentModel.ISupportInitialize)(this.nudDiceResult)).BeginInit();
             this.tlpMain.SuspendLayout();
             this.SuspendLayout();
@@ -46,7 +47,7 @@ namespace Chummer
             this.lblDescription.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.lblDescription.AutoSize = true;
             this.tlpMain.SetColumnSpan(this.lblDescription, 3);
-            this.lblDescription.Location = new System.Drawing.Point(3, 6);
+            this.lblDescription.Location = new System.Drawing.Point(3, 7);
             this.lblDescription.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
             this.lblDescription.Name = "lblDescription";
             this.lblDescription.Size = new System.Drawing.Size(360, 26);
@@ -60,7 +61,7 @@ namespace Chummer
             this.cmdOK.AutoSize = true;
             this.cmdOK.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.cmdOK.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.cmdOK.Location = new System.Drawing.Point(162, 94);
+            this.cmdOK.Location = new System.Drawing.Point(162, 97);
             this.cmdOK.Name = "cmdOK";
             this.cmdOK.Size = new System.Drawing.Size(41, 23);
             this.cmdOK.TabIndex = 4;
@@ -73,20 +74,19 @@ namespace Chummer
             // 
             this.lblDice.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.lblDice.AutoSize = true;
-            this.lblDice.Location = new System.Drawing.Point(75, 71);
+            this.lblDice.Location = new System.Drawing.Point(75, 74);
             this.lblDice.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
             this.lblDice.Name = "lblDice";
             this.lblDice.Size = new System.Drawing.Size(81, 13);
             this.lblDice.TabIndex = 1;
             this.lblDice.Tag = "Label_LifestyleNuyen_ResultOf";
             this.lblDice.Text = "Result of 4D6: (";
-            this.lblDice.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
             // lblResult
             // 
             this.lblResult.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblResult.AutoSize = true;
-            this.lblResult.Location = new System.Drawing.Point(209, 71);
+            this.lblResult.Location = new System.Drawing.Point(209, 74);
             this.lblResult.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
             this.lblResult.Name = "lblResult";
             this.lblResult.Size = new System.Drawing.Size(37, 13);
@@ -98,7 +98,7 @@ namespace Chummer
             // 
             this.nudDiceResult.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.nudDiceResult.AutoSize = true;
-            this.nudDiceResult.Location = new System.Drawing.Point(162, 68);
+            this.nudDiceResult.Location = new System.Drawing.Point(162, 71);
             this.nudDiceResult.Maximum = new decimal(new int[] {
             100,
             0,
@@ -127,7 +127,8 @@ namespace Chummer
             this.tlpMain.Controls.Add(this.lblDescription, 0, 0);
             this.tlpMain.Controls.Add(this.lblDice, 0, 2);
             this.tlpMain.Controls.Add(this.cmdOK, 1, 3);
-            this.tlpMain.Controls.Add(this.cboSelectLifestyle, 0, 1);
+            this.tlpMain.Controls.Add(this.cboSelectLifestyle, 1, 1);
+            this.tlpMain.Controls.Add(this.lblSelectLifestyle, 0, 1);
             this.tlpMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpMain.Location = new System.Drawing.Point(9, 9);
             this.tlpMain.Name = "tlpMain";
@@ -137,20 +138,33 @@ namespace Chummer
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tlpMain.Size = new System.Drawing.Size(366, 120);
+            this.tlpMain.Size = new System.Drawing.Size(366, 123);
             this.tlpMain.TabIndex = 5;
             // 
             // cboSelectLifestyle
             // 
-            this.cboSelectLifestyle.Anchor = System.Windows.Forms.AnchorStyles.None;
-            this.tlpMain.SetColumnSpan(this.cboSelectLifestyle, 3);
+            this.cboSelectLifestyle.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
+            this.tlpMain.SetColumnSpan(this.cboSelectLifestyle, 2);
+            this.cboSelectLifestyle.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.cboSelectLifestyle.FormattingEnabled = true;
-            this.cboSelectLifestyle.Location = new System.Drawing.Point(100, 41);
+            this.cboSelectLifestyle.Location = new System.Drawing.Point(162, 44);
             this.cboSelectLifestyle.Name = "cboSelectLifestyle";
-            this.cboSelectLifestyle.Size = new System.Drawing.Size(165, 21);
+            this.cboSelectLifestyle.Size = new System.Drawing.Size(201, 21);
             this.cboSelectLifestyle.TabIndex = 5;
             this.cboSelectLifestyle.TooltipText = "";
             this.cboSelectLifestyle.SelectedIndexChanged += new System.EventHandler(this.cboSelectLifestyle_SelectionChanged);
+            // 
+            // lblSelectLifestyle
+            // 
+            this.lblSelectLifestyle.Anchor = System.Windows.Forms.AnchorStyles.Right;
+            this.lblSelectLifestyle.AutoSize = true;
+            this.lblSelectLifestyle.Location = new System.Drawing.Point(74, 48);
+            this.lblSelectLifestyle.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
+            this.lblSelectLifestyle.Name = "lblSelectLifestyle";
+            this.lblSelectLifestyle.Size = new System.Drawing.Size(82, 13);
+            this.lblSelectLifestyle.TabIndex = 6;
+            this.lblSelectLifestyle.Tag = "Label_LifestyleNuyen_SelectLifestyle";
+            this.lblSelectLifestyle.Text = "Lifestyle to Use:";
             // 
             // frmLifestyleNuyen
             // 
@@ -158,7 +172,8 @@ namespace Chummer
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(384, 138);
+            this.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
+            this.ClientSize = new System.Drawing.Size(384, 141);
             this.Controls.Add(this.tlpMain);
             this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
@@ -189,5 +204,6 @@ namespace Chummer
         private Chummer.NumericUpDownEx nudDiceResult;
         private Chummer.BufferedTableLayoutPanel tlpMain;
         private ElasticComboBox cboSelectLifestyle;
+        private System.Windows.Forms.Label lblSelectLifestyle;
     }
 }

--- a/Chummer/frmLifestyleNuyen.Designer.cs
+++ b/Chummer/frmLifestyleNuyen.Designer.cs
@@ -36,6 +36,7 @@ namespace Chummer
             this.lblResult = new System.Windows.Forms.Label();
             this.nudDiceResult = new Chummer.NumericUpDownEx();
             this.tlpMain = new Chummer.BufferedTableLayoutPanel(this.components);
+            this.cboSelectLifestyle = new Chummer.ElasticComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.nudDiceResult)).BeginInit();
             this.tlpMain.SuspendLayout();
             this.SuspendLayout();
@@ -59,7 +60,7 @@ namespace Chummer
             this.cmdOK.AutoSize = true;
             this.cmdOK.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
             this.cmdOK.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.cmdOK.Location = new System.Drawing.Point(162, 67);
+            this.cmdOK.Location = new System.Drawing.Point(162, 94);
             this.cmdOK.Name = "cmdOK";
             this.cmdOK.Size = new System.Drawing.Size(41, 23);
             this.cmdOK.TabIndex = 4;
@@ -72,7 +73,7 @@ namespace Chummer
             // 
             this.lblDice.Anchor = System.Windows.Forms.AnchorStyles.Right;
             this.lblDice.AutoSize = true;
-            this.lblDice.Location = new System.Drawing.Point(75, 44);
+            this.lblDice.Location = new System.Drawing.Point(75, 71);
             this.lblDice.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
             this.lblDice.Name = "lblDice";
             this.lblDice.Size = new System.Drawing.Size(81, 13);
@@ -85,7 +86,7 @@ namespace Chummer
             // 
             this.lblResult.Anchor = System.Windows.Forms.AnchorStyles.Left;
             this.lblResult.AutoSize = true;
-            this.lblResult.Location = new System.Drawing.Point(209, 44);
+            this.lblResult.Location = new System.Drawing.Point(209, 71);
             this.lblResult.Margin = new System.Windows.Forms.Padding(3, 6, 3, 6);
             this.lblResult.Name = "lblResult";
             this.lblResult.Size = new System.Drawing.Size(37, 13);
@@ -97,7 +98,17 @@ namespace Chummer
             // 
             this.nudDiceResult.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.nudDiceResult.AutoSize = true;
-            this.nudDiceResult.Location = new System.Drawing.Point(162, 41);
+            this.nudDiceResult.Location = new System.Drawing.Point(162, 68);
+            this.nudDiceResult.Maximum = new decimal(new int[] {
+            100,
+            0,
+            0,
+            0});
+            this.nudDiceResult.Minimum = new decimal(new int[] {
+            0,
+            0,
+            0,
+            0});
             this.nudDiceResult.Name = "nudDiceResult";
             this.nudDiceResult.Size = new System.Drawing.Size(41, 20);
             this.nudDiceResult.TabIndex = 2;
@@ -111,21 +122,35 @@ namespace Chummer
             this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
             this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpMain.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 50F));
-            this.tlpMain.Controls.Add(this.lblResult, 2, 1);
-            this.tlpMain.Controls.Add(this.nudDiceResult, 1, 1);
+            this.tlpMain.Controls.Add(this.lblResult, 2, 2);
+            this.tlpMain.Controls.Add(this.nudDiceResult, 1, 2);
             this.tlpMain.Controls.Add(this.lblDescription, 0, 0);
-            this.tlpMain.Controls.Add(this.lblDice, 0, 1);
-            this.tlpMain.Controls.Add(this.cmdOK, 1, 2);
+            this.tlpMain.Controls.Add(this.lblDice, 0, 2);
+            this.tlpMain.Controls.Add(this.cmdOK, 1, 3);
+            this.tlpMain.Controls.Add(this.cboSelectLifestyle, 0, 1);
             this.tlpMain.Dock = System.Windows.Forms.DockStyle.Fill;
             this.tlpMain.Location = new System.Drawing.Point(9, 9);
             this.tlpMain.Name = "tlpMain";
-            this.tlpMain.RowCount = 3;
+            this.tlpMain.RowCount = 4;
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
+            this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle());
             this.tlpMain.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Absolute, 20F));
-            this.tlpMain.Size = new System.Drawing.Size(366, 93);
+            this.tlpMain.Size = new System.Drawing.Size(366, 120);
             this.tlpMain.TabIndex = 5;
+            // 
+            // cboSelectLifestyle
+            // 
+            this.cboSelectLifestyle.Anchor = System.Windows.Forms.AnchorStyles.None;
+            this.tlpMain.SetColumnSpan(this.cboSelectLifestyle, 3);
+            this.cboSelectLifestyle.FormattingEnabled = true;
+            this.cboSelectLifestyle.Location = new System.Drawing.Point(100, 41);
+            this.cboSelectLifestyle.Name = "cboSelectLifestyle";
+            this.cboSelectLifestyle.Size = new System.Drawing.Size(165, 21);
+            this.cboSelectLifestyle.TabIndex = 5;
+            this.cboSelectLifestyle.TooltipText = "";
+            this.cboSelectLifestyle.SelectedIndexChanged += new System.EventHandler(this.cboSelectLifestyle_SelectionChanged);
             // 
             // frmLifestyleNuyen
             // 
@@ -133,7 +158,7 @@ namespace Chummer
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.AutoSize = true;
-            this.ClientSize = new System.Drawing.Size(384, 111);
+            this.ClientSize = new System.Drawing.Size(384, 138);
             this.Controls.Add(this.tlpMain);
             this.DoubleBuffered = true;
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
@@ -163,5 +188,6 @@ namespace Chummer
         private System.Windows.Forms.Label lblResult;
         private Chummer.NumericUpDownEx nudDiceResult;
         private Chummer.BufferedTableLayoutPanel tlpMain;
+        private ElasticComboBox cboSelectLifestyle;
     }
 }

--- a/Chummer/frmLifestyleNuyen.cs
+++ b/Chummer/frmLifestyleNuyen.cs
@@ -17,13 +17,17 @@
  *  https://github.com/chummer5a/chummer5a
  */
 ﻿using System;
+ using System.Collections.Generic;
+ using System.Linq;
  using System.Windows.Forms;
+ using Chummer.Backend.Equipment;
 
 namespace Chummer
 {
     public partial class frmLifestyleNuyen : Form
     {
         readonly Character _objCharacter;
+        private Lifestyle _objLifestyle;
 
         #region Control Events
         public frmLifestyleNuyen(Character objCharacter)
@@ -47,18 +51,46 @@ namespace Chummer
 
         private void frmLifestyleNuyen_Load(object sender, EventArgs e)
         {
-            lblDice.Text = string.Format(GlobalOptions.CultureInfo, LanguageManager.GetString("Label_LifestyleNuyen_ResultOf"), Dice.ToString(GlobalOptions.CultureInfo));
-            nudDiceResult.Maximum = Dice * 6;
-            nudDiceResult.Minimum = Dice;
-            nudDiceResult_ValueChanged(sender, e);
+            RefreshCboSelectLifestyle();
+            RefreshCalculation(sender, e);
         }
 
         private void nudDiceResult_ValueChanged(object sender, EventArgs e)
         {
             string strSpace = LanguageManager.GetString("String_Space");
             lblResult.Text = strSpace + '+' + strSpace + Extra.ToString("#,0", GlobalOptions.CultureInfo) + ')' + strSpace + '×'
-                             + strSpace + Multiplier.ToString(_objCharacter.Options.NuyenFormat + '¥', GlobalOptions.CultureInfo)
+                             + strSpace + SelectedLifestyle.Multiplier.ToString(_objCharacter.Options.NuyenFormat + '¥', GlobalOptions.CultureInfo)
                              + strSpace + '=' + strSpace + StartingNuyen.ToString(_objCharacter.Options.NuyenFormat + '¥', GlobalOptions.CultureInfo);
+        }
+
+        private void cboSelectLifestyle_SelectionChanged(object sender, EventArgs e)
+        {
+            _objLifestyle = (Lifestyle) cboSelectLifestyle.SelectedItem;
+            RefreshCalculation(sender, e);
+            lblDice.Text = string.Format(GlobalOptions.CultureInfo, LanguageManager.GetString("Label_LifestyleNuyen_ResultOf"), SelectedLifestyle.Dice.ToString(GlobalOptions.CultureInfo));
+
+        }
+
+        private void RefreshCboSelectLifestyle()
+        {
+            List<Lifestyle> lstLifestyles = _objCharacter.Lifestyles.ToList();
+
+
+
+            lstLifestyles.Sort((y,x) => x.ExpectedValue.CompareTo(y.ExpectedValue));
+
+            cboSelectLifestyle.ValueMember = nameof(ListItem.Value);
+            cboSelectLifestyle.DisplayMember = nameof(ListItem.Name);
+            cboSelectLifestyle.DataSource = lstLifestyles;
+        }
+
+        private void RefreshCalculation(object sender, EventArgs e)
+        {
+
+            nudDiceResult.Maximum = SelectedLifestyle.Dice * 6;
+            nudDiceResult.Minimum = SelectedLifestyle.Dice;
+            nudDiceResult_ValueChanged(sender, e);
+
         }
         #endregion
 
@@ -81,7 +113,9 @@ namespace Chummer
         /// <summary>
         /// The total amount of Nuyen resulting from the dice roll.
         /// </summary>
-        public decimal StartingNuyen => ((nudDiceResult.Value + Extra) * Multiplier);
+        public decimal StartingNuyen => ((nudDiceResult.Value + Extra) * SelectedLifestyle.Multiplier);
+
+        public Lifestyle SelectedLifestyle => _objLifestyle;
 
         #endregion
     }

--- a/Chummer/frmLifestyleNuyen.cs
+++ b/Chummer/frmLifestyleNuyen.cs
@@ -68,14 +68,11 @@ namespace Chummer
             _objLifestyle = (Lifestyle) cboSelectLifestyle.SelectedItem;
             RefreshCalculation(sender, e);
             lblDice.Text = string.Format(GlobalOptions.CultureInfo, LanguageManager.GetString("Label_LifestyleNuyen_ResultOf"), SelectedLifestyle.Dice.ToString(GlobalOptions.CultureInfo));
-
         }
 
         private void RefreshCboSelectLifestyle()
         {
             List<Lifestyle> lstLifestyles = _objCharacter.Lifestyles.ToList();
-
-
 
             lstLifestyles.Sort((y,x) => x.ExpectedValue.CompareTo(y.ExpectedValue));
 
@@ -86,11 +83,9 @@ namespace Chummer
 
         private void RefreshCalculation(object sender, EventArgs e)
         {
-
             nudDiceResult.Maximum = SelectedLifestyle.Dice * 6;
             nudDiceResult.Minimum = SelectedLifestyle.Dice;
             nudDiceResult_ValueChanged(sender, e);
-
         }
         #endregion
 
@@ -115,6 +110,9 @@ namespace Chummer
         /// </summary>
         public decimal StartingNuyen => ((nudDiceResult.Value + Extra) * SelectedLifestyle.Multiplier);
 
+        /// <summary>
+        /// The currently selected lifestyl
+        /// </summary>
         public Lifestyle SelectedLifestyle => _objLifestyle;
 
         #endregion

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -6817,6 +6817,10 @@
       <key>Label_LifestyleNuyen_ResultOf</key>
       <text>Result of {0}D6: (</text>
     </string>
+    <string>
+      <key>Label_LifestyleNuyen_SelectLifestyle</key>
+      <text>Lifestyle to Use:</text>
+    </string>
     <!-- End Region-->
     <!-- Region Select Metatype Window -->
     <string>


### PR DESCRIPTION
Implements feature request #4416 

Added a combobox, that displays all purchased lifestyles.
The cbo is sorted by expected value, under the assumption, that the user rolled an average of 3.5/Dice.

