### PR TITLE
Moved Holster from mods to gears in Ares Arms Bug Stomper Armor

### DIFF
--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -3236,8 +3236,10 @@
       <mods>
         <name>Custom Fit</name>
         <name>Gear Access</name>
-        <name>Holster</name>
       </mods>
+      <gears>
+        <usegear>Holster</usegear>
+      </gears>
       <source>SL</source>
       <page>130</page>
     </armor>


### PR DESCRIPTION
Holsters are actually gears not mods.