### PR TITLE
Minor updates to Manifest files

### DIFF
--- a/Chummer/customdata/Exclude German sourcebooks/amend_german_books.xml
+++ b/Chummer/customdata/Exclude German sourcebooks/amend_german_books.xml
@@ -23,8 +23,8 @@
       <hide />
     </book>
     <book>
-      <!-- Shadowrun 2050 is for 5e in German, but 4e in English. So we need to hide it because we only have the 5e version in Chummer5a, which is German-only -->
       <id>71a6304e-03dc-41db-be01-a86acab1517b</id>
+      <!-- Shadowrun 2050 is for 5e in German, but 4e in English. So we need to hide it because we only have the 5e version in Chummer5a, which is German-only -->
       <hide />
     </book>
   </books>

--- a/Chummer/customdata/Exclude German sourcebooks/manifest.xml
+++ b/Chummer/customdata/Exclude German sourcebooks/manifest.xml
@@ -28,8 +28,14 @@
     </authors>
     <descriptions>
       <description>
-        <text>This ruleset hides all books containing the word German in their title from being selected.</text>
+        <text>This ruleset hides all German specific sourcebooks from being selected.\nIt is not required when playing with Shadowrun Missions Rules.</text>
         <lang>en-us</lang>
       </description>
     </descriptions>
+    <incompatibilities>
+      <incompatibility>
+        <name>Shadowrun Missions Rules</name>
+        <guid>62aeb98e-e61c-4d0e-b4ff-03e0469e6e2b</guid>
+      </incompatibility>
+    </incompatibilities>
   </manifest>

--- a/Chummer/customdata/Rainforest Carbine Missions Errata/manifest.xml
+++ b/Chummer/customdata/Rainforest Carbine Missions Errata/manifest.xml
@@ -58,8 +58,14 @@
   </authors>
   <descriptions>
     <description>
-      <text>This ruleset replaces the Rainforest Carbine from Gun H(e)aven 3 with the rules specified in Shadowrun Missions Combined FAQ 1.3. It is not required when playing with Shadowrun Missions' rules.</text>
+      <text>This ruleset replaces the Rainforest Carbine from Gun H(e)aven 3 with the rules specified in Shadowrun Missions Combined FAQ 1.3.\nIt is not required when playing with Shadowrun Missions Rules.</text>
       <lang>en-us</lang>
     </description>
   </descriptions>
+  <incompatibilities>
+    <incompatibility>
+      <name>Shadowrun Missions Rules</name>
+      <guid>62aeb98e-e61c-4d0e-b4ff-03e0469e6e2b</guid>
+    </incompatibility>
+  </incompatibilities>
 </manifest>

--- a/Chummer/customdata/Shadowrun Missions Animal Prices/manifest.xml
+++ b/Chummer/customdata/Shadowrun Missions Animal Prices/manifest.xml
@@ -61,8 +61,14 @@
   </authors>
   <descriptions>
     <description>
-      <text>This ruleset implements only the prices and availabilities for animals as purchasable pets according to the stats outlined in Shadowrun Missions Combined FAQ version 1.3. It is not required when playing with Shadowrun Missions' rules.</text>
+      <text>This ruleset implements only the prices and availabilities for animals as purchasable pets according to the stats outlined in Shadowrun Missions Combined FAQ version 1.3.\nIt is not required when playing with Shadowrun Missions Rules.</text>
       <lang>en-us</lang>
     </description>
   </descriptions>
+  <incompatibilities>
+    <incompatibility>
+      <name>Shadowrun Missions Rules</name>
+      <guid>62aeb98e-e61c-4d0e-b4ff-03e0469e6e2b</guid>
+    </incompatibility>
+  </incompatibilities>
 </manifest>

--- a/Chummer/customdata/Shadowrun Missions Rules/amend_books.xml
+++ b/Chummer/customdata/Shadowrun Missions Rules/amend_books.xml
@@ -68,6 +68,7 @@
     </book>
     <book>
       <name>Shadowrun 2050 (5th Edition)</name>
+      <!-- Shadowrun 2050 is for 5e in German, but 4e in English. So we need to hide it because we only have the 5e version in Chummer5a, which is German-only -->
       <hide />
     </book>
     <book>

--- a/Chummer/customdata/Shadowrun Missions Rules/manifest.xml
+++ b/Chummer/customdata/Shadowrun Missions Rules/manifest.xml
@@ -74,5 +74,9 @@
       <name>Rainforest Carbine Missions Errata</name>
       <guid>39B1963E-DFB3-4082-8D7F-79F88DAB786F</guid>
     </incompatibility>
+    <incompatibility>
+      <name>Exclude German Sourcebooks</name>
+      <guid>08C4538B-6448-4DDF-BE93-D8A7696DB7BD</guid>
+    </incompatibility>
   </incompatibilities>
 </manifest>


### PR DESCRIPTION
Added 'incompatibility' clause with Shadowrun Missions rules definition to:
1) Exclude German sourcebooks
2) Rainforest Carbine Missions Erata
3) Shadowrun Missions Animal Prices
And standardized the comment that the Ruleset is not required if the "Shaowrun Missions Rules" ruleset is selected.

Modified the "Shadowrun Missions Rules" :
1) Added comment about "Shadowrun 2050 (5th Edition" to match the one in the "Exclude German sourcebooks"
2) Added 'incompatibility' clause for "Exclude German Sourcebooks" to the Manifest.