### PR TITLE
Rework clip handling to fix bugs

### DIFF
--- a/Chummer/Backend/Equipment/Clip.cs
+++ b/Chummer/Backend/Equipment/Clip.cs
@@ -28,16 +28,24 @@ namespace Chummer.Backend.Equipment
     {
         private readonly Character _objCharacter;
         private readonly Weapon _objWeapon;
+        // can be null for the internal clip
+        private readonly WeaponAccessory _objAccessory;
         private Gear _objAmmoGear;
 
-        internal Clip(Character objCharacter, Weapon objWeapon, Gear objGear, int intAmmoCount)
+        internal Clip(Character objCharacter, WeaponAccessory objAccessory, Weapon objWeapon, Gear objGear, int intAmmoCount)
         {
             _objCharacter = objCharacter;
             _objWeapon = objWeapon;
+            _objAccessory = objAccessory;
             AmmoGear = objGear;
             Ammo = intAmmoCount;
             AmmoLocation = "loaded";
         }
+
+        /// <summary>
+        /// The GUID of the weapon accessory this clip is owned by. GUID of the weapon if it's not owned by an accessory.
+        /// </summary>
+        internal string OwnedBy => _objAccessory?.InternalId ?? _objWeapon?.InternalId;
 
         internal int Ammo { get; set; }
 
@@ -111,7 +119,7 @@ namespace Chummer.Backend.Equipment
 
         public string AmmoLocation { get; set; }
 
-        internal static Clip Load(XmlNode node, Character objCharacter, Weapon objWeapon)
+        internal static Clip Load(XmlNode node, Character objCharacter, Weapon objWeapon, WeaponAccessory objOwnerAccessory)
         {
             if (node == null)
                 return null;
@@ -129,7 +137,7 @@ namespace Chummer.Backend.Equipment
                         ? objWeapon.ParentVehicle.FindVehicleGear(strAmmoGuid)
                         : objCharacter.Gear.DeepFindById(strAmmoGuid);
                 }
-                Clip objReturn = new Clip(objCharacter, objWeapon, objGear, intCount);
+                Clip objReturn = new Clip(objCharacter, objOwnerAccessory, objWeapon, objGear, intCount);
                 string strTemp = string.Empty;
                 if (node.TryGetStringFieldQuickly("location", ref strTemp))
                     objReturn.AmmoLocation = strTemp;

--- a/Chummer/Forms/Character Forms/CharacterCareer.Designer.cs
+++ b/Chummer/Forms/Character Forms/CharacterCareer.Designer.cs
@@ -766,6 +766,7 @@ namespace Chummer
             this.cmdDeleteGear = new Chummer.SplitButton();
             this.chkCommlinks = new Chummer.ColorableCheckBox(this.components);
             this.cmdAddGear = new Chummer.SplitButton();
+            this.chkHideLoadedAmmo = new Chummer.ColorableCheckBox(this.components);
             this.tabArmor = new System.Windows.Forms.TabPage();
             this.tlpArmor = new Chummer.BufferedTableLayoutPanel(this.components);
             this.treArmor = new System.Windows.Forms.TreeView();
@@ -12610,22 +12611,24 @@ namespace Chummer
             // 
             this.tlpGearButtons.AutoSize = true;
             this.tlpGearButtons.AutoSizeMode = System.Windows.Forms.AutoSizeMode.GrowAndShrink;
-            this.tlpGearButtons.ColumnCount = 4;
+            this.tlpGearButtons.ColumnCount = 5;
             this.tlpGear.SetColumnSpan(this.tlpGearButtons, 2);
             this.tlpGearButtons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
             this.tlpGearButtons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
             this.tlpGearButtons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle(System.Windows.Forms.SizeType.Percent, 33.33333F));
             this.tlpGearButtons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tlpGearButtons.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
             this.tlpGearButtons.Controls.Add(this.cmdAddLocation, 2, 0);
             this.tlpGearButtons.Controls.Add(this.cmdDeleteGear, 1, 0);
             this.tlpGearButtons.Controls.Add(this.chkCommlinks, 3, 0);
             this.tlpGearButtons.Controls.Add(this.cmdAddGear, 0, 0);
+            this.tlpGearButtons.Controls.Add(this.chkHideLoadedAmmo, 4, 0);
             this.tlpGearButtons.Location = new System.Drawing.Point(0, 0);
             this.tlpGearButtons.Margin = new System.Windows.Forms.Padding(0);
             this.tlpGearButtons.Name = "tlpGearButtons";
             this.tlpGearButtons.RowCount = 1;
             this.tlpGearButtons.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
