### PR TITLE
Disable Street Grimoires Commanding Voice Errata

### DIFF
--- a/Chummer/customdata/Disable Street Grimoires Commanding Voice Errata/amend_powers.xml
+++ b/Chummer/customdata/Disable Street Grimoires Commanding Voice Errata/amend_powers.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+<chummer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema powers.xsd">
+  
+  <powers>
+      <power>
+      <name>Authoritative Tone</name>
+     <hide />
+    </power>
+  </powers>
+
+  <powers amendoperation="append">
+	  <power>
+  	  <id>d405a00b-a211-487a-b368-d2bf391b720a</id>
+	    <name>Commanding Voice</name>
+	    <points>0.25</points>
+  	  <levels>True</levels>
+	    <limit>1</limit>
+	    <source>SG</source>
+      <page>170</page>
+      <maxlevels>3</maxlevels>
+  	</power>
+  </powers>
+</chummer>

--- a/Chummer/customdata/Disable Street Grimoires Commanding Voice Errata/manifest.xml
+++ b/Chummer/customdata/Disable Street Grimoires Commanding Voice Errata/manifest.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--This file is part of Chummer5a.
+
+    Chummer5a is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Chummer5a is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Chummer5a.  If not, see <http://www.gnu.org/licenses/>.
+
+    You can obtain the full source code for Chummer5a at
+    https://github.com/chummer5a/chummer5a
+-->
+  <manifest xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema ../manifest.xsd">
+    <guid>3C9636B8-F5F6-49D4-AE8F-12F8F8371334</guid>
+    <version>1</version>
+    <authors>
+      <author>
+        <name>Teksura</name>
+        <main>true</main>
+      </author>
+    </authors>
+    <descriptions>
+      <description>
+        <text>This ruleset cdisables the Street Grimoire errata for Commanding Voice. Specifically, it removes Authorative Tone and replaces it with Commanding Voice as given in the original printing of Street Grimoire.</text>
+        <lang>en-us</lang>
+      </description>
+    </descriptions>
+  </manifest>


### PR DESCRIPTION
Resolves issue #4839 

What this does is add an amends file which will hide Authoritative Tone, and re-adds Commanding Voice as written in Street Grimoire. 

This bypasses the missing functionality [DelnarErsike](https://github.com/DelnarErsike) mentioned. While not exactly an ideal fix, it *is* a fix I know how to do, and can be safely removed if anyone decides to push a better fix. :)