### PR TITLE
SG Health Spell Keyword Fix

### DIFF
--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -1989,7 +1989,7 @@
       <source>SG</source>
       <category>Health</category>
       <damage>0</damage>
-      <descriptor>Negative</descriptor>
+      <descriptor>Essence</descriptor>
       <duration>P</duration>
       <dv>F-2</dv>
       <range>T</range>
@@ -2002,7 +2002,7 @@
       <source>SG</source>
       <category>Health</category>
       <damage>0</damage>
-      <descriptor>Negative</descriptor>
+      <descriptor>Essence</descriptor>
       <duration>S</duration>
       <dv>F-3</dv>
       <range>T</range>
@@ -2054,7 +2054,7 @@
       <source>SG</source>
       <category>Health</category>
       <damage>0</damage>
-      <descriptor>Negative</descriptor>
+      <descriptor>Essence</descriptor>
       <duration>S</duration>
       <dv>F-1</dv>
       <range>T</range>


### PR DESCRIPTION
Fixes Keywords of 3 SG Spells. They were originally created with the Negative keyword, but at some point there was some stealth errata which changed that to the Essence keyword.


![Screenshot 2023-06-21 at 4 13 20 PM](https://github.com/chummer5a/chummer5a/assets/1766631/0059b454-5fea-41ec-8146-df4d32d06a5a)
![Screenshot 2023-06-21 at 4 13 26 PM](https://github.com/chummer5a/chummer5a/assets/1766631/76ff551f-dac5-4086-bb04-2c24c40f8a20)
