### PR TITLE
Giving Quick Healer a +2 bonus to First Aid and Medicine

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -521,6 +521,14 @@
           <val>2</val>
         </spelldicepool>
         <stuncmrecovery>2</stuncmrecovery>
+        <specificskill>
+          <name>First Aid</name>
+          <bonus>2</bonus>
+        </specificskill>
+        <specificskill>
+          <name>Medicine</name>
+          <bonus>2</bonus>
+        </specificskill>
       </bonus>
       <forbidden>
         <oneof>


### PR DESCRIPTION
Quick Healer's text reads:

> A character with the Quick Healer quality receives a +2 dice pool modifier to all Healing Tests made on/for/by her, including magical healing.

As it provides a bonus to tests made by the character, this would apply to First Aid and Medicine tests. I am unaware of any RAW tests involving the First Aid or Medicine skill which are not Healing tests.