### PR TITLE
German translation fix: Zugriff → Zuggriff

### DIFF
--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -1539,7 +1539,7 @@
 			<mod>
 				<id>aec187e5-5eca-4f27-9181-b39991579d76</id>
 				<name>Drag Handle</name>
-				<translate>Zugriff</translate>
+				<translate>Zuggriff</translate>
 				<altpage>25</altpage>
 			</mod>
 			<mod>


### PR DESCRIPTION
Fixes a typo in the German translation of “Drag Handle” from *Bullets & Bandages* (*Kugeln & Bandagen*):

![Zuggriff](https://user-images.githubusercontent.com/959587/194171665-b34ca977-cf2d-4c72-9cf2-6265dbd14eba.png)

Both “Zugriff” and “Zuggriff” are valid German words but they mean different things.