### PR TITLE
Implemented an ApplicationMonitor Class to kill Chummer from a timer thread if needed.

### DIFF
--- a/Chummer/Backend/Helpers/ApplicationMonitor.cs
+++ b/Chummer/Backend/Helpers/ApplicationMonitor.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Windows.Forms;
+using NLog;
+
+namespace Chummer
+{
+    /// <summary>
+    /// Class to handle the forceful shutdown of Chummer if the eventloop stucks for some reason.
+    /// </summary>
+    public class ApplicationMonitor
+    {
+        private readonly System.Timers.Timer timer;
+        private static readonly Lazy<Logger> s_ObjLogger = new Lazy<Logger>(LogManager.GetCurrentClassLogger);
+        private static Logger Log => s_ObjLogger.Value;
+        private int elapsedCount;
+
+        public ApplicationMonitor(int terminateAfterMilliseconds)
+        {
+            timer = new System.Timers.Timer();
+            timer.Interval = terminateAfterMilliseconds;
+            timer.Elapsed += TimerElapsed;
+        }
+
+        /// <summary>
+        /// Starts the timer that will kill the event loop and the application if not stopped.
+        /// </summary>
+        public void StartMonitoring()
+        {
+            Log.Debug("Started the Forcefull Shutdown Timer");
+            timer.Start();
+        }
+
+        private void TimerElapsed(object sender, EventArgs e)
+        {
+            elapsedCount++;
+
+            // The first time we ask "nicely" to stop.
+            if (elapsedCount == 1)
+            {
+                Log.Warn("Chummer took more than {Interval} to fully close calling Application.Exit", timer.Interval);
+                Application.Exit();
+                return;
+            }
+
+            // Now we just kill the process completely
+            Log.Error("Chummer took more than {Interval} seconds to fully close and will be killed now", 2*timer.Interval);
+            System.Diagnostics.Process.GetCurrentProcess().Kill();
+        }
+
+        /// <summary>
+        /// This stops the forceful shutdown of chummer
+        /// </summary>
+        public void SignalShutdown()
+        {
+            Log.Info("Stopped the forced shutdown", timer.Interval);
+            timer.Stop();
+        }
+    }
+}

--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -377,6 +377,7 @@
     <Compile Include="Backend\Datastructures\LockingDictionary.cs" />
     <Compile Include="Backend\Equipment\Clip.cs" />
     <Compile Include="Backend\Equipment\WeaponMount.cs" />
+    <Compile Include="Backend\Helpers\ApplicationMonitor.cs" />
     <Compile Include="Backend\Helpers\AsyncFriendlyReaderWriterLock.cs" />
     <Compile Include="Backend\Helpers\AsyncLock.cs" />
     <Compile Include="Backend\Helpers\CancellationTokenTaskSource.cs" />

--- a/Chummer/Forms/ChummerMainForm.cs
+++ b/Chummer/Forms/ChummerMainForm.cs
@@ -31,6 +31,7 @@ using System.Security;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows.Forms;
+using Chummer.Annotations;
 using Microsoft.ApplicationInsights.DataContracts;
 using NLog;
 using Application = System.Windows.Forms.Application;
@@ -2675,10 +2676,10 @@ namespace Chummer
 
             // Everything should be properly disposed of by now.
             // If Chummer does not continue closing gracefully the Application monitor will kill the process.
-            ApplicationMonitor.StartMonitoring();
+            ApplicationMonitor?.StartMonitoring();
         }
 
-        public ApplicationMonitor ApplicationMonitor { private get; set; }
+        [CanBeNull] public ApplicationMonitor ApplicationMonitor { private get; set; }
 
         private void DisposeOpenForms()
         {

--- a/Chummer/Forms/ChummerMainForm.cs
+++ b/Chummer/Forms/ChummerMainForm.cs
@@ -1339,7 +1339,7 @@ namespace Chummer
                         objTemp.Dispose();
                     }
                 }
-                
+
                 try
                 {
                     Task tskOld = Interlocked.Exchange(ref _tskVersionUpdate, null);
@@ -2672,7 +2672,13 @@ namespace Chummer
             {
                 Log.Warn(ex, ex.Message);
             }
+
+            // Everything should be properly disposed of by now.
+            // If Chummer does not continue closing gracefully the Application monitor will kill the process.
+            ApplicationMonitor.StartMonitoring();
         }
+
+        public ApplicationMonitor ApplicationMonitor { private get; set; }
 
         private void DisposeOpenForms()
         {

--- a/Chummer/Program.cs
+++ b/Chummer/Program.cs
@@ -616,7 +616,11 @@ namespace Chummer
                             }
 
                             MainForm.MyStartupPvt = pvt;
+
+                            var appMonitor = new ApplicationMonitor(3000);
+                            MainForm.ApplicationMonitor = appMonitor;
                             Application.Run(MainForm);
+                            appMonitor.SignalShutdown();
                         }
 
                         OpenCharacters.Clear();


### PR DESCRIPTION
fixes #5010

Implemented an `ApplicationMonitor` class that starts a timer on another Thread.
If the set interval elapses `Application.Exit()` will be called to stop the WinForms event loop.
In the case of Chummer still not closing properly and progressing beyond `Application.Run()` we kill the process on the next timer tick.

The timer is started as the last step of the Main Form closing.
The timer is stopped if we progress beyond Application.Run() which implies that we now started to gracefully exiting Chummer.