### PR TITLE
Added Schattenload pdf items as custom data

### DIFF
--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -659,6 +659,18 @@
     <Content Include="customdata\Adapsin Applied as Multiplier, Not Grade\manifest.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="customdata\Add Schattenload Items\custom_books.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="customdata\Add Schattenload Items\custom_weapons.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="customdata\Add Schattenload Items\manifest.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="customdata\Add Schattenload Items\custom_vehicles.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
     <Content Include="customdata\Ammo Skip Internal Mount\amend_weapons.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>

--- a/Chummer/customdata/Add Schattenload Items/custom_books.xml
+++ b/Chummer/customdata/Add Schattenload Items/custom_books.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<chummer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema books.xsd">
+  <books>
+    <book>
+      <id>6c0c7f3a-1be3-4d98-8b56-8254573fc0b8</id>
+      <name>Schattenload HK Puncheon</name>
+      <code>SL02.19</code>
+    </book>
+    <book>
+      <id>f5ef339d-b21d-4a95-86c6-13fca45b596b</id>
+      <name>Extraload Verordneter Frohsinn</name>
+      <code>SL03.19</code>
+    </book>
+    <book>
+      <id>669fc6c7-fe28-4f04-a8e2-d85ed5add2ef</id>
+      <name>Extraload Der Multimog</name>
+      <code>SL07.19</code>
+    </book>
+  </books>
+</chummer>

