### PR TITLE
NA Dataset update 2022-07-22

### DIFF
--- a/Chummer/customdata/Neon Anarchy House Rules/amend_armor.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_armor.xml
@@ -54,5 +54,9 @@
 			<name>Grey Mana Integration</name>
 			<avail>FixedValues(6R,6R,6R,9R,9R,9R)</avail>
 		</mod>
+		<mod>
+			<name>Universal Mirror Material</name>
+			<avail>8F</avail>
+		</mod>
 	</mods>
 </chummer>

--- a/Chummer/customdata/Neon Anarchy House Rules/amend_gear.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_gear.xml
@@ -124,5 +124,14 @@
 		    <name>Naga Venom</name>
 			<rating amendoperation="replace">12</rating>
 		</gear>
+		<gear>
+			<name>Micro-Transceiver</name>
+			<gears amendoperation="addnode">
+				<usegear amendoperation="addnode">
+				  <name amendoperation="addnode">Subvocal Mic</name>
+				  <category amendoperation="addnode">Electronics Accessories</category>
+				</usegear>
+			</gears>
+		</gear>
 	</gears>
 </chummer>

--- a/Chummer/customdata/Neon Anarchy House Rules/amend_lifestyles.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_lifestyles.xml
@@ -23,14 +23,90 @@
 	https://www.reddit.com/r/NeonAnarchy
 -->
 <chummer>
-	<lifestyles>
-		<lifestyle>
-			<name>Commercial</name>
-			<hide />
-		</lifestyle>
-		<lifestyle>
-			<name>Traveler</name>
-			<hide />
-		</lifestyle>
-	</lifestyles>
+  <lifestyles>
+	<lifestyle>
+		<name>Commercial</name>
+		<hide />
+	</lifestyle>
+	<lifestyle>
+		<name>Traveler</name>
+		<hide />
+	</lifestyle>
+  </lifestyles>
+  <qualities>
+    <quality>
+      <id>280535d6-9e2a-4831-8b22-b2fb0647cff7</id>
+      <name>Cramped Garage (Airplane)</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <id>df7d2669-2af5-475b-853d-819498b3badc</id>
+      <name>Cramped Garage (Boat)</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <id>efe7c46c-b863-4696-a750-015837861f81</id>
+      <name>Cramped Garage (Car (Body 4 or Less))</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <id>3d62f25c-8c84-476f-907d-a95073711b44</id>
+      <name>Cramped Garage (Car (Body 5 or More))</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <id>10a65174-a6a3-467b-b66e-6a837bf0e11b</id>
+      <name>Cramped Garage (Helicopter)</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Gym</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Shooting Range</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Sports Court - Small</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Cramped Workshop/Facility</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Cramped</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Dangerous Area</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <id>61e7bb21-cb25-44ff-a332-639fe9dac893</id>
+      <name>Thrifty</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Household Gremlins I</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Household Gremlins II</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>No Masters</name>
+	  <hide/>
+    </quality>
+    <quality>
+      <name>Cramped Garage (Stable)</name>
+      <hide/>
+    </quality>
+    <quality>
+      <name>Haunted</name>
+      <hide/>
+    </quality>
+  </qualities>
 </chummer>

--- a/Chummer/customdata/Neon Anarchy House Rules/amend_powers.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_powers.xml
@@ -33,5 +33,13 @@
 				</weaponcategorydv>
 			</bonus>
 		</power>
+		<power>
+			<name>Missile Mastery</name>
+			<bonus>
+				<addweapon amendoperation="addnode">
+				  <name>Improvised Thrown Weapon (Missile Mastery)</name>
+				</addweapon>
+			</bonus>
+		</power>
 	</powers>
 </chummer>

--- a/Chummer/customdata/Neon Anarchy House Rules/amend_vehicles.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_vehicles.xml
@@ -176,4 +176,14 @@
 			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Exotic Ranged Weapons,Cyberweapon,Bio-Weapon,Unarmed,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Shotguns,Machine Guns,Assault Cannons,Grenade Launchers,Missile Launchers,Laser Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Sporting Rifles,Sniper Rifles,Carbines</weaponcategories>
 		</weaponmount>
 	</weaponmounts>
+	<weaponmountmods>	
+		<mod>
+		  <name>Ammo Bin</name>
+		  <forbidden>
+			<vehicledetails>
+			  <category operation="contains">Drones</category>
+			</vehicledetails>
+		  </forbidden>
+		</mod>
+	</weaponmountmods>
 </chummer>

