### PR TITLE
Stopped adding Ammo in career mode to crash chummer in non English and auto enforces the "correct" weapon category.

### DIFF
--- a/Chummer/Backend/Equipment/Gear.cs
+++ b/Chummer/Backend/Equipment/Gear.cs
@@ -319,7 +319,7 @@ namespace Chummer.Backend.Equipment
                     Description = LanguageManager.GetString("String_SelectWeaponCategoryAmmo"),
                     WeaponType = strAmmoWeaponType
                 };
-                if (!string.IsNullOrEmpty(_strForcedValue) && !_strForcedValue.Equals(_strName, StringComparison.Ordinal))
+                if (!string.IsNullOrEmpty(_strForcedValue) && !_strForcedValue.Equals(CurrentDisplayNameShort, StringComparison.Ordinal))
                     frmPickWeaponCategory.OnlyCategory = _strForcedValue;
 
                 if (frmPickWeaponCategory.ShowDialog(Program.MainForm) == DialogResult.Cancel)

--- a/Chummer/frmCareer.cs
+++ b/Chummer/frmCareer.cs
@@ -14535,6 +14535,10 @@ namespace Chummer
                     string strForceValue = strForceItemValue;
                     if (string.IsNullOrEmpty(strForceValue))
                         strForceValue = objAmmoForWeapon?.AmmoCategory;
+                    //If the amount of an ammunition was increased, force the correct weapon category.
+                    if (objStackGear?.Category == "Ammunition")
+                        strForceValue = objStackGear?.Extra;
+
                     Gear objGear = new Gear(CharacterObject);
                     objGear.Create(objXmlGear, frmPickGear.SelectedRating, lstWeapons, strForceValue);
 


### PR DESCRIPTION
Fixes #4400 


----
*Explanation of the original problem, that was fixed in 9a74066*
It isn't the "+" in the weapons tab, but in the street gear tab and only occurs in non English.

The problem is, that `Gear.cs` passes over a the `_strForcedValue` to `frmPickWeaponCategory.OnlyCategory`.
The `_strForcedValue` in `Gear` is equal to the name of the ammunition to add.

Because of this the `frmPickWeaponCategory` tries to create a list from the .xml node `/chummer/categories/category[. = "Munition: Standardmunition"]` which comes up empty.

This happens in other languages than English, because the passing of an forced value is controlled by this if statement
`if (!string.IsNullOrEmpty(_strForcedValue) && !_strForcedValue.Equals(_strName, StringComparison.Ordinal))`
Which evaluates true, because it compares the non translated name to the translated name.

Using `CurrentDisplayNameShort` instead of `_strName` works. It then Displays the whole list of weapon categoreis
This however isn't the optimal solution, we would like the only selectable category to be the "correct" one.

---
For 89c540e
Now the "correct" weapon category is automatically forced and selected, when increasing the quantity of ammo in career mode.

Correct in this context means: The same weapon category as the previously selected ammo type.