--- a/Chummer/customdata/Add Schattenload Items/custom_vehicles.xml
+++ b/Chummer/customdata/Add Schattenload Items/custom_vehicles.xml
@@ -1,0 +1,255 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<chummer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.w3.org/2001/XMLSchema vehicles.xsd">
+  <vehicles>
+    <vehicle>
+      <id>d2336327-1f36-479f-94f2-62a359c0dcbd</id>
+      <name>Sony Economically-4</name>
+      <category>Drones: Anthro</category>
+      <page>3</page>
+      <source>SL03.19</source>
+      <handling>2</handling>
+      <speed>3</speed>
+      <accel>1</accel>
+      <body>3</body>
+      <armor>0</armor>
+      <pilot>3</pilot>
+      <sensor>3</sensor>
+      <cost>18000</cost>
+      <avail>4</avail>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>3</rating>
+          <maxrating>6</maxrating>
+        </gear>
+      </gears>
+      <mods>
+        <name>Drone Arm</name>
+        <name>Drone Arm</name>
+        <name>Drone Leg</name>
+        <name>Drone Leg</name>
+      </mods>
+    </vehicle>
+    <vehicle>
+      <id>21116c38-076e-4f99-9e0b-6083f8a9c83a</id>
+      <name>Sony Reliable-4</name>
+      <category>Drones: Anthro</category>
+      <page>3</page>
+      <source>SL03.19</source>
+      <handling>2</handling>
+      <speed>3</speed>
+      <accel>2</accel>
+      <body>4</body>
+      <armor>3</armor>
+      <pilot>4</pilot>
+      <sensor>4</sensor>
+      <cost>34000</cost>
+      <avail>12R</avail>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>4</rating>
+          <maxrating>6</maxrating>
+        </gear>
+        <gear>
+          <name>Quick-Draw Holster</name>
+        </gear>
+      </gears>
+      <mods>
+        <name>Drone Arm</name>
+        <name>Drone Arm</name>
+        <name>Drone Leg</name>
+        <name>Drone Leg</name>
+        <name>Emotive Display</name>
+      </mods>
+      <weaponmounts>
+        <weaponmount>
+          <control>Remote</control>
+          <flexibility>Fixed</flexibility>
+          <size>Standard (Drone)</size>
+          <visibility>External</visibility>
+          <allowedweapons>Underarm Ballistic Shield</allowedweapons>
+        </weaponmount>
+        <weaponmount>
+          <control>Remote</control>
+          <flexibility>Fixed</flexibility>
+          <size>Standard (Drone)</size>
+          <visibility>External</visibility>
+          <allowedweapons>Gas Grenade Launcher</allowedweapons>
+        </weaponmount>
+      </weaponmounts>
+      <weapons>
+        <weapon>
+          <name>Gas Grenade Launcher</name>
+        </weapon>
+        <weapon>
+          <name>Underarm Ballistic Shield</name>
+        </weapon>
+      </weapons>
+    </vehicle>
+    <vehicle>
+      <id>dac6f24b-a8e1-4d83-bc43-27ee02b0963a</id>
+      <name>Sony Versatile Cologne Ed.</name>
+      <category>Drones: Anthro</category>
+      <page>3</page>
+      <source>SL03.19</source>
+      <handling>2</handling>
+      <speed>3</speed>
+      <accel>1</accel>
+      <body>3</body>
+      <armor>0</armor>
+      <pilot>3</pilot>
+      <sensor>3</sensor>
+      <cost>23000</cost>
+      <avail>18R</avail>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>3</rating>
+          <maxrating>6</maxrating>
+        </gear>
+      </gears>
+      <mods>
+        <name>Drone Arm</name>
+        <name>Drone Arm</name>
+        <name>Drone Leg</name>
+        <name>Drone Leg</name>
+      </mods>
+      <weaponmounts>
+        <weaponmount>
+          <control>Remote</control>
+          <flexibility>Fixed</flexibility>
+          <size>Standard (Drone)</size>
+          <visibility>External</visibility>
+          <allowedweapons>Caramel Bonbon Grenade Launcher</allowedweapons>
+        </weaponmount>
+      </weaponmounts>
+      <weapons>
+        <weapon>
+          <name>Caramel Bonbon Grenade Launcher</name>
+        </weapon>
+      </weapons>
+    </vehicle>
+    <vehicle>
+      <id>cbd915a6-8ab8-4509-b70f-a2cd27803a1e</id>
+      <name>Sony Orderly-4</name>
+      <category>Drones: Anthro</category>
+      <page>3</page>
+      <source>SL03.19</source>
+      <handling>4</handling>
+      <speed>3</speed>
+      <accel>1</accel>
+      <body>4</body>
+      <armor>3</armor>
+      <pilot>4</pilot>
+      <sensor>4</sensor>
+      <cost>38000</cost>
+      <avail>11R</avail>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>4</rating>
+          <maxrating>6</maxrating>
+        </gear>
+      </gears>
+      <mods>
+        <name>Drone Arm</name>
+        <name>Drone Arm</name>
+        <name>Drone Leg</name>
+        <name>Drone Leg</name>
+        <name>Emotive Display</name>
+      </mods>
+    </vehicle>
+<!--Region Der Multimog-->
+    <vehicle>
+      <id>1b27cddf-25fb-46a0-aff0-c252231ac616</id>
+      <name>Mercedes Multimog-D1</name>
+      <page>1</page>
+      <source>SL07.19</source>
+      <accel>1</accel>
+      <armor>16</armor>
+      <avail>0</avail>
+      <body>16</body>
+      <category>Trucks</category>
+      <cost>45000</cost>
+      <handling>3/4</handling>
+      <pilot>1</pilot>
+      <sensor>2</sensor>
+      <speed>3</speed>
+      <bodymodslots>4</bodymodslots>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>2</rating>
+          <maxrating>7</maxrating>
+        </gear>
+      </gears>
+      <seats>6</seats>
+    </vehicle>
+    <vehicle>
+      <id>6a612d60-2776-4556-8b56-9e781241005d</id>
+      <name>Mercedes Multimog-K4 "Greif"</name>
+      <page>1</page>
+      <source>SL07.19</source>
+      <accel>1</accel>
+      <armor>18</armor>
+      <avail>12</avail>
+      <body>18</body>
+      <category>Trucks</category>
+      <cost>83000</cost>
+      <handling>3/4</handling>
+      <pilot>1</pilot>
+      <sensor>4</sensor>
+      <speed>3</speed>
+      <bodymodslots>4</bodymodslots>
+      <gears>
+        <gear>
+          <name>Sensor Array</name>
+          <rating>3</rating>
+          <maxrating>7</maxrating>
+        </gear>
+      </gears>
+      <mods>
+        <name>Rigger Adaptation</name>
+        <name rating="4">ECM</name>
+        <name>Satellite Link</name>
+        <name>Landing Drone Rack (Small)</name>
+        <name>Landing Drone Rack (Small)</name>
+      </mods>
+      <seats>6</seats>
+    </vehicle>
+  </vehicles>
+<!--Mods-->
+  <mods>
+    <mod>
+      <id>a8673414-5ad8-441c-bcea-65a93ab3d8c4</id>
+      <name>Emotive Display</name>
+      <page>3</page>
+      <source>SL03.19</source>
+      <avail>0</avail>
+      <category>Cosmetic</category>
+      <cost>0</cost>
+      <rating>0</rating>
+      <slots>0</slots>
+    </mod>
+  </mods>
+</chummer>

--- a/Chummer/customdata/Add Schattenload Items/custom_vehicles.xml
+++ b/Chummer/customdata/Add Schattenload Items/custom_vehicles.xml
@@ -87,7 +87,7 @@
           <flexibility>Fixed</flexibility>
           <size>Standard (Drone)</size>
           <visibility>External</visibility>
-          <allowedweapons>Underarm Ballistic Shield</allowedweapons>
+          <allowedweapons>Forearm Ballistic Shield</allowedweapons>
         </weaponmount>
         <weaponmount>
           <control>Remote</control>
