### PR TITLE
Neon Anarchy Maintenance - concealability and rating cap changes

### DIFF
--- a/Chummer/customdata/Neon Anarchy House Rules/amend_gear.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_gear.xml
@@ -120,5 +120,9 @@
 			<name>Fab Sensor Upkeep (1 Month Advance Payment)</name>
 			<category>Contracts/Upkeep</category>
 		</gear>
+		<gear>
+		    <name>Naga Venom</name>
+			<rating amendoperation="replace">12</rating>
+		</gear>
 	</gears>
 </chummer>

--- a/Chummer/customdata/Neon Anarchy House Rules/amend_weapons.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_weapons.xml
@@ -288,7 +288,7 @@
 			<name>Throwing Syringe</name>
 			<useskill>Throwing Weapons</useskill>
 		</weapon>
-
+		<!-- Actual stst changes -->
 		<weapon>
 			<name>Heavy Crossbow</name>
 			<accessorymounts>
@@ -317,13 +317,21 @@
 				<!--<mount>Under</mount> I hope your dream comes true one day, Moebius-->
 			</accessorymounts>
 		</weapon>
-	<weapon>
+		<weapon>
 			<name>Mitsubishi Yakusoku MRL</name>
 			<accuracy>5</accuracy>
 		</weapon>
-	<weapon>
+		<weapon>
 			<name>Onotari Arms Ballista MML</name>
 			<accuracy>5</accuracy>
+		</weapon>
+		<weapon>
+			<name>Nodachi</name>
+			<conceal>+10</conceal>
+		</weapon>
+		<weapon>
+			<name>Osmium Mace</name>
+			<conceal>+10</conceal>
 		</weapon>
 	</weapons>
 </chummer>


### PR DESCRIPTION
Nodachi is now +10 conceal
Osmium Mace is now +10 conceal
Naga venom is now capped to rating 12