### PR TITLE
Fixed ChummerHub.Client not including all .dll files it needs

### DIFF
--- a/Plugins/ChummerHub.Client/ChummerHub.Client.csproj
+++ b/Plugins/ChummerHub.Client/ChummerHub.Client.csproj
@@ -12,6 +12,7 @@
     <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />


### PR DESCRIPTION
ChummerHub.Client did not include all the needed .dll files in it's library and thus would not load.
(Most notably System.Text.Json)