### PR TITLE
Fixed unbound spirits counting towards spirit limit

### DIFF
--- a/Chummer/Backend/Shared Methods/CharacterShared.cs
+++ b/Chummer/Backend/Shared Methods/CharacterShared.cs
@@ -5917,7 +5917,7 @@ namespace Chummer
         protected void AddSpirit()
         {
             // The number of bound Spirits cannot exceed the character's CHA.
-            if (!CharacterObject.IgnoreRules && CharacterObject.Spirits.Count(x => x.EntityType == SpiritType.Spirit) >= CharacterObject.CHA.Value)
+            if (!CharacterObject.IgnoreRules && CharacterObject.Spirits.Count(x => x.EntityType == SpiritType.Spirit && x.Bound) >= CharacterObject.CHA.Value)
             {
                 Program.MainForm.ShowMessageBox(this, LanguageManager.GetString("Message_BoundSpiritLimit"), LanguageManager.GetString("MessageTitle_BoundSpiritLimit"), MessageBoxButtons.OK, MessageBoxIcon.Information);
                 return;


### PR DESCRIPTION
A summoner can have CHA bound spirits, unbound ones should not count towards that limit.