### PR TITLE
Added the traditions Shamanic[Traditional] and Shamanic[Ancestor]. I …

### DIFF
--- a/Chummer/data/traditions.xml
+++ b/Chummer/data/traditions.xml
@@ -941,6 +941,39 @@
         <spiritmanipulation>Spirit of Earth</spiritmanipulation>
       </spirits>
     </tradition>
+    <tradition>
+      <id>9d18592e-5f49-4992-babd-d1ac98c48f78</id>
+      <name>Shamanic [Traditionalist]</name>
+      <drain>{WIL} + {CHA}</drain>
+      <source>FA</source>
+      <page>74</page>
+      <addqualities>
+        <addquality forced="False">Mentor Spirit</addquality>
+        <addquality forced="True" select="Shamans Code: Harmony with Nature">Code of Honor</addquality>
+      </addqualities>
+      <spirits>
+        <spiritcombat>Spirit of Beasts</spiritcombat>
+        <spiritdetection>Spirit of Water</spiritdetection>
+        <spirithealth>Spirit of Earth</spirithealth>
+        <spiritillusion>Spirit of Air</spiritillusion>
+        <spiritmanipulation>Spirit of Man</spiritmanipulation>
+      </spirits>
+      <skilldisable>Binding</skilldisable>
+    </tradition>
+    <tradition>
+      <id>9d18592e-5f49-4992-babd-d1ac98c48f78</id>
+      <name>Shamanic [Ancestor]</name>
+      <drain>{WIL} + {CHA}</drain>
+      <source>FA</source>
+      <page>74</page>
+      <spirits>
+        <spiritcombat>Spirit of Beasts</spiritcombat>
+        <spiritdetection>Spirit of Water</spiritdetection>
+        <spirithealth>Spirit of Earth</spirithealth>
+        <spiritillusion>Spirit of Air</spiritillusion>
+        <spiritmanipulation>Spirit of Man</spiritmanipulation>
+      </spirits>
+    </tradition>    
     <!-- End Region -->
     <!-- Region SotA ADL-->
     <tradition>


### PR DESCRIPTION
Partly Fixes: Updated Shamanic Traditions are Missing #4857 

[x] Added the traditions Shamanic[Traditional] and Shamanic[Ancestor]. 

I dont see how I could implement the requirement for Shamanic[Traditional] to have the mentor spirit. It clearly requires the positive Quality but does not give it for free. 
-> Someone creating a Shamanic[Traditional] character will have to satisfy the requirement of mentor spirit namually. 

Also, there is no way to automatically give a positive Quality on reaching a certain initiate level. 
-> This also has to be done manually.