--- a/Chummer/customdata/Neon Anarchy House Rules/amend_vehicles.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/amend_vehicles.xml
@@ -28,6 +28,9 @@
 			<name>Horizon Noizquito (Microdrone)</name>
 			<hide />
 		</vehicle>
+		<vehicle xpathfilter="source='SS' and category='Corpsec/Police/Military'">
+			<hide amendoperation="addnode"/>
+		</vehicle>
 		<vehicle>
 			<name>Krime Bazoo Basic</name>
 			<avail>0</avail>
@@ -137,10 +140,12 @@
 		<weaponmount>
 			<name>Standard [SR5]</name>
 			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Cyberweapon,Bio-Weapon,Unarmed,Crossbows,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Sporting Rifles,Carbines</weaponcategories>
+			<hide />
 		</weaponmount>
 		<weaponmount>
 			<name>Heavy [SR5]</name>
 			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Cyberweapon,Bio-Weapon,Unarmed,Crossbows,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Grenade Launchers,Missile Launchers,Laser Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Flamethrowers,Sporting Rifles,Exotic Ranged Weapons,Carbines</weaponcategories>
+			<hide />
 		</weaponmount>
 		<weaponmount>
 			<name>Light</name>
@@ -148,11 +153,11 @@
 		</weaponmount>
 		<weaponmount>
 			<name>Standard</name>
-			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Cyberweapon,Bio-Weapon,Unarmed,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Sporting Rifles,Carbines</weaponcategories>
+			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Cyberweapon,Bio-Weapon,Unarmed,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Sporting Rifles,Carbines,Crossbows</weaponcategories>
 		</weaponmount>
 		<weaponmount>
 			<name>Heavy</name>
-			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Cyberweapon,Bio-Weapon,Unarmed,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Grenade Launchers,Missile Launchers,Laser Weapons,Sporting Rifles,Carbines</weaponcategories>
+			<weaponcategories>Blades,Clubs,Improvised Weapons,Exotic Melee Weapons,Cyberweapon,Bio-Weapon,Unarmed,Tasers,Holdouts,Light Pistols,Heavy Pistols,Machine Pistols,Submachine Guns,Assault Rifles,Sniper Rifles,Shotguns,Exotic Ranged Weapons,Flamethrowers,Special Weapons,Light Machine Guns,Medium Machine Guns,Heavy Machine Guns,Assault Cannons,Grenade Launchers,Missile Launchers,Laser Weapons,Sporting Rifles,Carbines,Crossbows</weaponcategories>
 		</weaponmount>
 		<weaponmount>
 			<name>Standard (Drone)</name>

--- a/Chummer/customdata/Neon Anarchy House Rules/custom_weapons.xml
+++ b/Chummer/customdata/Neon Anarchy House Rules/custom_weapons.xml
@@ -19,127 +19,149 @@
 -->
 <!--This file is part a series of data files created for r/NeonAnarchy.
 
-	You can learn more at
-	https://www.reddit.com/r/NeonAnarchy
+    You can learn more at
+    https://www.reddit.com/r/NeonAnarchy
 -->
 <chummer>
