### PR TITLE
Allows ghouls to access their DTR Infected Optional Powers

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -10610,6 +10610,12 @@
           <quality>Infected: Fomoraig</quality>
           <quality>Infected: Gnawer</quality>
           <quality>Infected: Mutaqua</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
         </oneof>
       </required>
       <source>RF</source>
@@ -10838,6 +10844,12 @@
           <quality>Infected: Sukuyan (Human)</quality>
           <quality>Infected: Sukuyan (Non-Human)</quality>
           <quality>Infected: Wendigo</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
         </oneof>
       </required>
       <source>RF</source>
@@ -10866,6 +10878,12 @@
           <quality>Infected: Sukuyan (Human)</quality>
           <quality>Infected: Sukuyan (Non-Human)</quality>
           <quality>Infected: Wendigo</quality>
+          <quality>Infected: Ghoul (Dwarf)</quality>
+          <quality>Infected: Ghoul (Elf)</quality>
+          <quality>Infected: Ghoul (Human)</quality>
+          <quality>Infected: Ghoul (Ork)</quality>
+          <quality>Infected: Ghoul (Sasquatch)</quality>
+          <quality>Infected: Ghoul (Troll)</quality>
         </oneof>
       </required>
       <source>RF</source>


### PR DESCRIPTION
This would give all Ghoul variants (which is to say ghoul [human], ghoul [elf], etc.) the ability to take the optional powers Armor, Immunity (Pathogens), and Immunity (Toxins), as per Dark Terrors p.156's updated power list. 