### PR TITLE
Update gear.xml

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -49,7 +49,7 @@
     <category blackmarket="Electronics">Cyberdecks</category>
     <category blackmarket="Electronics">Cyberterminals</category>
     <category blackmarket="Electronics">Disguises</category>
-    <category blackmarket="Drugs">Drugs</category>
+    <category blackmarket="Drugs"> </category>
     <category blackmarket="Electronics">Electronics Accessories</category>
     <category blackmarket="Electronics">Electronic Modification</category>
     <category blackmarket="Electronics">Electronic Parts</category>
@@ -93,6 +93,7 @@
     <category blackmarket="Electronics">Matrix Accessories</category>
     <category blackmarket="Electronics">Booster Chips</category>
     <category blackmarket="Magic">Appearance Modification</category>
+    <category blackmarket="Drugs">Drug Grades</category>
   </categories>
   <gears>
     <!-- Region Ammo -->
@@ -12838,6 +12839,7 @@
       <id>62bffcd7-4a43-45cd-9cf7-3067ba9688f6</id>
       <name>Bliss</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>411</page>
@@ -12849,6 +12851,7 @@
       <id>8dc829b9-8b94-4510-ab1a-2305cbad69c9</id>
       <name>Cram</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>411</page>
@@ -12860,6 +12863,7 @@
       <id>5f5bc907-ce31-4f34-b7cf-a48d9d5d10b3</id>
       <name>Deepweed</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>411</page>
@@ -12871,6 +12875,7 @@
       <id>929c4835-1754-4999-9215-9859e8ec5384</id>
       <name>Jazz</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>411</page>
@@ -12882,6 +12887,7 @@
       <id>098bf489-bea9-4f17-b3d9-aead979fdc32</id>
       <name>Kamikaze</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>412</page>
@@ -12893,6 +12899,7 @@
       <id>d4cf626d-0af1-41f7-bec0-e53b4dba2eb1</id>
       <name>Long Haul</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>412</page>
@@ -12903,6 +12910,7 @@
       <id>d7ec13fa-8601-4f9c-a59c-6a86573b40ee</id>
       <name>Nitro</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>412</page>
@@ -12914,6 +12922,7 @@
       <id>836f54d5-1e11-49ea-b115-34c14ed843c9</id>
       <name>Novacoke</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>412</page>
@@ -12925,6 +12934,7 @@
       <id>778eefae-94ad-4f8c-ad03-8b9039b5c48e</id>
       <name>Psyche</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>412</page>
@@ -12935,6 +12945,7 @@
       <id>3a946800-be1e-4bbb-899a-c3d1c48a3a31</id>
       <name>Zen</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SR5</source>
       <page>412</page>
@@ -12946,6 +12957,7 @@
       <id>35309aeb-0cbc-4b64-a809-34de50812564</id>
       <name>Crash</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -12956,6 +12968,7 @@
       <id>c4ae816f-f683-469d-a7cd-ec1931740e1e</id>
       <name>Cryo</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -12967,6 +12980,7 @@
       <!-- ReSharper disable once MarkupTextTypo -->
       <name>HemoSynth</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -12977,6 +12991,7 @@
       <id>076825cd-dc6f-4e48-8c73-e958b21c1766</id>
       <name>NanoScan</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -12987,6 +13002,7 @@
       <id>cf2dd622-8312-4807-97f0-c5d30f9f67b4</id>
       <name>Neostigmine</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -12997,6 +13013,7 @@
       <id>1135e850-8371-4827-b2fe-94f5659583d4</id>
       <name>Ondansetron</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -13007,6 +13024,7 @@
       <id>b14cc8cf-8d19-4306-a71a-9a7f761eb321</id>
       <name>Sugammadex</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>BB</source>
       <page>19</page>
@@ -13017,6 +13035,7 @@
       <id>1e391e72-1c21-44b3-b935-7abfba2dca43</id>
       <name>Evo Aphrodite Reactive Biomatter</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>TVG</source>
       <page>19</page>
@@ -13028,6 +13047,7 @@
       <id>c113d0e8-8720-47fb-9ac6-fdc9e262c94b</id>
       <name>Accelerator</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>LCD</source>
       <page>205</page>
@@ -13039,6 +13059,7 @@
       <id>ee783a4e-331f-4e03-bf47-7ecb93341919</id>
       <name>Buffout</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>LCD</source>
       <page>204</page>
@@ -13050,6 +13071,7 @@
       <id>31f51b7e-d2eb-4274-aead-72710b198c13</id>
       <name>Numb</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>LCD</source>
       <page>204</page>
