### PR TITLE
Fixed critters that carry skills only as improvements but not as skill entries in the datafile

### DIFF
--- a/Chummer/Classes/clsCharacter.cs
+++ b/Chummer/Classes/clsCharacter.cs
@@ -1099,20 +1099,33 @@ namespace Chummer
             foreach (XmlNode xmlSkill in charNode.SelectNodes("skills/skill"))
             {
                 string strRating = xmlSkill.Attributes?["rating"]?.InnerText;
-
+                bool bImprovementAdded = false;
                 if (!string.IsNullOrEmpty(strRating))
                 {
                     ImprovementManager.CreateImprovement(this, xmlSkill.InnerText, Improvement.ImprovementSource.Metatype, string.Empty, Improvement.ImprovementType.SkillLevel, string.Empty,
                         CommonFunctions.ExpressionToInt(strRating, intForce, 0, 0));
                     ImprovementManager.Commit(this);
+                    bImprovementAdded = true;
                 }
                 string strSkill = xmlSkill.InnerText;
                 Skill objSkill = SkillsSection.GetActiveSkill(strSkill);
-                if (objSkill == null) continue;
-                string strSpec = xmlSkill.Attributes?["spec"]?.InnerText ?? string.Empty;
-                ImprovementManager.CreateImprovement(this, strSkill, Improvement.ImprovementSource.Metatype, string.Empty, Improvement.ImprovementType.SkillSpecialization, strSpec);
-                SkillSpecialization spec = new SkillSpecialization(this, strSpec, true);
-                objSkill.Specializations.Add(spec);
+                if (objSkill == null)
+                {
+                    if (!bImprovementAdded)
+                        continue;
+
+                    //This skill does not yet exist but the datafile asks to improve it.
+                    //We need to add it so it is not only improved but also shown on the skills tab.
+                    SkillsSection.AddSkills(SkillsSection.FilterOption.Name, strSkill);
+                    objSkill = SkillsSection.GetActiveSkill(strSkill);
+                }
+                if (objSkill != null) //More or less a safeguard only. Should not be empty at that point any longer.
+                {
+                    string strSpec = xmlSkill.Attributes?["spec"]?.InnerText ?? string.Empty;
+                    ImprovementManager.CreateImprovement(this, strSkill, Improvement.ImprovementSource.Metatype, string.Empty, Improvement.ImprovementType.SkillSpecialization, strSpec);
+                    SkillSpecialization spec = new SkillSpecialization(this, strSpec, true);
+                    objSkill.Specializations.Add(spec);
+                }
             }
             //Set the Skill Group Ratings for the Critter.
             foreach (XmlNode xmlSkillGroup in charNode.SelectNodes("skills/group"))

--- a/Chummer/changelog.txt
+++ b/Chummer/changelog.txt
@@ -55,6 +55,7 @@ Application Changes:
 - Cyberware and vehicles now export the amount that their Matrix Condition Monitors are filled. Weapons now properly export all of their Matrix-related properties, including their Matrix attributes and their Matrix Condition Monitor status.
 - Deleting a skill by undoing the Karma expense for adding it now properly deletes the skill instead of lowering its rating by 1. Fixes #4323.
 - Fixed an issue that prevented 'ware with a capacity of 0 from having any gear added to it, even ones that are explicitly allowed. Fixes #4228.
+- Fixed an issue that some specific skills were not shown for critters based on a Force selection
 
 Data Changes:
 - Consolidated all German Data Changes custom data and all German-exclusive content of sourcebooks printed in English into a single German Data Changes c.ustom data folder.


### PR DESCRIPTION
Since several versions Chummer does no longer show some skills for Critters even if they should have them.

**How to reproduce:**
* Create a Spirit of Man, select any force (does not matter)
* Check the Skills tab
* Spellcasting, Assensing and astral combat are not shown

**Expected behaviour**

The data file defines it as expected, so it should be shown
```
  <skills>
        <skill rating="F">Assensing</skill>
        <skill rating="F">Astral Combat</skill>
        <skill rating="F">Perception</skill>
        <skill rating="F">Spellcasting</skill>
        <skill rating="F">Unarmed Combat</skill>
      </skills>
```

**Explanation**
Seems like Critters only add an Metatype specific improvement, but not the skill itself.
This does not matter for "common" skills, but some specific ones are not shown at all if they don't exist in the Character. (MAG based ones for example)

**Proposed fix**
This PR checks if a skill is missing for every improvement that is added. If the skill is missing, it is added.
I'm not entirely sure if the location I selected is appropriate but it fixes the issue. If there is a better place for such fix, I would be happy to learn about it.