-            this.tlpGearButtons.Size = new System.Drawing.Size(392, 29);
+            this.tlpGearButtons.Size = new System.Drawing.Size(512, 29);
             this.tlpGearButtons.TabIndex = 207;
             // 
             // cmdAddLocation
@@ -12684,6 +12687,22 @@ namespace Chummer
             this.cmdAddGear.Text = "&Add Gear";
             this.cmdAddGear.UseVisualStyleBackColor = true;
             this.cmdAddGear.Click += new System.EventHandler(this.cmdAddGear_Click);
+            // 
+            // chkHideLoadedAmmo
+            // 
+            this.chkHideLoadedAmmo.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.chkHideLoadedAmmo.AutoSize = true;
+            this.chkHideLoadedAmmo.DefaultColorScheme = true;
+            this.chkHideLoadedAmmo.FlatAppearance.MouseDownBackColor = System.Drawing.SystemColors.ControlDarkDark;
+            this.chkHideLoadedAmmo.FlatAppearance.MouseOverBackColor = System.Drawing.SystemColors.ControlDark;
+            this.chkHideLoadedAmmo.Location = new System.Drawing.Point(395, 6);
+            this.chkHideLoadedAmmo.Name = "chkHideLoadedAmmo";
+            this.chkHideLoadedAmmo.Size = new System.Drawing.Size(114, 17);
+            this.chkHideLoadedAmmo.TabIndex = 118;
+            this.chkHideLoadedAmmo.Tag = "Checkbox_HideAmmo";
+            this.chkHideLoadedAmmo.Text = "Hide loaded ammo";
+            this.chkHideLoadedAmmo.UseVisualStyleBackColor = true;
+            this.chkHideLoadedAmmo.CheckedChanged += new System.EventHandler(this.chkHideLoadedAmmo_CheckedChanged);
             // 
             // tabArmor
             // 
@@ -23948,5 +23967,6 @@ namespace Chummer
         private BufferedTableLayoutPanel tlpVehiclesButtons;
         private Button cmdUnloadWeapon;
         private Button cmdUnloadVehicleWeapon;
+        private ColorableCheckBox chkHideLoadedAmmo;
     }
 }

--- a/Chummer/Forms/Character Forms/CharacterCareer.cs
+++ b/Chummer/Forms/Character Forms/CharacterCareer.cs
@@ -350,7 +350,9 @@ namespace Chummer
                                     await RefreshContacts(panContacts, panEnemies, panPets);
 
                                     await RefreshArmor(treArmor, cmsArmorLocation, cmsArmor, cmsArmorMod, cmsArmorGear);
-                                    await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
+                                    await RefreshGears(treGear, cmsGearLocation, cmsGear,
+                                        await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken),
+                                        await chkHideLoadedAmmo.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
                                     await RefreshFociFromGear(treFoci, null);
                                     await RefreshCyberware(treCyberware, cmsCyberware, cmsCyberwareGear);
                                     await RefreshWeapons(treWeapons, cmsWeaponLocation, cmsWeapon, cmsWeaponAccessory,
@@ -1476,7 +1478,10 @@ namespace Chummer
         {
             try
             {
-                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken), e);
+                await RefreshGears(treGear, cmsGearLocation, cmsGear,
+                    await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken),
+                    await chkHideLoadedAmmo.DoThreadSafeFuncAsync(x => x.Checked, GenericToken),
+                    e);
                 await RefreshFociFromGear(treFoci, null, e);
             }
             catch (OperationCanceledException)
@@ -2570,7 +2575,9 @@ namespace Chummer
                                                        chkPsycheActiveTechnomancer);
 
                                 await RefreshArmor(treArmor, cmsArmorLocation, cmsArmor, cmsArmorMod, cmsArmorGear);