-	<weapons>
-		<weapon>
-			<id>6aa0fdb2-c6dc-11ea-87d0-0242ac130003</id>
-			<name>Grenade: Painade</name>
-			<category>Gear</category>
-			<type>Ranged</type>
-			<conceal>0</conceal>
-			<accuracy>Physical</accuracy>
-			<reach>0</reach>
-			<damage>8S</damage>
-			<ap>-</ap>
-			<mode>0</mode>
-			<rc>0</rc>
-			<ammo>0</ammo>
-			<avail>10R</avail>
-			<cost>100</cost>
-			<source>CA</source>
-			<page>135</page>
-			<range>Standard Grenade</range>
-			<spec>Non-Aerodynamic</spec>
-			<useskill>Throwing Weapons</useskill>
-		</weapon>
-		<weapon>
-			<id>6414c5fa-c6dc-11ea-87d0-0242ac130003</id>
-			<name>Grenade: Painade, Aerodynamic</name>
-			<category>Gear</category>
-			<type>Ranged</type>
-			<conceal>0</conceal>
-			<accuracy>Physical</accuracy>
-			<reach>0</reach>
-			<damage>8S</damage>
-			<ap>-</ap>
-			<mode>0</mode>
-			<rc>0</rc>
-			<ammo>0</ammo>
-			<avail>10R</avail>
-			<cost>100</cost>
-			<source>CA</source>
-			<page>135</page>
-			<range>Aerodynamic Grenade</range>
-			<spec>Aerodynamic</spec>
-			<useskill>Throwing Weapons</useskill>
-		</weapon>
-		<weapon>
-			<id>8bf5c745-8aae-475d-b79e-29a8803ae7fc</id>
-			<name>Single-shot Dart</name>
-			<category>Micro-Drone Weapons</category>
-			<type>Ranged</type>
-			<conceal>0</conceal>
-			<accuracy>5</accuracy>
-			<reach>0</reach>
-			<damage>As Drug/Toxin</damage>
-			<ap>-</ap>
-			<mode>SS</mode>
-			<rc>5</rc>
-			<ammo>1(b)</ammo>
-			<avail>4R</avail>
-			<cost>400</cost>
-			<source>R5</source>
-			<page>124</page>
-			<accessorymounts>
-				<mount>Top</mount>
-				<mount>Stock</mount>
-				<mount>Side</mount>
-			</accessorymounts>
-			<range>Heavy Pistols</range>
-			<sizecategory>Heavy Pistols</sizecategory>
-		</weapon>
-		<weapon>
-			<id>68bde947-d5d3-4a63-908b-66f85ac2ee6d</id>
-			<name>Single-shot Bullet</name>
-			<category>Micro-Drone Weapons</category>
-			<type>Ranged</type>
-			<conceal>0</conceal>
-			<accuracy>4</accuracy>
-			<reach>0</reach>
-			<damage>6P</damage>
-			<ap>-</ap>
-			<mode>SS</mode>
-			<rc>5</rc>
-			<ammo>1(b)</ammo>
-			<avail>4R</avail>
-			<cost>325</cost>
-			<source>R5</source>
-			<page>124</page>
-			<accessorymounts>
-				<mount>Top</mount>
-				<mount>Stock</mount>
-				<mount>Side</mount>
-			</accessorymounts>
-			<range>Heavy Pistols</range>
-			<sizecategory>Heavy Pistols</sizecategory>
-		</weapon>
-		<weapon>
-			<id>e1b8c8c4-db31-41b5-bbdb-450926e35976</id>
-			<name>Medusa Bite</name>
-			<category>Blades</category>
-			<type>Melee</type>
-			<conceal>0</conceal>
-			<accuracy>5</accuracy>
-			<reach>0</reach>
-			<damage>Toxin</damage>
-			<ap>-</ap>
-			<mode>0</mode>
-			<rc>0</rc>
-			<ammo>0</ammo>
-			<avail>0</avail>
-			<cost>0</cost>
-			<source>CA</source>
-			<page>147</page>
-			<allowgear>
-				<gearcategory>Drugs</gearcategory>
-				<gearcategory>Toxins</gearcategory>
-			</allowgear>
-			<useskill>Atypical Melee</useskill>
-			<spec>Injection</spec>
-			<hide />
-		</weapon>
-	</weapons>
+    <weapons>
+        <weapon>
+            <id>6aa0fdb2-c6dc-11ea-87d0-0242ac130003</id>
+            <name>Grenade: Painade</name>
+            <category>Gear</category>
+            <type>Ranged</type>
+            <conceal>0</conceal>
+            <accuracy>Physical</accuracy>
+            <reach>0</reach>
+            <damage>8S</damage>
+            <ap>-</ap>
+            <mode>0</mode>
+            <rc>0</rc>
+            <ammo>0</ammo>
+            <avail>10R</avail>
+            <cost>100</cost>
+            <source>CA</source>
+            <page>135</page>
+            <range>Standard Grenade</range>
+            <spec>Non-Aerodynamic</spec>
+            <useskill>Throwing Weapons</useskill>
+        </weapon>
+        <weapon>
+            <id>6414c5fa-c6dc-11ea-87d0-0242ac130003</id>
+            <name>Grenade: Painade, Aerodynamic</name>
+            <category>Gear</category>
+            <type>Ranged</type>
+            <conceal>0</conceal>
+            <accuracy>Physical</accuracy>
+            <reach>0</reach>
+            <damage>8S</damage>
+            <ap>-</ap>
+            <mode>0</mode>
+            <rc>0</rc>
+            <ammo>0</ammo>
+            <avail>10R</avail>
+            <cost>100</cost>
+            <source>CA</source>
+            <page>135</page>
+            <range>Aerodynamic Grenade</range>
+            <spec>Aerodynamic</spec>
+            <useskill>Throwing Weapons</useskill>
+        </weapon>
+        <weapon>
+            <id>8bf5c745-8aae-475d-b79e-29a8803ae7fc</id>
+            <name>Single-shot Dart</name>
+            <category>Micro-Drone Weapons</category>
+            <type>Ranged</type>
+            <conceal>0</conceal>
+            <accuracy>5</accuracy>
+            <reach>0</reach>
+            <damage>As Drug/Toxin</damage>
+            <ap>-</ap>
+            <mode>SS</mode>
+            <rc>5</rc>
+            <ammo>1(b)</ammo>
+            <avail>4R</avail>
+            <cost>400</cost>
+            <source>R5</source>
+            <page>124</page>
+            <accessorymounts>
+                <mount>Top</mount>
+                <mount>Stock</mount>
+                <mount>Side</mount>
+            </accessorymounts>
+            <range>Heavy Pistols</range>
+            <sizecategory>Heavy Pistols</sizecategory>
+        </weapon>
+        <weapon>
+            <id>68bde947-d5d3-4a63-908b-66f85ac2ee6d</id>
+            <name>Single-shot Bullet</name>
+            <category>Micro-Drone Weapons</category>
+            <type>Ranged</type>
+            <conceal>0</conceal>
+            <accuracy>4</accuracy>
+            <reach>0</reach>
+            <damage>6P</damage>
+            <ap>-</ap>
+            <mode>SS</mode>
+            <rc>5</rc>
+            <ammo>1(b)</ammo>
+            <avail>4R</avail>
+            <cost>325</cost>
+            <source>R5</source>
+            <page>124</page>
+            <accessorymounts>
+                <mount>Top</mount>
+                <mount>Stock</mount>
+                <mount>Side</mount>
+            </accessorymounts>
+            <range>Heavy Pistols</range>
+            <sizecategory>Heavy Pistols</sizecategory>
+        </weapon>
+        <weapon>
+            <id>e1b8c8c4-db31-41b5-bbdb-450926e35976</id>
+            <name>Medusa Bite</name>
+            <category>Blades</category>
+            <type>Melee</type>
+            <conceal>0</conceal>
+            <accuracy>5</accuracy>
+            <reach>0</reach>
+            <damage>Toxin</damage>
+            <ap>-</ap>
+            <mode>0</mode>
+            <rc>0</rc>
+            <ammo>0</ammo>
+            <avail>0</avail>
+            <cost>0</cost>
+            <source>CA</source>
+            <page>147</page>
+            <allowgear>
+                <gearcategory>Drugs</gearcategory>
+                <gearcategory>Toxins</gearcategory>
+            </allowgear>
+            <useskill>Atypical Melee</useskill>
+            <spec>Injection</spec>
+            <hide />
+        </weapon>
+        <weapon>
+          <id>389d4f84-da6c-4175-81f2-058f36ca5c8f</id>
+          <name>Improvised Thrown Weapon (Missile Mastery)</name>
+          <category>Unarmed</category>
+          <type>Ranged</type>
+          <conceal>0</conceal>
+          <accuracy>3</accuracy>
+          <reach>0</reach>
+		  <damage>({STR})P</damage>
+          <ap>0</ap>
+          <mode>0</mode>
+          <rc>0</rc>
+          <ammo>0</ammo>
+          <avail>0</avail>
+          <cost>0</cost>
+          <source>SG</source>
+          <page>170</page>
+		  <range>Shuriken</range>
+          <allowaccessory>False</allowaccessory>
+          <hide />
+          <useskill>Throwing Weapons</useskill>
+        </weapon>
+    </weapons>
 </chummer>


### PR DESCRIPTION
List of changes:
- UMM is 8F as the book says. Shouldn't this be in the base data?
- Standard and heavy vehicle weapon mounts can now mount crossbows.
- Banned Stolen Souls vehicles are hidden.
- Core weapon mounts are hidden. R5 ones obsolete them.
- Cost-reducing lifestyle options are hidden.
- Missile Mastery adds a weapon to represent throwing arbitrary objects.
- Micro-Transceiver explicitly includes a subvocal mic.
- Drone weapon mounts no longer can take the vehicle ammo bin.