@@ -13060,6 +13082,7 @@
       <id>87186987-c004-439a-8958-d7b82198fb69</id>
       <name>Pinpoint</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>LCD</source>
       <page>204</page>
@@ -13071,6 +13094,7 @@
       <id>8cb8086b-3171-4a60-bee4-2996e29d5156</id>
       <name>Liquid Nutrients</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SS</source>
       <page>189</page>
@@ -13081,6 +13105,7 @@
       <id>8461fd87-ea93-4edb-92a1-4a20ad444471</id>
       <name>Normal Saline</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>SS</source>
       <page>189</page>
@@ -13101,6 +13126,7 @@
       <id>cf54b977-b2d9-4572-8e92-c3cc949f2c42</id>
       <name>AEXD</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>179</page>
@@ -13111,6 +13137,7 @@
       <id>53f656f4-bfa9-469e-a08d-ddf4fc71f824</id>
       <name>Aisa</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>179</page>
@@ -13121,6 +13148,7 @@
       <id>d32f1811-5ffb-4cd4-9873-ddcf207e95cb</id>
       <name>Animal Tongue</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>186</page>
@@ -13131,6 +13159,7 @@
       <id>009bd079-f7ee-4055-a86f-af03d6837cc8</id>
       <name>Ayao's Will</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>184</page>
@@ -13141,6 +13170,7 @@
       <id>f4eb63ce-c182-406c-b625-5699047e33a9</id>
       <name>Betameth</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13152,6 +13182,7 @@
       <id>67436993-439d-4e6b-b64a-3f506f44721a</id>
       <name>Betel</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13162,6 +13193,7 @@
       <id>440ae069-da45-4721-b45f-6441c931180f</id>
       <name>Cereprax</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13172,6 +13204,7 @@
       <id>68c65dca-e0e1-4291-8d1b-b23649027271</id>
       <name>Crimson Orchid</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>184</page>
@@ -13182,6 +13215,7 @@
       <id>c4f2a23f-8806-4333-92b3-81d6d09ff8b5</id>
       <name>Dopadrine</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13192,6 +13226,7 @@
       <id>27b4ed38-dc23-4225-ad8d-146bdfe2e598</id>
       <name>eX</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13202,6 +13237,7 @@
       <id>f7ed8b97-e26a-4296-b59d-e7c893696011</id>
       <name>Forget-Me-Not</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13212,6 +13248,7 @@
       <id>75e9b82f-eb1a-4db1-8cde-29d2cf0eaba6</id>
       <name>Galak</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>180</page>
@@ -13222,6 +13259,7 @@
       <id>9195ee9e-c5b1-4e8f-9b1a-786393a302dc</id>
       <name>G3</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>181</page>
@@ -13232,6 +13270,7 @@
       <id>0ed6e114-6a9f-4bd6-ba27-2b4f28b10305</id>
       <name>Guts</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>181</page>
@@ -13243,6 +13282,7 @@
       <id>df660e33-ce77-46e4-8c13-a92e3b5f37e8</id>
       <name>Hecate's Blessing</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>185</page>
@@ -13253,6 +13293,7 @@
       <id>a713f573-128b-4143-adc0-32f52e698587</id>
       <name>Hurlg</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>181</page>
@@ -13263,6 +13304,7 @@
       <id>d70434e3-183c-4243-8213-b9f9166387ea</id>
       <name>Immortal Flower</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>186</page>
@@ -13273,6 +13315,7 @@
       <id>3659055c-db84-4f75-bfa9-afe5d0f39803</id>
       <name>K-10</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>181</page>
@@ -13283,6 +13326,7 @@
       <id>f818d571-c817-49b2-86b6-ad9fb94ead54</id>
       <name>Laés</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>185</page>
@@ -13293,6 +13337,7 @@
       <id>1c672c5d-88f7-43dd-b4d0-42571eb07547</id>
       <name>Leäl</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>185</page>
@@ -13303,6 +13348,7 @@
       <id>58319c25-b724-4db4-b492-1068ca44cb73</id>
       <name>Little Smoke</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13314,6 +13360,7 @@
       <id>65122a92-ae48-4e94-8c68-69c1bdc7d46a</id>
       <name>Memory Fog</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>181</page>
@@ -13324,6 +13371,7 @@
       <id>a2b0310b-5a8f-4b01-b478-967d345ce22c</id>
       <name>Nightwatch</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>182</page>
