### PR TITLE
Neon Anarchy maintenance: Sensei and Made Man quality changes

### DIFF
--- a/Chummer/customdata/Neon Anarchy House Rules/amend_qualities.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_qualities.xml
@@ -198,6 +198,13 @@
 			<hide />
 		</quality>
 		<quality>
+			<name>Made Man</name>
+			<bonus>
+				<addcontact amendoperation="remove" />
+			</bonus>
+			<notes operation="addnode">Manually add a free Group Contact with Connection between 1 and 3 to represent the relevant gang or syndicate.</notes>
+		</quality>
+		<quality>
 			<name>Massive Network</name>
 			<hide />
 		</quality>
@@ -230,6 +237,13 @@
 		<quality>
 			<name>Revels in Murder</name>
 			<hide />
+		</quality>
+		<quality>
+			<name>Sensei</name>
+			<bonus>
+				<selectcontact amendoperation="remove" />
+				<selecttext xml="skills.xml" xpath="/chummer/skillgroups/name | /chummer/skills/skill[not(skillgroup) or skillgroup = '']/name" allowedit="True" />
+			</bonus>
 		</quality>
 		<quality>
 			<name>Special Modifications</name>


### PR DESCRIPTION
Sensei now peoperly doesn't require selecting a contact and only shows skill groups and ungrouped skills, because skills within a group can be trained by a group sensei so a grouped-skill sensei is banned for being strictly worse.

Made Man no longer gives the free group contact.