### PR TITLE
Implemented TryGetVersionFieldQuickly

### DIFF
--- a/Chummer/Backend/Extensions/XmlNodeExtensions.cs
+++ b/Chummer/Backend/Extensions/XmlNodeExtensions.cs
@@ -526,6 +526,39 @@ namespace Chummer
         }
 
         /// <summary>
+        /// Like TryGetField for Version, but taking advantage of version.TryParse... boo, no TryParse interface! :(
+        /// If TryParse outputs null it will to try to use int.TryParse and use the output as a major. e.g. 1 becomes 1.0
+        /// </summary>
+        /// <param name="node"></param>
+        /// <param name="field"></param>
+        /// <param name="read"></param>
+        /// <param name="objCulture"></param>
+        /// <returns></returns>
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool TryGetVersionFieldQuickly(this XmlNode node, string field, ref Version read, IFormatProvider objCulture = null)
+        {
+            XmlElement objField = node?[field];
+            if (objField == null)
+                return false;
+            if (objCulture == null)
+                objCulture = GlobalOptions.InvariantCultureInfo;
+
+            if (!Version.TryParse(objField.InnerText, out Version tmpVersion))
+            {
+                if (tmpVersion == null)
+                {
+                    if (!int.TryParse(objField.InnerText, NumberStyles.Any, objCulture, out int tmpMajor))
+                        return false;
+
+                    tmpVersion = new Version(tmpMajor, 0);
+                }
+            }
+
+            read = tmpVersion;
+            return true;
+        }
+
+        /// <summary>
         /// Like TryGetField for guids, but taking advantage of guid.TryParse. Allows for returning false if the guid is Empty.
         /// </summary>
         /// <param name="node">XPathNavigator node of the object.</param>

--- a/Chummer/Classes/clsCustomDataDirectoryInfo.cs
+++ b/Chummer/Classes/clsCustomDataDirectoryInfo.cs
@@ -61,8 +61,10 @@ namespace Chummer
                     xmlObjManifest.LoadStandard(strFullDirectory);
                     var xmlNode = xmlObjManifest.SelectSingleNode("manifest");
 
-                    xmlNode.TryGetField("version", Version.TryParse, out _objMyVersion, new Version(1, 0));
+                    xmlNode.TryGetVersionFieldQuickly("version", ref _objMyVersion);
+
                     xmlNode.TryGetGuidFieldQuickly("guid", ref _guid);
+                    
 
                     GetManifestDescriptions(xmlNode);
                     GetManifestAuthors(xmlNode);
@@ -143,8 +145,10 @@ namespace Chummer
                     if (string.IsNullOrEmpty(strDependencyName) || guidId == Guid.Empty)
                         continue;
 
-                    objXmlNode.TryGetField("maxversion", Version.TryParse, out Version objNewMaximumVersion);
-                    objXmlNode.TryGetField("minversion", Version.TryParse, out Version objNewMinimumVersion);
+                    Version objNewMaximumVersion = new Version(1, 0);
+                    Version objNewMinimumVersion = new Version(1, 0);
+                    objXmlNode.TryGetVersionFieldQuickly("maxversion", ref objNewMaximumVersion);
+                    objXmlNode.TryGetVersionFieldQuickly("maxversion", ref objNewMinimumVersion);
 
                     DirectoryDependency objDependency = new DirectoryDependency(strDependencyName, guidId, objNewMinimumVersion, objNewMaximumVersion);
                     _lstDependencies.Add(objDependency);
@@ -169,8 +173,10 @@ namespace Chummer
                     if (string.IsNullOrEmpty(strDependencyName) || guidId == Guid.Empty)
                         continue;
 
-                    objXmlNode.TryGetField("maxversion", Version.TryParse, out Version objNewMaximumVersion);
-                    objXmlNode.TryGetField("minversion", Version.TryParse, out Version objNewMinimumVersion);
+                    Version objNewMaximumVersion = new Version(1, 0);
+                    Version objNewMinimumVersion = new Version(1, 0);
+                    objXmlNode.TryGetVersionFieldQuickly("maxversion", ref objNewMaximumVersion);
+                    objXmlNode.TryGetVersionFieldQuickly("maxversion", ref objNewMinimumVersion);
 
                     DirectoryDependency objIncompatibility = new DirectoryDependency(strDependencyName, guidId, objNewMinimumVersion, objNewMaximumVersion);
                     _lstIncompatibilities.Add(objIncompatibility);


### PR DESCRIPTION
fixes #4513 

`TryGetField` interacts badly with `Version.TryParse`, because this will output `null` and not default to `TryGetField`s error default value. This then leads to `NullPointerExceptions`. 

`TryGetVersionFieldQuickly` uses `version.TryParse`. If this outputs null it tries `int.TryParse` to get it as a `Major` for `Version`.

As an example
`<version>1</version>` will evaluate to `1.0` instead of giving out `null`.