### PR TITLE
Remove precedence from Suprathyroid Reaction improvement

### DIFF
--- a/Chummer/data/bioware.xml
+++ b/Chummer/data/bioware.xml
@@ -461,7 +461,7 @@
           <name>AGI</name>
           <val>1</val>
         </specificattribute>
-        <specificattribute precedence="0">
+        <specificattribute>
           <name>REA</name>
           <val>1</val>
         </specificattribute>
@@ -3523,7 +3523,7 @@
           <name>AGI</name>
           <val>1</val>
         </specificattribute>
-        <specificattribute precedence="0">
+        <specificattribute>
           <name>REA</name>
           <val>1</val>
         </specificattribute>


### PR DESCRIPTION
Removes `precedence="0"` from Suprathyroid Gland's reaction improvement. It seems to be stoping reaction from stacking (but no other attributes) with other sources.