### PR TITLE
Fix for #4083 by implementing simple bool check to prevent overrides

### DIFF
--- a/Chummer/Forms/Character Forms/CharacterCareer.cs
+++ b/Chummer/Forms/Character Forms/CharacterCareer.cs
@@ -13532,7 +13532,8 @@ namespace Chummer
                            Amount = objExpense.Amount,
                            Refund = objExpense.Refund,
                            SelectedDate = objExpense.Date,
-                           ForceCareerVisible = objExpense.ForceCareerVisible
+                           ForceCareerVisible = objExpense.ForceCareerVisible,
+                           IsInEditMode = true
                        }))
             {
                 frmEditExpense.MyForm.LockFields(blnAllowEdit);
@@ -13590,7 +13591,8 @@ namespace Chummer
                            Amount = objExpense.Amount,
                            Refund = objExpense.Refund,
                            SelectedDate = objExpense.Date,
-                           ForceCareerVisible = objExpense.ForceCareerVisible
+                           ForceCareerVisible = objExpense.ForceCareerVisible,
+                           IsInEditMode = true
                        }))
             {
                 frmEditExpense.MyForm.LockFields(blnAllowEdit);

--- a/Chummer/Forms/Creation Forms/CreateExpense.cs
+++ b/Chummer/Forms/Creation Forms/CreateExpense.cs
@@ -176,6 +176,8 @@ namespace Chummer
         public bool KarmaNuyenExchange { get; set; }
         public string KarmaNuyenExchangeString { get; set; }
 
+        public bool IsInEditMode { get; set; }
+
         #endregion Properties
 
         #region Methods
@@ -222,8 +224,11 @@ namespace Chummer
 
         private async void CreateExpanse_Load(object sender, EventArgs e)
         {
-            string strText = await LanguageManager.GetStringAsync("String_ExpenseDefault");
-            await txtDescription.DoThreadSafeAsync(x => x.Text = strText);
+            if (!IsInEditMode)
+            {
+                string strText = await LanguageManager.GetStringAsync("String_ExpenseDefault");
+                await txtDescription.DoThreadSafeAsync(x => x.Text = strText);
+            }
             await chkKarmaNuyenExchange.DoThreadSafeAsync(x =>
             {
                 x.Visible = !string.IsNullOrWhiteSpace(KarmaNuyenExchangeString);


### PR DESCRIPTION
Simple change to check if the `CreateExpense` form is meant to edit or newly generated and thus preventing overwriting of `Reason`

Fixes #4803 