@@ -102,7 +102,7 @@
           <name>Gas Grenade Launcher</name>
         </weapon>
         <weapon>
-          <name>Underarm Ballistic Shield</name>
+          <name>Forearm Ballistic Shield</name>
         </weapon>
       </weapons>
     </vehicle>

--- a/Chummer/customdata/Add Schattenload Items/custom_weapons.xml
+++ b/Chummer/customdata/Add Schattenload Items/custom_weapons.xml
@@ -1,0 +1,187 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<chummer>
+  <weapons>
+    <weapon>
+      <id>75ff26f3-d775-4b74-8042-0d3ba2233358</id>
+      <name>HK Puncheon</name>
+      <category>Exotic Ranged Weapons</category>
+      <type>Ranged</type>
+      <conceal>-2</conceal>
+      <accuracy>2</accuracy>
+      <reach>0</reach>
+      <damage>Chemical</damage>
+      <ap>-</ap>
+      <mode>SA</mode>
+      <rc>0</rc>
+      <ammo>6(c)</ammo>
+      <avail>9R</avail>
+      <cost>1150</cost>
+      <source>SL02.19</source>
+      <page>1</page>
+      <accessorymounts>
+        <mount>Barrel</mount>
+      </accessorymounts>
+      <accessories>
+        <accessory>
+          <name>Ceramic/Plasteel Components</name>
+          <rating>3</rating>
+        </accessory>
+      </accessories>
+      <range>Holdouts</range>
+      <sizecategory>Light Pistols</sizecategory>
+      <useskill>Pistols</useskill>
+      <weapontype>squirtgun</weapontype>
+    </weapon>
+    <weapon>
+      <id>a02a80a3-f9f5-4d0f-8c4a-627b2f4ed45b</id>
+      <name>HK Puncheon (Booster)</name>
+      <category>Exotic Ranged Weapons</category>
+      <type>Ranged</type>
+      <conceal>-2</conceal>
+      <accuracy>2</accuracy>
+      <reach>0</reach>
+      <damage>Chemical</damage>
+      <ap>-</ap>
+      <mode>SA</mode>
+      <rc>0</rc>
+      <ammo>6(c)</ammo>
+      <avail>9R</avail>
+      <cost>1150</cost>
+      <source>SL02.19</source>
+      <page>1</page>
+      <accessorymounts>
+        <mount>Barrel</mount>
+        <mount>Under</mount>
+      </accessorymounts>
+      <accessories>
+        <accessory>
+          <name>BOOSTER</name>
+        </accessory>
+        <accessory>
+          <name>Slide Mount</name>
+          <mount>Under</mount>
+        </accessory>
+        <accessory>
+          <name>Ceramic/Plasteel Components</name>
+          <rating>3</rating>
+        </accessory>
+      </accessories>
+      <range>Heavy Pistols</range>
+      <sizecategory>Heavy Pistols</sizecategory>
+      <useskill>Pistols</useskill>
+      <weapontype>squirtgun</weapontype>
+    </weapon>
+    <!--Region Verordnete Fröhlichkeit-->
+    <weapon>
+      <id>f3022b64-7b98-4e95-a53b-a1cbb7949fdc</id>
+      <name>Gas Grenade Launcher</name>
+      <category>Underbarrel Weapons</category>
+      <type>Ranged</type>
+      <conceal>6</conceal>
+      <accuracy>6</accuracy>
+      <reach>0</reach>
+      <damage>Grenade</damage>
+      <ap>Grenade</ap>
+      <mode>SS</mode>
+      <rc>0</rc>
+      <ammo>6(m)</ammo>
+      <avail>0</avail>
+      <cost>0</cost>
+      <source>SL03.19</source>
+      <page>3</page>
+      <ammocategory>Grenade Launchers</ammocategory>
+      <range>Grenade Launchers</range>
+      <useskill>Heavy Weapons</useskill>
+      <weapontype>glauncher</weapontype>
+      <hide />
+    </weapon>
+    <weapon>
+      <id>4828d74b-aa1d-48c9-ad70-9033ece30c55</id>
+      <name>Underarm Ballistic Shield</name>
+      <category>Exotic Melee Weapons</category>
+      <type>Melee</type>
+      <conceal>8</conceal>
+      <accuracy>4</accuracy>
+      <reach>0</reach>
+      <damage>({STR}+2)S</damage>
+      <ap>0</ap>
+      <mode>0</mode>
+      <rc>0</rc>
+      <ammo>0</ammo>
+      <avail></avail>
+      <cost>0</cost>
+      <source>SL03.19</source>
+      <page>3</page>
+      <hide />
+      <spec>Shields</spec>
+    </weapon>
+    <weapon>
+      <id>942c784a-4629-480a-91fc-9e0a9100017d</id>
+      <name>Caramel Bonbon Grenade Launcher</name>
+      <category>Underbarrel Weapons</category>
+      <type>Ranged</type>
+      <conceal>6</conceal>
+      <accuracy>6</accuracy>
+      <reach>0</reach>
+      <damage>Grenade</damage>
+      <ap>Grenade</ap>
+      <mode>SS</mode>
+      <rc>0</rc>
+      <ammo>6(m)</ammo>
+      <avail>0</avail>
+      <cost>0</cost>
+      <source>SL03.19</source>
+      <page>3</page>
+      <ammocategory>Grenade Launchers</ammocategory>
+      <hide />
+      <range>Grenade Launchers</range>
+      <useskill>Heavy Weapons</useskill>
+      <weapontype>glauncher</weapontype>
+    </weapon>
+  </weapons>
+  <accessories>
+    <accessory>
+      <!--As far as I know an accessory can't add other accessories, so this is a a hidden workaround and only comes with the HK Puncheon (Booster) weapon-->
+      <id>9a8068a7-3a4e-4dd9-b5e5-141119458c63</id>
+      <name>BOOSTER</name>
+      <mount />
+      <avail>9R</avail>
+      <cost>250</cost>
+      <source>SL02.19</source>
+      <page>1</page>
+      <rating>0</rating>
+      <conceal>2</conceal>
+      <accuracy>2</accuracy>
+      <required>
+        <weapondetails>
+          <name>HK Puncheon</name>
+        </weapondetails>
+      </required>
+      <forbidden>
+        <oneof>
+          <accessory>BOOSTER</accessory>
+        </oneof>
+      </forbidden>
+      <hide />
+    </accessory>
+  </accessories>
+
+</chummer>

