### PR TITLE
Fixing spelling of Homburg

### DIFF
--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -3377,7 +3377,7 @@
     </armor>
     <armor>
       <id>b91be09d-b428-495c-a334-31b316a4ef79</id>
-      <name>Hornburg</name>
+      <name>Homburg</name>
       <category>Clothing</category>
       <armor>0</armor>
       <armorcapacity>0</armorcapacity>


### PR DESCRIPTION
Homburg is a hat.
Hornburg is a great stronghold of Rohan at the mouth of Helm's Deep.