### PR TITLE
Fixed a error with MAG/RES karma cost and burning out in chargen

### DIFF
--- a/Chummer/Backend/Attributes/Attribute.Core.cs
+++ b/Chummer/Backend/Attributes/Attribute.Core.cs
@@ -1643,7 +1643,17 @@ namespace Chummer.Backend.Attributes
                 {
                     intUpgradeCost = (intValue + 1) * intOptionsCost;
                 }
-                if (_objCharacter.Settings.AlternateMetatypeAttributeKarma)
+
+                // This houserule does not work with how MAG / RES loss due to ESS loss in Chargen is handled
+                // As long as the true Metatype Min is always 1, this will work. That should be the case for RAW, but can be problematic in CustomData
+                // TODO: The handling of MAG / RES loss in chargen should be changed to use maybe use ImprovementType.AttributeLevel
+                var excludedAttributes = new HashSet<string>()
+                {
+                    "MAG",
+                    "RES",
+                    "MAGAdept"
+                };
+                if (_objCharacter.Settings.AlternateMetatypeAttributeKarma && !excludedAttributes.Contains(Abbrev))
                     intUpgradeCost -= (MetatypeMinimum - 1) * intOptionsCost;
 
                 decimal decExtra = 0;


### PR DESCRIPTION
It Fixes the following issue with the houserule Treat Metatype Min as 1 for Karma cost:

-Making a Human, prio [Meta C/ Attribute A/ Magic B(MysAd)/ Skills E/ Resources D]
-Using Exceptional Attribute (MAG)
-Spending 3 ESS on an Essence Hole (to test a burnout adept thing)
-Maxing out MAG at start with Priority Points, in this case MAG 4.
-After marking as created, buy Initiation(s)
-Costs to upgrade MAG start at 10 Karma, and go up by 5. -> Should be 25

This PR simply ignores the houserule for MAG/RES/MAGAdept.
This should work without any problems in RAW, but could lead to problems if someone uses a custom data that sets the MetaType Min of Mag to >1. Then the Karma cost will be too high, with the houserule.

A better solution would be to rework how MAG loss by ESS loss is handled in CharGen, maybe by using `ImprovementType.AttributeLevel` instead.


