### PR TITLE
Fixed point buy metatype selection

### DIFF
--- a/Chummer/Character Creation/frmKarmaMetatype.Designer.cs
+++ b/Chummer/Character Creation/frmKarmaMetatype.Designer.cs
@@ -612,6 +612,7 @@ namespace Chummer
             this.cmdOK.Tag = "String_OK";
             this.cmdOK.Text = "OK";
             this.cmdOK.UseVisualStyleBackColor = true;
+            this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
             // 
             // frmKarmaMetatype
             // 


### PR DESCRIPTION
In `frmKarmaMetatype` `cmdOk`s on click event wasn't connected to `cmdOk_Click` and thus didn't work.