-                                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
+                                await RefreshGears(treGear, cmsGearLocation, cmsGear,
+                                    await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken),
+                                    await chkHideLoadedAmmo.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
                                 await RefreshFociFromGear(treFoci, null);
                                 await RefreshCyberware(treCyberware, cmsCyberware, cmsCyberwareGear);
                                 await RefreshWeapons(treWeapons, cmsWeaponLocation, cmsWeapon, cmsWeaponAccessory,
@@ -11955,9 +11962,21 @@ namespace Chummer
 
         private async void chkCommlinks_CheckedChanged(object sender, EventArgs e)
         {
+            await FilterCheckboxChanged();
+        }
+
+        private async void chkHideLoadedAmmo_CheckedChanged(object sender, EventArgs e)
+        {
+            await FilterCheckboxChanged();
+        }
+
+        private async ValueTask FilterCheckboxChanged()
+        {
             try
             {
-                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
+                bool commlinksOnly = await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken);
+                bool hideLoadedAmmo = await chkHideLoadedAmmo.DoThreadSafeFuncAsync(x => x.Checked, GenericToken);
+                await RefreshGears(treGear, cmsGearLocation, cmsGear, commlinksOnly, hideLoadedAmmo);
             }
             catch (OperationCanceledException)
             {

--- a/Chummer/Forms/Character Forms/CharacterCreate.cs
+++ b/Chummer/Forms/Character Forms/CharacterCreate.cs
@@ -405,7 +405,7 @@ namespace Chummer
                                     await RefreshContacts(panContacts, panEnemies, panPets);
 
                                     await RefreshArmor(treArmor, cmsArmorLocation, cmsArmor, cmsArmorMod, cmsArmorGear);
-                                    await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
+                                    await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken), false);
                                     await RefreshFociFromGear(treFoci, null);
                                     await RefreshCyberware(treCyberware, cmsCyberware, cmsCyberwareGear);
                                     await RefreshWeapons(treWeapons, cmsWeaponLocation, cmsWeapon, cmsWeaponAccessory,
@@ -2111,7 +2111,7 @@ namespace Chummer
                                 await RefreshContacts(panContacts, panEnemies, panPets);
 
                                 await RefreshArmor(treArmor, cmsArmorLocation, cmsArmor, cmsArmorMod, cmsArmorGear);
-                                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
+                                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken), false);
                                 await RefreshFociFromGear(treFoci, null);
                                 await RefreshCyberware(treCyberware, cmsCyberware, cmsCyberwareGear);
                                 await RefreshWeapons(treWeapons, cmsWeaponLocation, cmsWeapon, cmsWeaponAccessory,
@@ -8438,7 +8438,7 @@ namespace Chummer
         {
             try
             {
-                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken));
+                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken), false);
             }
             catch (OperationCanceledException)
             {
@@ -17798,7 +17798,7 @@ namespace Chummer
         {
             try
             {
-                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken), e);
+                await RefreshGears(treGear, cmsGearLocation, cmsGear, await chkCommlinks.DoThreadSafeFuncAsync(x => x.Checked, GenericToken), false, e);
                 await RefreshFociFromGear(treFoci, null, e);
             }
             catch (OperationCanceledException)

--- a/Chummer/Forms/Character Forms/CharacterShared.cs
+++ b/Chummer/Forms/Character Forms/CharacterShared.cs
@@ -3683,7 +3683,7 @@ namespace Chummer
             }
         }
 
-        protected async ValueTask RefreshGears(TreeView treGear, ContextMenuStrip cmsGearLocation, ContextMenuStrip cmsGear, bool blnCommlinksOnly, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs = null)
+        protected async ValueTask RefreshGears(TreeView treGear, ContextMenuStrip cmsGearLocation, ContextMenuStrip cmsGear, bool blnCommlinksOnly, bool blnHideLoadedAmmo, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs = null)
         {
             if (treGear == null)
                 return;
@@ -3813,6 +3813,9 @@ namespace Chummer
                 async ValueTask AddToTree(Gear objGear, int intIndex = -1, bool blnSingleAdd = true)
                 {
                     if (blnCommlinksOnly && !objGear.IsCommlink)
+                        return;
+
+                    if (blnHideLoadedAmmo && objGear.LoadedIntoClip != null)
                         return;
 
                     TreeNode objNode = objGear.CreateTreeNode(cmsGear);

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -555,6 +555,10 @@
       <text>Only show Commlinks</text>
     </string>
     <string>
+      <key>Checkbox_HideAmmo</key>
+      <text>Hide loaded ammo</text>
+    </string>
+    <string>
       <key>Checkbox_ActiveCommlink</key>
       <text>Active Commlink</text>
     </string>


### PR DESCRIPTION
- Add and remove clips when clip-giving accessories are added
- Associate clips with clip-giving accessories, so they get removed when the accessory is removed
- Unload clips whenever they're being removed, also whenever the weapon is being removed
- Load accessories before loading clips, so we can access and associate them
- Fix bug when transferring ammo to vehicles, where the ammo wouldn't be transferred
- Remove AmmoSlots, it's not needed anymore

This fixes a number of issues reported in the Discord

There's still one outstanding bug I could find - the vehicle view doesn't update automatically when things change (ammo loaded, etc.). This doesn't affect functionality, just display