@@ -13334,6 +13382,7 @@
       <id>6e219091-8e3c-4a65-bb1d-78a351d8bf54</id>
       <name>NoPaint</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>182</page>
@@ -13344,6 +13393,7 @@
       <id>11c547f4-37d1-4d6a-8760-1d11ef48c7f7</id>
       <name>Oneiro</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>186</page>
@@ -13355,6 +13405,7 @@
       <id>aa22ff52-1615-48cb-9e55-e63539ede39a</id>
       <name>Overdrive</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>186</page>
@@ -13366,6 +13417,7 @@
       <id>7fdde8cd-95f8-4316-9ca4-2ad06f77cb15</id>
       <name>Oxygenated Fluorocarbons</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>182</page>
@@ -13376,6 +13428,7 @@
       <id>c3965bac-b2b0-47b1-96d8-0a1a7cb4e1b6</id>
       <name>Pixie Dust</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>186</page>
@@ -13387,6 +13440,7 @@
       <id>9c3ae30d-dd3e-49da-a30b-acbe06b444ac</id>
       <name>Push</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>182</page>
@@ -13396,7 +13450,7 @@
     <gear>
       <id>1131acde-3791-4870-8c05-1b261e3beaa1</id>
       <name>PsychChips (Illegal)</name>
-      <category>Drugs</category>
+      <category>BTLs</category>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13406,7 +13460,7 @@
     <gear>
       <id>48c252e2-8bfd-46e4-ae77-b394b9e92773</id>
       <name>PsychChips (Legal)</name>
-      <category>Drugs</category>
+      <category>BTLs</category>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13417,6 +13471,7 @@
       <id>5fe2bf62-471e-4000-8ab8-641623983302</id>
       <name>Red Mescaline</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>182</page>
@@ -13427,6 +13482,7 @@
       <id>60cfe7ff-c634-405f-9894-7baee61e4445</id>
       <name>Ripper</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>182</page>
@@ -13437,6 +13493,7 @@
       <id>68ac6703-8540-4efe-b9d9-51f9db14d6b7</id>
       <name>Rock Lizard Blood</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13447,6 +13504,7 @@
       <id>127e4e88-6966-44ad-a95b-eeaaa9a7472e</id>
       <name>Shade</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13458,6 +13516,7 @@
       <id>62d633d1-0e3a-4ea6-a4ba-f88ccdf72cf9</id>
       <name>Slab</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>183</page>
@@ -13468,6 +13527,7 @@
       <id>447827BE-96A4-471F-929F-CB4BFF4CCBB4</id>
       <name>Reaper</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>183</page>
@@ -13478,6 +13538,7 @@
       <id>cd2dd310-464f-4f12-ae42-cdc293e3a2df</id>
       <name>Snuff</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>183</page>
@@ -13489,6 +13550,7 @@
       <id>6c030daa-7dc0-4d7e-86a8-d36f4b15e13f</id>
       <name>Sober Time</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>183</page>
@@ -13499,6 +13561,7 @@
       <id>8a40ed45-a19c-47a6-8449-f3235492e809</id>
       <name>Soothsayer</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>184</page>
@@ -13509,6 +13572,7 @@
       <id>7e8a18bd-f80f-432e-b985-823fc6be0d5a</id>
       <name>Trance</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>186</page>
@@ -13520,6 +13584,7 @@
       <id>8a01190e-f484-4fc6-981e-3e954ce17107</id>
       <name>Woad</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>184</page>
@@ -13530,6 +13595,7 @@
       <id>ca121b86-d4d1-411d-a524-389e6bd2091b</id>
       <name>Wudu'aku</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13541,6 +13607,7 @@
       <id>2d35de28-3b3d-4009-8ced-de5fd3869069</id>
       <name>Zero</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>184</page>
@@ -13551,6 +13618,7 @@
       <id>dace6412-6d90-4b98-b00c-86483b278e01</id>
       <name>Zombie Dust</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>CF</source>
       <page>187</page>
@@ -13561,6 +13629,7 @@
       <id>329f3767-f1ca-49ef-971a-6509ad3e8c41</id>
       <name>Shiva (Vintage)</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <avail>12F</avail>
       <cost>200</cost>
@@ -13571,6 +13640,7 @@
       <id>c5c06863-d382-41b7-93de-bd10659515ca</id>
       <name>Shiva II</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <avail>6R</avail>
       <cost>150</cost>
@@ -13768,6 +13838,45 @@
       <page>193</page>
       <avail>8F</avail>
       <cost>200</cost>
