### PR TITLE
Update gear.xml

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -20756,7 +20756,7 @@
       <page>170</page>
       <avail>+4</avail>
       <requireparent />
-      <cost>(Parent Cost * 2)</cost>
+      <cost>(Parent Cost)</cost>
     </gear>
     <gear>
       <id>357d77f6-0e9e-4e5f-87f2-9c4b5422d23c</id>


### PR DESCRIPTION
Following this [discussion in discord](https://discord.com/channels/365227581018079232/365227867535310858/1054196813256740918).

This changes the cost of the Internal Synth from No Future to a cost equal to the parent cost, effectively doubling the cost of the instrument, rather than the internal synthlink itself costing double that of the base instrument. 

The basis for this is consistency with the internal Smartgun system's cost. The table for the internal smartgun also lists the cost as {Cost of weapon} x2. From that alone one might think that the internal smartgun system therefore costs twice as much as the weapon cost. However, the text below explains that what this actually means is it "doubles the cost of the weapon"

![Screen Shot 2022-12-18 at 7 41 42 PM](https://user-images.githubusercontent.com/1766631/208344812-7812761e-bd0d-42a5-97ed-fc0b17db6fee.png)
![Screen Shot 2022-12-18 at 7 47 06 PM](https://user-images.githubusercontent.com/1766631/208344825-7d173cd9-5560-468f-ba3d-245f03ffedfc.png)
![Screen Shot 2022-12-18 at 7 58 31 PM](https://user-images.githubusercontent.com/1766631/208344867-ebb04e3a-3fde-4330-b055-c2e30c8c8b7c.png)


Overall, this is some CGL fuckery in the way they present information on the tables and it's not fully clear what is intended.  