### PR TITLE
Add some tweaks to the printed character sheet

### DIFF
--- a/Chummer/sheets/Shadowrun 5 set.xslt
+++ b/Chummer/sheets/Shadowrun 5 set.xslt
@@ -622,17 +622,31 @@
                 <td style="text-align: center;">
                   <xsl:if test="qualities/quality">
                     <div class="block" id="QualitiesBlock">
-                    <table class="tablestyle">
-                      <tr>
-                        <th width="80%" style="text-align: left">
-                          <xsl:value-of select="$lang.Quality" />
-                        </th>
-                        <th width="10%" />
-                        <th width="10%" />
-                      </tr>
-                      <xsl:call-template name="Qualities" />
-                    </table>
-                  </div>
+                      <table class="tablestyle">
+                        <tr>
+                          <th width="80%" style="text-align: left">
+                            <xsl:value-of select="$lang.Qualities" />: 
+                            <xsl:value-of select="$lang.Positive" />
+                          </th>
+                          <th width="10%" />
+                          <th width="10%" />
+                        </tr>
+                        <xsl:call-template name="Qualities">
+                          <xsl:with-param name="quality_type" select="'Positive'" />
+                        </xsl:call-template>
+                        <tr>
+                          <th width="80%" style="text-align: left">
+                            <xsl:value-of select="$lang.Qualities" />: 
+                            <xsl:value-of select="$lang.Negative" />
+                          </th>
+                          <th width="10%" />
+                          <th width="10%" />
+                        </tr>
+                        <xsl:call-template name="Qualities">
+                          <xsl:with-param name="quality_type" select="'Negative'" />
+                        </xsl:call-template>
+                      </table>
+                    </div>
                     <xsl:call-template name="RowSummary">
                       <xsl:with-param name="text" select="$lang.Qualities" />
                       <xsl:with-param name="blockname" select="'QualitiesBlock'" />
@@ -2924,12 +2938,15 @@
   </xsl:template>
 
   <xsl:template name="gear1">
-    <xsl:variable name="halfcut" select="number(round(count(gears/gear) div 3))" />
+    <xsl:variable name="halfcut" select="number(round((count(gears/gear) + count(gears/gear/children) + count(gears/gear/notes)) div 3))" />
     <xsl:variable name="sortedcopy">
       <xsl:for-each select="gears/gear">
         <xsl:sort select="location" />
         <xsl:sort select="name" />
-        <xsl:if test="position() &lt;= $halfcut">
+        <xsl:variable name="endpoint" select="number(position())"/>
+        <xsl:variable name="subgears" select="../gear[position() &lt; $endpoint]"/>
+        <xsl:variable name="countrows" select="number(count($subgears) + count($subgears/children) + count($subgears/notes))"/>
+        <xsl:if test="$countrows &lt;= $halfcut">
           <xsl:copy-of select="current()" />
         </xsl:if>
       </xsl:for-each>
@@ -2940,12 +2957,15 @@
   </xsl:template>
 
   <xsl:template name="gear2">
-    <xsl:variable name="halfcut" select="number(round(count(gears/gear) div 3))" />
+    <xsl:variable name="halfcut" select="number(round((count(gears/gear) + count(gears/gear/children) + count(gears/gear/notes)) div 3))" />
     <xsl:variable name="sortedcopy">
       <xsl:for-each select="gears/gear">
         <xsl:sort select="location" />
         <xsl:sort select="name" />
-        <xsl:if test="position() &gt; $halfcut and position() &lt;= $halfcut * 2">
+        <xsl:variable name="endpoint" select="number(position())"/>
+        <xsl:variable name="subgears" select="../gear[position() &lt; $endpoint]"/>
+        <xsl:variable name="countrows" select="number(count($subgears) + count($subgears/children) + count($subgears/notes))"/>
+        <xsl:if test="$countrows &gt; $halfcut and $countrows &lt;= $halfcut * 2">
           <xsl:copy-of select="current()" />
         </xsl:if>
       </xsl:for-each>
@@ -2956,12 +2976,15 @@
   </xsl:template>
 
   <xsl:template name="gear3">
-    <xsl:variable name="halfcut" select="number(round(count(gears/gear) div 3))" />
+    <xsl:variable name="halfcut" select="number(round((count(gears/gear) + count(gears/gear/children) + count(gears/gear/notes)) div 3))" />
     <xsl:variable name="sortedcopy">
       <xsl:for-each select="gears/gear">
         <xsl:sort select="location" />
         <xsl:sort select="name" />
