### PR TITLE
[WIP] Add priority array to sheets

### DIFF
--- a/Chummer/sheets/Fancy Blocks set.xslt
+++ b/Chummer/sheets/Fancy Blocks set.xslt
@@ -637,7 +637,7 @@
           <img src="data:image/jpeg;base64,{mainmugshotbase64}" class="mugshot" />
         </td></tr>
       </xsl:if>
-      <xsl:if test="prioritymetatype != ''">
+      <xsl:if test="buildmethod = 'Priority'">
         <tr><td colspan="2"><div class="bigheader">[<xsl:value-of select="$lang.Priorities" />]</div></td></tr>
                         <tr><td><xsl:value-of select="$lang.Metatype" /></td><td><strong><xsl:value-of select="prioritymetatype" /></strong></td></tr>
                         <tr><td><xsl:value-of select="$lang.Attributes" /></td><td><strong><xsl:value-of select="priorityattributes" /></strong></td></tr>

--- a/Chummer/sheets/Formatted Text-Only set.xslt
+++ b/Chummer/sheets/Formatted Text-Only set.xslt
@@ -161,7 +161,7 @@
           <xsl:with-param name="length" select="40" />
         </xsl:call-template>
 
-                <xsl:if test="prioritymetatype != ''">
+                <xsl:if test="buildmethod = 'Priority'">
                     <br />
                     <br />== <xsl:value-of select="$lang.Priorities" /> ==
           <br /><xsl:value-of select="$lang.Metatype" />: <xsl:value-of select="prioritymetatype" />

--- a/Chummer/sheets/Shadowrun 5 set.xslt
+++ b/Chummer/sheets/Shadowrun 5 set.xslt
@@ -111,7 +111,17 @@
                 <td width="16.67%" class="title">
                   <xsl:value-of select="$lang.Name" />:
                 </td>
-                <td colspan="5">
+                <td>
+                <xsl:attribute name="colspan">
+		            <xsl:choose>
+			            <xsl:when test="buildmethod = 'Priority'">
+				            <xsl:value-of select="'3'" />
+			            </xsl:when>
+			            <xsl:otherwise>
+				            <xsl:value-of select="'5'" />
+			            </xsl:otherwise>
+		            </xsl:choose>
+	            </xsl:attribute>
                   <xsl:choose>
                     <xsl:when test="alias = '' or name = '' or name = $lang.UnnamedCharacter">
                       <xsl:value-of select="$TitleName" />
@@ -125,6 +135,14 @@
                     </xsl:otherwise>
                   </xsl:choose>
                 </td>
+                <xsl:if test="buildmethod = 'Priority'">
+                  <td class="upper">
+                      <xsl:value-of select="$lang.Priorities" />:
+                  </td>
+                  <td>
+                      <xsl:value-of select="prioritymetatype" /><xsl:value-of select="priorityattributes" /><xsl:value-of select="priorityspecial" /><xsl:value-of select="priorityskills" /><xsl:value-of select="priorityresources" />
+                  </td>
+              </xsl:if>
               </tr>
               <xsl:if test="playername != ''">
               <tr>

--- a/Chummer/sheets/Text-Only set.xslt
+++ b/Chummer/sheets/Text-Only set.xslt
@@ -75,7 +75,7 @@
             <xsl:value-of select="nuyen" />
             <xsl:value-of select="$lang.NuyenSymbol" />
 
-          <xsl:if test="prioritymetatype != ''">
+          <xsl:if test="buildmethod = 'Priority'">
             <br />
             <br />== <xsl:value-of select="$lang.Priorities" /> ==
             <br /><xsl:value-of select="$lang.Metatype" />: <xsl:value-of select="prioritymetatype" />


### PR DESCRIPTION
Added priority section to Shadowrun 5 character sheets and updated logic to hide/show priority section based on buildmethod
- [x] changed logic to only show priorities when build method is Priority
- [x] placed in existing unused whitespace 
- [ ] Make priorities fancy - give it its own collapsible section and show priority types next to the letter choice
- [ ] add to changelog