### PR TITLE
Removed Hemorrhage as a ritual

### DIFF
--- a/Chummer/customdata/SR Missions 1.4 Rules/amend_spells.xml
+++ b/Chummer/customdata/SR Missions 1.4 Rules/amend_spells.xml
@@ -20,10 +20,6 @@
 <chummer>
   <spells>
     <spell>
-      <name>Hemorrhage</name>
-      <hide />
-    </spell>
-    <spell>
       <name>Manablade</name>
       <hide />
     </spell>

--- a/Chummer/customdata/ShadowNET Rules/amend_spells.xml
+++ b/Chummer/customdata/ShadowNET Rules/amend_spells.xml
@@ -68,10 +68,6 @@
     -->
     <!-- Begin Blood Magic -->
     <spell>
-      <name>Hemorrhage</name>
-      <hide />
-    </spell>
-    <spell>
       <name>Corps Cadavre</name>
       <hide />
     </spell>

--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -3577,19 +3577,6 @@
       <type>P</type>
     </spell>
     <spell>
-      <id>2c7be069-208e-41e4-b3cf-97c9fc480fbc</id>
-      <name>Hemorrhage</name>
-      <page>91</page>
-      <source>SG</source>
-      <category>Rituals</category>
-      <damage>0</damage>
-      <descriptor />
-      <duration>I</duration>
-      <dv>Special</dv>
-      <range>Special</range>
-      <type>P</type>
-    </spell>
-    <spell>
       <id>eab0bcfd-9bf5-4482-9cca-2bdecb7f7b59</id>
       <name>Hand of Glory</name>
       <page>213</page>

--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -37600,12 +37600,6 @@
                 <altpage>23</altpage>
             </spell>
             <spell>
-                <id>2c7be069-208e-41e4-b3cf-97c9fc480fbc</id>
-                <name>Hemorrhage</name>
-                <translate>Blutsturz</translate>
-                <altpage>95</altpage>
-            </spell>
-            <spell>
                 <id>eab0bcfd-9bf5-4482-9cca-2bdecb7f7b59</id>
                 <name>Hand of Glory</name>
                 <translate>Hand des Ruhms</translate>

--- a/Chummer/lang/fr-fr_data.xml
+++ b/Chummer/lang/fr-fr_data.xml
@@ -40416,12 +40416,6 @@
                 <altpage>21</altpage>
             </spell>
             <spell>
-                <id>2c7be069-208e-41e4-b3cf-97c9fc480fbc</id>
-                <name>Hemorrhage</name>
-                <translate>Hémorragie</translate>
-                <altpage>91</altpage>
-            </spell>
-            <spell>
                 <id>eab0bcfd-9bf5-4482-9cca-2bdecb7f7b59</id>
                 <name>Hand of Glory</name>
                 <translate>Main de la gloire</translate>

--- a/Chummer/lang/ja-jp_data.xml
+++ b/Chummer/lang/ja-jp_data.xml
@@ -39358,12 +39358,6 @@
                 <altpage>21</altpage>
             </spell>
             <spell>
-                <id>2c7be069-208e-41e4-b3cf-97c9fc480fbc</id>
-                <name>Hemorrhage</name>
-                <translate>Hemorrhage</translate>
-                <altpage>91</altpage>
-            </spell>
-            <spell>
                 <id>eab0bcfd-9bf5-4482-9cca-2bdecb7f7b59</id>
                 <name>Hand of Glory</name>
                 <translate>Hand of Glory</translate>

--- a/Chummer/lang/pt-br_data.xml
+++ b/Chummer/lang/pt-br_data.xml
@@ -32154,12 +32154,6 @@
                 <altpage>21</altpage>
             </spell>
             <spell>
-                <id>2c7be069-208e-41e4-b3cf-97c9fc480fbc</id>
-                <name>Hemorrhage</name>
-                <translate>Hemorrhage</translate>
-                <altpage>91</altpage>
-            </spell>
-            <spell>
                 <id>eab0bcfd-9bf5-4482-9cca-2bdecb7f7b59</id>
                 <name>Hand of Glory</name>
                 <translate>Hand of Glory</translate>


### PR DESCRIPTION
Fixes #4431

In the books it looks like an blood ritual, thanks to the incredible layouting and editing by catalyst (and Pegasus to be fair).
But it is actually a special greater bloodspirit power. This becomes apparent when reading the description of greater blood spirits.

"If the summoning granted a Greater Power, the blood spirit gains the unique power of Hemorrhage."