### PR TITLE
E'lyzée Elio Translation Fix

### DIFF
--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -2985,7 +2985,7 @@
     </armor>
     <armor>
       <id>7418141b-ec31-4334-a642-6acf469c0e5f</id>
-      <name>E'lyzée Elio: Bra's Cloak</name>
+      <name>E'lyzée Elio: Bra's Cape</name>
       <category>High-Fashion Armor Clothing</category>
       <armor>10</armor>
       <armoroverride>+2</armoroverride>
@@ -3000,7 +3000,7 @@
     </armor>
     <armor>
       <id>7cc0ee32-7f67-495c-91d1-2ab9e19ec54b</id>
-      <name>E'lyzée Elio: Tha'il Cloak</name>
+      <name>E'lyzée Elio: Tha'il Cape</name>
       <category>High-Fashion Armor Clothing</category>
       <armor>8</armor>
       <armoroverride>+2</armoroverride>


### PR DESCRIPTION
Fixing a translation error. Based on the context of the german source and the fluff description provided, I have been informed that these are in fact capes, not cloaks. A Distinction that most likely nobody except me cares about.