+    </gear>
+    
+   
+      <!-- Adds the drug grades as a plugin for drugs. -->
+    <gear>
+      <id>f22e79fa-fb04-4369-a761-a1a46e242bc8</id>
+      <name>Street Cooked</name>
+      <category>Drug Grades</category>
+      <rating>0</rating>
+      <source>CF</source>
+      <page>190</page>
+      <avail>0</avail>
+      <capacity>0</capacity>
+      <requireparent />
+      <cost>Parent Cost * -.5</cost>
+    </gear>    
+    <gear>
+      <id>21f33089-cb7a-4bef-80ae-03d04f1c47ad</id>
+      <name>Pharmaceutical</name>
+      <category>Drug Grades</category>
+      <rating>0</rating>
+      <source>CF</source>
+      <page>190</page>
+      <avail>0</avail>
+      <capacity>0</capacity>
+      <requireparent />
+      <cost>Parent Cost</cost>
+    </gear>    
+    <gear>
+      <id>d8cdb6ea-5150-4ec0-8166-88d33e714364</id>
+      <name>Designer</name>
+      <category>Drug Grades</category>
+      <rating>0</rating>
+      <source>CF</source>
+      <page>190</page>
+      <avail>0</avail>
+      <capacity>0</capacity>
+      <requireparent />
+      <cost>Parent Cost * 5</cost>
     </gear>
     <!-- End Region -->
     <!-- Region Armor Enhancements -->
@@ -19859,6 +19968,7 @@
       <id>94975837-a10e-41c7-acdd-cb2bda48f372</id>
       <name>Kamikaze (2050)</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>2050</source>
       <page>197</page>
@@ -20192,6 +20302,7 @@
       <id>466b1d86-e088-4973-b914-a405ba0829f7</id>
       <name>NanoScrub</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>DTR</source>
       <page>83</page>
@@ -20202,6 +20313,7 @@
       <id>a9b847fd-d3ec-46e1-a7b0-e339b4221453</id>
       <name>Overwriter Nanites</name>
       <category>Drugs</category>
+      <addoncategory>Drug Grades</addoncategory>
       <rating>0</rating>
       <source>DTR</source>
       <page>83</page>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -13853,6 +13853,13 @@
       <capacity>0</capacity>
       <requireparent />
       <cost>Parent Cost * -.5</cost>
+      <required>
+        <geardetails>
+          <OR>
+            <category>Drugs</category>
+          </OR>
+        </geardetails>
+      </required>
     </gear>    
     <gear>
       <id>21f33089-cb7a-4bef-80ae-03d04f1c47ad</id>
@@ -13865,6 +13872,13 @@
       <capacity>0</capacity>
       <requireparent />
       <cost>Parent Cost</cost>
+      <required>
+        <geardetails>
+          <OR>
+            <category>Drugs</category>
+          </OR>
+        </geardetails>
+      </required>
     </gear>    
     <gear>
       <id>d8cdb6ea-5150-4ec0-8166-88d33e714364</id>
@@ -13877,6 +13891,13 @@
       <capacity>0</capacity>
       <requireparent />
       <cost>Parent Cost * 5</cost>
+      <required>
+        <geardetails>
+          <OR>
+            <category>Drugs</category>
+          </OR>
+        </geardetails>
+      </required>
     </gear>
     <!-- End Region -->
     <!-- Region Armor Enhancements -->

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -49,7 +49,7 @@
     <category blackmarket="Electronics">Cyberdecks</category>
     <category blackmarket="Electronics">Cyberterminals</category>
     <category blackmarket="Electronics">Disguises</category>
-    <category blackmarket="Drugs"> </category>
+    <category blackmarket="Drugs">Drugs</category>
     <category blackmarket="Electronics">Electronics Accessories</category>
     <category blackmarket="Electronics">Electronic Modification</category>
     <category blackmarket="Electronics">Electronic Parts</category>


### PR DESCRIPTION
Adds Street Cooked, Pharmaceutical, and Designer drug grades as plugins to Drugs.

Adds <addoncategory>Drug Grades</addoncategory> to all Drugs to restrict the plugin menu to only show the Drug Grades as a plugin so that menu is reasonably user friendly.

Also sets Psychchips (Legal) and Psychchips (Illegal) to be categorized as BTLs instead of Drugs. No idea why they were set to Drugs.


~~Todo in the future: Figure out a way to make Pharma/Designer/Street Cooked ONLY show up in Drugs, so people can't make, like, a Street Cooked Ambulance Gurney. I'll get right on that when I can be bothered to get right on that. So, possibly some time next year.~~