### PR TITLE
Fix for #4645

### DIFF
--- a/Chummer/Backend/Characters/Character.cs
+++ b/Chummer/Backend/Characters/Character.cs
@@ -2697,7 +2697,7 @@ namespace Chummer
 
             if (callOnSaveCallBack)
             {
-                blnErrorFree = DoOnSaveCompleted.Aggregate(blnErrorFree, (current, funcToRun) => funcToRun(this) && current);
+                blnErrorFree = DoOnSaveCompleted.ToArray().Aggregate(blnErrorFree, (current, funcToRun) => funcToRun(this) && current);
             }
             return blnErrorFree;
         }

--- a/Chummer/Backend/Datastructures/LockingDictionary.cs
+++ b/Chummer/Backend/Datastructures/LockingDictionary.cs
@@ -347,8 +347,9 @@ namespace Chummer
             {
                 using (new EnterUpgradeableReadLock(_rwlThis))
                 {
-                    if (_dicData[key].Equals(value))
-                        return;
+                    if (_dicData.ContainsKey(key))
+                        if (_dicData[key].Equals(value))
+                            return;
                     using (new EnterWriteLock(_rwlThis))
                         _dicData[key] = value;
                 }

--- a/Chummer/Forms/EditGlobalSettings.cs
+++ b/Chummer/Forms/EditGlobalSettings.cs
@@ -1522,8 +1522,16 @@ namespace Chummer
                                          : strFile,
                                      xmlSheet.SelectSingleNodeAndCacheExpression("name")?.Value ?? string.Empty));
                 }
-
-                string strOldSelected = cboXSLT.SelectedValue?.ToString() ?? string.Empty;
+                string strOldSelected;
+                try
+                {
+                    strOldSelected = cboXSLT.SelectedValue?.ToString() ?? string.Empty;
+                }
+                catch(IndexOutOfRangeException)
+                { 
+                    strOldSelected = string.Empty;
+                }
+                 
                 // Strip away the language prefix
                 int intPos = strOldSelected.LastIndexOf(Path.DirectorySeparatorChar);
                 if (intPos != -1)


### PR DESCRIPTION
@DelnarErsike please take a look, since I don't really understand the Locking-Mechanic.

Problem is: the Plugin messes with the Collection in the Callback. Now - that is probably wrong in itself, but even IF a Plugin does that, the main-program should not crash. That's why I suggest to cast the callback-enumerator to an array before we aggregate it.

#4645 