### PR TITLE
Fix a few ammunition bugs.

### DIFF
--- a/Chummer/Backend/Equipment/Weapon.cs
+++ b/Chummer/Backend/Equipment/Weapon.cs
@@ -6541,7 +6541,7 @@ namespace Chummer.Backend.Equipment
                         else
                         {
                             objCurrentlyLoadedAmmo.Quantity = decQty;
-                            objSelectedAmmo.Quantity -= decQty;
+                            objSelectedAmmo.Quantity -= decTopUp;
                             await treGearView.DoThreadSafeAsync(x =>
                             {
                                 // Refresh the Gear tree.

--- a/Chummer/Forms/Character Forms/CharacterCareer.cs
+++ b/Chummer/Forms/Character Forms/CharacterCareer.cs
@@ -16360,6 +16360,14 @@ namespace Chummer
                     await treGear.DoThreadSafeAsync(x => x.SelectedNode.Text = objGear.CurrentDisplayName, token);
                     await ProcessEquipmentConditionMonitorBoxDisplays(panGearMatrixCM, objGear.MatrixCM,
                                                                       objGear.MatrixCMFilled, token);
+                    if (objGear.LoadedIntoClip != null)
+                    {
+                        await cmdGearIncreaseQty.DoThreadSafeAsync(x => x.Enabled = false);
+                        await cmdGearReduceQty.DoThreadSafeAsync(x => x.Enabled = false);
+                        await cmdGearMergeQty.DoThreadSafeAsync(x => x.Enabled = false);
+                        await cmdGearSplitQty.DoThreadSafeAsync(x => x.Enabled = false);
+                        await cmdGearMoveToVehicle.DoThreadSafeAsync(x => x.Enabled = false);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
First commit: Fixes an issue commented in Discord, where ammunition can be removed/added/merged/split while loaded into a clip.
Ammunition can still be sold when loaded into a clip, but this just unloads the clip.

Second commit: Fixes reloading taking too much ammo out of some ammunition, leading to negative ammo values