### PR TITLE
Added workarounds for missing methods in WINE for system dialog box

### DIFF
--- a/Chummer/Backend/Static/NativeMethods.cs
+++ b/Chummer/Backend/Static/NativeMethods.cs
@@ -786,7 +786,7 @@ namespace Chummer
             /// <summary>High definition DVD media in the HD DVD format.</summary>
             SIID_MEDIAHDDVD = 89,
 
-            /// <summary>High definition DVD media in the Blu-ray Discâ„¢ format.</summary>
+            /// <summary>High definition DVD media in the Blu-ray Disc™ format.</summary>
             SIID_MEDIABLURAY = 90,
 
             /// <summary>Video CD (VCD) media.</summary>


### PR DESCRIPTION
Just catching some exceptions that come up due to methods being stubbed in WINE and using some passable defaults.

Drawbacks:
* System Strings like 'ok' 'cancel' 'try again' won't localize.
* Icons that are not implemented in WINE will default to a standard alert icon.

Example of this fix running on wine 8.2 on arch linux under KDE:

![Screenshot](https://i.imgur.com/csZOXzc.png)

Fixes #4995