### PR TITLE
German translation fix: Adreinalin → Adrenalin

### DIFF
--- a/Chummer/lang/de-de_data.xml
+++ b/Chummer/lang/de-de_data.xml
@@ -29090,7 +29090,7 @@
 				<id>68399920-e3ff-4d17-a69a-0265c57422ab</id>
 				<name>Poor Self Control (Thrill Seeker)</name>
 				<source>RF</source>
-				<translate>Schlechte Selbstbeherrschung (Adreinalinjunkie)</translate>
+				<translate>Schlechte Selbstbeherrschung (Adrenalinjunkie)</translate>
 				<altpage>136</altpage>
 			</quality>
 			<quality>
@@ -32591,7 +32591,7 @@
 			<quality translated="True">
 				<id>bbb3bce6-8adc-4992-94b5-7248556a391a</id>
 				<name>Poor Self Control (Thrill Seeker) (Dareadrenaline)</name>
-				<translate>Schlechte Selbstbeherrschung (Adreinalinjunkie) (Daredrenalin)</translate>
+				<translate>Schlechte Selbstbeherrschung (Adrenalinjunkie) (Daredrenalin)</translate>
 				<altpage>161</altpage>
 			</quality>
 			<quality translated="True">


### PR DESCRIPTION
This pull request fixes a typo in the German translation. You can verify the correct spelling in *Schattenläufer* (*Run Faster*), p. 136:

![Adrenalinjunkie](https://user-images.githubusercontent.com/959587/196166202-978dd7df-484f-46f5-b6c8-868b62da948f.png)