### PR TITLE
Restrict codeql.yml action to changes in relevant file types

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,9 +14,26 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master" ]
+    # Only run on the following paths / file type changes
+    paths:
+        - "**.sln"
+        - "**.csproj"
+        - "**.cs"
+        - "**.cshtml"
+        - "**.xaml"
+        - "**.yml" # Include this to have the action rerun on yml changes
+
   pull_request:
     # The branches below must be a subset of the branches above
     branches: [ "master" ]
+    # Only run on the following paths / file type changes
+    paths:
+        - "**.sln"
+        - "**.csproj"
+        - "**.cs"
+        - "**.cshtml"
+        - "**.xaml"
+        - "**.yml" # Include this to have the action rerun on yml changes
   schedule:
     - cron: '20 15 * * 1'
 


### PR DESCRIPTION
Actions can be restricted to run only when a change in a given path occours see https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths

According to CodeQL Docs it supports sln, csproj. cs, cshtml and xaml files for C# https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/

Thus we probably don't have to run the whole action on changes that don't include such a file, like pure .xml changes.

yml should be included, to be reactive to changes in the action itself.