--- a/Chummer/customdata/Add Schattenload Items/custom_weapons.xml
+++ b/Chummer/customdata/Add Schattenload Items/custom_weapons.xml
@@ -115,7 +115,7 @@
     </weapon>
     <weapon>
       <id>4828d74b-aa1d-48c9-ad70-9033ece30c55</id>
-      <name>Underarm Ballistic Shield</name>
+      <name>Forearm Ballistic Shield</name>
       <category>Exotic Melee Weapons</category>
       <type>Melee</type>
       <conceal>8</conceal>

--- a/Chummer/customdata/Add Schattenload Items/manifest.xml
+++ b/Chummer/customdata/Add Schattenload Items/manifest.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<manifest xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema ../manifest.xsd">
+  <guid>fc557702-1d1d-405f-b419-3de9cca41c4d</guid>
+  <version>1</version>
+  <authors>
+    <author>
+      <name>JoschiGrey</name>
+      <main>true</main>
+    </author>
+  </authors>
+  <descriptions>
+    <description>
+      <text>This ruleset adds the objects from the German exclusive "Schattenload" files for SR5. You will need to activate the books in the character options AFTER you activated this custom rule! Some of the equipment, especially the drones isn't fully stated out, so it was filled with fitting existing equipment.</text>
+      <lang>en-us</lang>
+    </description>
+    <description>
+      <text>Diese Regeln fügen die in den "Schattenload" genannten Gegenstände zu Chummer hinzu. Diese können gratis auf Pegasusdigital.de heruntergeladen werden. Die Bücher müssen gesondert in den Characteroptionen aktiviert werden, nachdem dieses Regel set aktiviert wurde. Einige Gegenstände sind nicht vollständig beschrieben, insbesondere die Ausrüstung der Dronen. Dies wurde mit passenden existierenden Gegenstände vervollständig.</text>
+      <lang>de-de</lang>
+    </description>
+  </descriptions>
+</manifest>


### PR DESCRIPTION
Added Weapons:
- HK Puncheon
- HK Puncheon with Booster

The booster adds a mounting slot, changes the size category and range category. It also has a slide rail attached. Because I couldn't find a way to make this happen, just with an accessory there are two puncheons and a hidden BOOSTER accessory.

Added Drones
- Sony Economically-4
- Sony Reliable-4
- Sony Versatile Cologne Ed.
- Sony Orderly-4

Two of them have a unspecified 6 shot grenade launcher. One being a "Gas Grenade Launcher" and the other being specifically modified to shoot candy. Those are added as renamed and hidden versions of the underbarrel grenade launcher. 
The Reliable also has an undefined forearm shield. This is a hidden rename of the normal ballistic shield.

Added Vehicles
- Mercedes Multimog-D1
- Mercedes Multimog-K4 "Greif"

Sadly the ECM of the K4 has no rating given in the book. So I just gave it a rating 4 one.

The combination of all those assumptions on my side made this set of rules unfit for the default rules and should only be added as custom rules with a grain of salt.