-        <xsl:if test="position() &gt; $halfcut * 2">
+        <xsl:variable name="endpoint" select="number(position())"/>
+        <xsl:variable name="subgears" select="../gear[position() &lt; $endpoint]"/>
+        <xsl:variable name="countrows" select="number(count($subgears) + count($subgears/children) + count($subgears/notes))"/>
+        <xsl:if test="$countrows &gt; $halfcut * 2">
           <xsl:copy-of select="current()" />
         </xsl:if>
       </xsl:for-each>
@@ -3017,6 +3040,17 @@
           <xsl:value-of select="page" />
         </td>
       </tr>
+
+      <xsl:if test="notes != ''">
+        <tr>
+          <xsl:if test="position() mod 2 != 1">
+            <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
+          </xsl:if>
+          <td colspan="100%" class="indent">
+            <xsl:value-of select="notes" />
+          </td>
+        </tr>
+      </xsl:if>
 
       <xsl:if test="iscommlink != 'True' and children/gear">
         <tr>

--- a/Chummer/sheets/xt.Qualities.xslt
+++ b/Chummer/sheets/xt.Qualities.xslt
@@ -4,15 +4,23 @@
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
         xmlns:msxsl="urn:schemas-microsoft-com:xslt">
   <xsl:template name="Qualities">
+    <xsl:param name="quality_type" />
 
-    <xsl:for-each select="qualities/quality">
+    <xsl:for-each select="qualities/quality[qualitytype_english=$quality_type]">
+      <xsl:sort select="qualitysource='Metatype'" order='descending' />
+      <xsl:sort select="substring-after(notes, 'Prefix: ')"/>
+      <xsl:sort select="(source = 'RF') and (page &gt; 110) and (page &lt; 124)"/>
       <xsl:sort select="name" />
+      <xsl:variable select="substring-after(notes, 'Prefix: ')" name="prefix" />
+      <xsl:variable select="substring-before(notes, 'Prefix: ')" name="notesbody" />
       <tr style="text-align: left" valign="top">
         <xsl:if test="position() mod 2 != 1">
           <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
         </xsl:if>
         <td>
+          <xsl:if test="$prefix != ''"><xsl:value-of select="$prefix"/> - </xsl:if>
           <xsl:value-of select="name" />
+          <xsl:if test="(source = 'RF') and (page &gt; 110) and (page &lt; 124)" > (metagenic)</xsl:if>
           <xsl:if test="extra != ''">: <xsl:value-of select="extra" /></xsl:if>
         </td>
         <td />
@@ -22,21 +30,21 @@
           <xsl:value-of select="page" />
         </td>
       </tr>
-      <xsl:if test="notes != '' and $ProduceNotes">
+      <xsl:if test="$notesbody != '' and $ProduceNotes">
         <tr>
           <xsl:if test="position() mod 2 != 1">
             <xsl:attribute name="bgcolor">#e4e4e4</xsl:attribute>
           </xsl:if>
           <td colspan="100" style="padding: 0 2%; text-align: justify;">
             <xsl:call-template name="PreserveLineBreaks">
-              <xsl:with-param name="text" select="notes" />
+              <xsl:with-param name="text" select="$notesbody" />
             </xsl:call-template>
           </td>
         </tr>
       </xsl:if>
       <xsl:call-template name="Xline">
         <xsl:with-param name="cntl" select="last()-position()" />
-        <xsl:with-param name="nte" select="notes != '' and $ProduceNotes" />
+        <xsl:with-param name="nte" select="$notesbody != '' and $ProduceNotes" />
       </xsl:call-template>
     </xsl:for-each>
   </xsl:template>


### PR DESCRIPTION
* Divide qualities into Positive and Negative sections
* Group Metagenic qualities together and label them accordingly (since this information isn't exposed, it instead checks whether the quality is from RF pages 110-124)
* Users can add a a `Prefix:` line at the end of each quality's Notes to add a prefix which will additionally sort by (e.g. so Magical qualities can be grouped separately from skill-related qualities)
* Include gear notes
* For gear column balancing purposes, include notes and children in line count - it's impossible to perfectly balance them since we have no way of detecting when a line wraps, but we can use this as a slightly better approximation