### PR TITLE
Cybersuite children are now included in ATT pools

### DIFF
--- a/Chummer/Backend/Attributes/Attribute.Core.cs
+++ b/Chummer/Backend/Attributes/Attribute.Core.cs
@@ -1023,7 +1023,7 @@ namespace Chummer.Backend.Attributes
                     Cyberware.CyberlimbAttributeAbbrevs.Contains(Abbrev))
                 {
                     return _objCharacter.Cyberware.Any(objCyberware =>
-                        (objCyberware.Category == "Cyberlimb" || objCyberware.Category == "Cybersuite") && !string.IsNullOrEmpty(objCyberware.LimbSlot), token);
+                        objCyberware.IsLimb && !string.IsNullOrEmpty(objCyberware.LimbSlot), token);
                 }
 
                 return false;
@@ -1074,10 +1074,10 @@ namespace Chummer.Backend.Attributes
                     Cyberware.CyberlimbAttributeAbbrevs.Contains(Abbrev))
                 {
                     return await _objCharacter.Cyberware
-                        .AnyAsync(
-                            objCyberware =>
-                                (objCyberware.Category == "Cyberlimb" || objCyberware.Category == "Cybersuite") &&
-                                !string.IsNullOrEmpty(objCyberware.LimbSlot), token: token)
+                        .AnyAsync
+                        (
+                            objCyberware => objCyberware.IsLimb,
+                            token: token)
                         .ConfigureAwait(false);
                 }
 
@@ -1293,16 +1293,13 @@ namespace Chummer.Backend.Attributes
                         int intLimbTotalReturn = 0;
                         foreach (Cyberware objCyberware in lstToCheck)
                         {
-                            if (objCyberware.Category == "Cyberlimb")
+                            if (objCyberware.IsLimb)
                             {
-                                if (!string.IsNullOrWhiteSpace(objCyberware.LimbSlot)
-                                    && !_objCharacter.Settings.ExcludeLimbSlot
-                                        .Contains(objCyberware.LimbSlot))
-                                {
-                                    intLimbCountReturn += objCyberware.LimbSlotCount;
-                                    intLimbTotalReturn += objCyberware.GetAttributeTotalValue(Abbrev) *
-                                                          objCyberware.LimbSlotCount;
-                                }
+                                if (_objCharacter.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)) continue;
+
+                                intLimbCountReturn += objCyberware.LimbSlotCount;
+                                intLimbTotalReturn += objCyberware.GetAttributeTotalValue(Abbrev) *
+                                                      objCyberware.LimbSlotCount;
                             }
                             else
                             {
@@ -1321,17 +1318,14 @@ namespace Chummer.Backend.Attributes
                         int intLimbTotalReturn = 0;
                         foreach (Cyberware objCyberware in lstToCheck)
                         {
-                            if (objCyberware.Category == "Cyberlimb")
+                            if (objCyberware.IsLimb)
                             {
-                                if (!string.IsNullOrWhiteSpace(objCyberware.LimbSlot)
-                                    && !_objCharacter.Settings.ExcludeLimbSlot
-                                        .Contains(objCyberware.LimbSlot))
-                                {
-                                    intLimbCountReturn += objCyberware.LimbSlotCount;
-                                    intLimbTotalReturn +=
-                                        await objCyberware.GetAttributeTotalValueAsync(Abbrev, token)
-                                            .ConfigureAwait(false) * objCyberware.LimbSlotCount;
-                                }
+                                if (_objCharacter.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)) continue;
+
+                                intLimbCountReturn += objCyberware.LimbSlotCount;
+                                intLimbTotalReturn +=
+                                    await objCyberware.GetAttributeTotalValueAsync(Abbrev, token)
+                                        .ConfigureAwait(false) * objCyberware.LimbSlotCount;
                             }
                             else
                             {
@@ -2118,26 +2112,7 @@ namespace Chummer.Backend.Attributes
                             {
                                 _objCharacter.Cyberware.ForEach(objCyberware =>
                                 {
-                                    switch (objCyberware.Category)
-                                    {
-                                        case "Cybersuite":
-                                        {
-                                            foreach (var objCyberwareChild in objCyberware.Children)
-                                            {
-                                                if (objCyberwareChild.Category != "Cyberlimb")
-                                                {
-                                                    continue;
-                                                }
-
-                                                sbdModifier = AppendCyberware(sbdModifier, objCyberwareChild, strSpace);
-                                            }
-
-                                            break;
-                                        }
-                                        case "Cyberlimb":
-                                            sbdModifier = AppendCyberware(sbdModifier, objCyberware, strSpace);
-                                            break;
-                                    }
+                                    sbdModifier = BuildTooltip(sbdModifier, objCyberware, strSpace);
                                 });
                             }
 
@@ -2148,13 +2123,28 @@ namespace Chummer.Backend.Attributes
                     }
                 }
 
-                StringBuilder AppendCyberware(StringBuilder sb, Cyberware cyberware, string strSpace)
+                StringBuilder BuildTooltip(StringBuilder sb, Cyberware cyberware, string strSpace)
                 {
-                    sb.AppendLine().Append(cyberware.CurrentDisplayName)
+                    if (!cyberware.IsLimb)
+                    {
+                        return sb;
+                    }
+
+                    if (cyberware.InheritAttributes)
+                    {
+                        foreach (var cyberwareChild in cyberware.Children)
+                        {
+                            sb = BuildTooltip(sb, cyberwareChild, strSpace);
+                        }
+
+                        return sb;
+                    }
+
+                    sb.AppendLine()
+                        .Append(cyberware.CurrentDisplayName)
                         .Append(strSpace)
                         .Append('(')
-                        .Append(cyberware.GetAttributeTotalValue(Abbrev)
-                            .ToString(GlobalSettings.CultureInfo))
+                        .Append(cyberware.GetAttributeTotalValue(Abbrev).ToString(GlobalSettings.CultureInfo))
                         .Append(')');
 
                     return sb;
@@ -2678,9 +2668,11 @@ namespace Chummer.Backend.Attributes
                     {
                         if (!CharacterObject.Settings.DontUseCyberlimbCalculation &&
                             Cyberware.CyberlimbAttributeAbbrevs.Contains(Abbrev) &&
-                            CharacterObject.Cyberware.Any(objCyberware => objCyberware.Category == "Cyberlimb"
-                                                                          && !string.IsNullOrWhiteSpace(objCyberware.LimbSlot)
-                                                                          && !CharacterObject.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)))
+                            CharacterObject.Cyberware.Any(objCyberware =>
+                                objCyberware.IsLimb &&
+                                !CharacterObject.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)
+                                )
+                            )
                         {
                             OnPropertyChanged(nameof(TotalValue));
                         }
@@ -2697,9 +2689,11 @@ namespace Chummer.Backend.Attributes
                 case nameof(CharacterSettings.DontUseCyberlimbCalculation):
                     {
                         if (Cyberware.CyberlimbAttributeAbbrevs.Contains(Abbrev) &&
-                            CharacterObject.Cyberware.Any(objCyberware => objCyberware.Category == "Cyberlimb"
-                                                                          && !string.IsNullOrWhiteSpace(objCyberware.LimbSlot)
-                                                                          && !CharacterObject.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)))
+                            CharacterObject.Cyberware.Any(objCyberware =>
+                                objCyberware.IsLimb &&
+                                !CharacterObject.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)
+                                )
+                            )
                         {
                             this.OnMultiplePropertyChanged(nameof(TotalValue), nameof(HasModifiers));
                         }
@@ -2709,9 +2703,11 @@ namespace Chummer.Backend.Attributes
                 case nameof(CharacterSettings.ExcludeLimbSlot):
                     {
                         if ((Abbrev == "AGI" || Abbrev == "STR") &&
-                            CharacterObject.Cyberware.Any(objCyberware => objCyberware.Category == "Cyberlimb"
-                                                                          && !string.IsNullOrWhiteSpace(objCyberware.LimbSlot)
-                                                                          && !CharacterObject.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)))
+                            CharacterObject.Cyberware.Any(objCyberware =>
+                                objCyberware.IsLimb &&
+                                !CharacterObject.Settings.ExcludeLimbSlot.Contains(objCyberware.LimbSlot)
+                                )
+                            )
                         {
                             this.OnMultiplePropertyChanged(nameof(TotalValue));
                         }

--- a/Chummer/Backend/Characters/Character.cs
+++ b/Chummer/Backend/Characters/Character.cs
@@ -2522,11 +2522,16 @@ namespace Chummer
                                         }
                                     }
 
-                                    if (!blnDoCyberlimbAttributesRefresh && !Settings.DontUseCyberlimbCalculation &&
-                                        objNewItem.Category == "Cyberlimb" && objNewItem.Parent == null &&
+                                    if
+                                    (
+                                        !blnDoCyberlimbAttributesRefresh &&
+                                        !Settings.DontUseCyberlimbCalculation &&
+                                        (objNewItem.Category == "Cyberlimb" || objNewItem.Category == "Cybersuite") &&
+                                        objNewItem.Parent == null &&
                                         objNewItem.ParentVehicle == null &&
                                         !string.IsNullOrWhiteSpace(objNewItem.LimbSlot) &&
-                                        !Settings.ExcludeLimbSlot.Contains(objNewItem.LimbSlot))
+                                        !Settings.ExcludeLimbSlot.Contains(objNewItem.LimbSlot)
+                                    )
                                     {
                                         blnDoCyberlimbAttributesRefresh = true;
                                     }
@@ -2547,11 +2552,16 @@ namespace Chummer
                                 dicChangedProperties[this].Add(objOldItem.EssencePropertyName);
                                 using (await EnterReadLock.EnterAsync(LockObject).ConfigureAwait(false))
                                 {
-                                    if (!blnDoCyberlimbAttributesRefresh && !Settings.DontUseCyberlimbCalculation &&
-                                        objOldItem.Category == "Cyberlimb" && objOldItem.Parent == null &&
+                                    if
+                                    (
+                                        !blnDoCyberlimbAttributesRefresh &&
+                                        !Settings.DontUseCyberlimbCalculation &&
+                                        (objOldItem.Category == "Cyberlimb" || objOldItem.Category == "Cybersuite") &&
+                                        objOldItem.Parent == null &&
                                         objOldItem.ParentVehicle == null &&
                                         !string.IsNullOrWhiteSpace(objOldItem.LimbSlot) &&
-                                        !Settings.ExcludeLimbSlot.Contains(objOldItem.LimbSlot))
+                                        !Settings.ExcludeLimbSlot.Contains(objOldItem.LimbSlot)
+                                    )
                                     {
                                         blnDoCyberlimbAttributesRefresh = true;
                                     }
@@ -2574,11 +2584,16 @@ namespace Chummer
                                         if (objOldItem.IsModularCurrentlyEquipped)
                                             blnDoEncumbranceRefresh = true;
                                         dicChangedProperties[this].Add(objOldItem.EssencePropertyName);
-                                        if (!blnDoCyberlimbAttributesRefresh && !Settings.DontUseCyberlimbCalculation &&
-                                            objOldItem.Category == "Cyberlimb" && objOldItem.Parent == null &&
+                                        if
+                                        (
+                                            !blnDoCyberlimbAttributesRefresh &&
+                                            !Settings.DontUseCyberlimbCalculation &&
+                                            (objOldItem.Category == "Cyberlimb" || objOldItem.Category == "Cybersuite") &&
+                                            objOldItem.Parent == null &&
                                             objOldItem.ParentVehicle == null &&
                                             !string.IsNullOrWhiteSpace(objOldItem.LimbSlot) &&
-                                            !Settings.ExcludeLimbSlot.Contains(objOldItem.LimbSlot))
+                                            !Settings.ExcludeLimbSlot.Contains(objOldItem.LimbSlot)
+                                        )
                                         {
                                             blnDoCyberlimbAttributesRefresh = true;
                                         }
@@ -2589,11 +2604,16 @@ namespace Chummer
                                         if (objNewItem.IsModularCurrentlyEquipped)
                                             blnDoEncumbranceRefresh = true;
                                         dicChangedProperties[this].Add(objNewItem.EssencePropertyName);
-                                        if (!blnDoCyberlimbAttributesRefresh && !Settings.DontUseCyberlimbCalculation &&
-                                            objNewItem.Category == "Cyberlimb" && objNewItem.Parent == null &&
+                                        if
+                                        (
+                                            !blnDoCyberlimbAttributesRefresh &&
+                                            !Settings.DontUseCyberlimbCalculation &&
+                                            (objNewItem.Category == "Cyberlimb" || objNewItem.Category == "Cybersuite") &&
+                                            objNewItem.Parent == null &&
                                             objNewItem.ParentVehicle == null &&
                                             !string.IsNullOrWhiteSpace(objNewItem.LimbSlot) &&
-                                            !Settings.ExcludeLimbSlot.Contains(objNewItem.LimbSlot))
+                                            !Settings.ExcludeLimbSlot.Contains(objNewItem.LimbSlot)
+                                        )
                                         {
                                             blnDoCyberlimbAttributesRefresh = true;
                                         }

--- a/Chummer/Backend/Characters/Character.cs
+++ b/Chummer/Backend/Characters/Character.cs
@@ -2526,10 +2526,9 @@ namespace Chummer
                                     (
                                         !blnDoCyberlimbAttributesRefresh &&
                                         !Settings.DontUseCyberlimbCalculation &&
-                                        (objNewItem.Category == "Cyberlimb" || objNewItem.Category == "Cybersuite") &&
+                                        objNewItem.IsLimb &&
                                         objNewItem.Parent == null &&
                                         objNewItem.ParentVehicle == null &&
-                                        !string.IsNullOrWhiteSpace(objNewItem.LimbSlot) &&
                                         !Settings.ExcludeLimbSlot.Contains(objNewItem.LimbSlot)
                                     )
                                     {
@@ -2556,10 +2555,9 @@ namespace Chummer
                                     (
                                         !blnDoCyberlimbAttributesRefresh &&
                                         !Settings.DontUseCyberlimbCalculation &&
-                                        (objOldItem.Category == "Cyberlimb" || objOldItem.Category == "Cybersuite") &&
+                                        objOldItem.IsLimb &&
                                         objOldItem.Parent == null &&
                                         objOldItem.ParentVehicle == null &&
-                                        !string.IsNullOrWhiteSpace(objOldItem.LimbSlot) &&
                                         !Settings.ExcludeLimbSlot.Contains(objOldItem.LimbSlot)
                                     )
                                     {
@@ -2588,10 +2586,10 @@ namespace Chummer
                                         (
                                             !blnDoCyberlimbAttributesRefresh &&
                                             !Settings.DontUseCyberlimbCalculation &&
-                                            (objOldItem.Category == "Cyberlimb" || objOldItem.Category == "Cybersuite") &&
+                                            objOldItem.IsLimb &&
                                             objOldItem.Parent == null &&
                                             objOldItem.ParentVehicle == null &&
-                                            !string.IsNullOrWhiteSpace(objOldItem.LimbSlot) &&
+
                                             !Settings.ExcludeLimbSlot.Contains(objOldItem.LimbSlot)
                                         )
                                         {
@@ -2608,10 +2606,9 @@ namespace Chummer
                                         (
                                             !blnDoCyberlimbAttributesRefresh &&
                                             !Settings.DontUseCyberlimbCalculation &&
-                                            (objNewItem.Category == "Cyberlimb" || objNewItem.Category == "Cybersuite") &&
+                                            objNewItem.IsLimb &&
                                             objNewItem.Parent == null &&
                                             objNewItem.ParentVehicle == null &&
-                                            !string.IsNullOrWhiteSpace(objNewItem.LimbSlot) &&
                                             !Settings.ExcludeLimbSlot.Contains(objNewItem.LimbSlot)
                                         )
                                         {

--- a/Chummer/Backend/Equipment/Cyberware.cs
+++ b/Chummer/Backend/Equipment/Cyberware.cs
@@ -322,13 +322,15 @@ namespace Chummer.Backend.Equipment
                                     lstImprovementSourcesToProcess.Add(objNewItem);
                                 }
 
-                                if (setAttributesToRefresh.Count < CyberlimbAttributeAbbrevs.Count &&
-                                    Category == "Cyberlimb" && Parent?.InheritAttributes != false
-                                    && ParentVehicle == null
-                                    &&
+                                if
+                                (
+                                    setAttributesToRefresh.Count < CyberlimbAttributeAbbrevs.Count &&
+                                    IsLimb &&
+                                    Parent?.InheritAttributes != false &&
+                                    ParentVehicle == null &&
                                     _objCharacter?.Settings.DontUseCyberlimbCalculation != true &&
-                                    !string.IsNullOrWhiteSpace(LimbSlot) &&
-                                    _objCharacter?.Settings.ExcludeLimbSlot.Contains(LimbSlot) != true)
+                                    _objCharacter?.Settings.ExcludeLimbSlot.Contains(LimbSlot) != true
+                                )
                                 {
                                     if (InheritAttributes)
                                     {
@@ -380,11 +382,10 @@ namespace Chummer.Backend.Equipment
                                     objOldItem.Parent = null;
 
                                 if (setAttributesToRefresh.Count < CyberlimbAttributeAbbrevs.Count &&
-                                    Category == "Cyberlimb" && Parent?.InheritAttributes != false
-                                    && ParentVehicle == null
-                                    &&
+                                    IsLimb &&
+                                    Parent?.InheritAttributes != false &&
+                                    ParentVehicle == null &&
                                     !_objCharacter.Settings.DontUseCyberlimbCalculation &&
-                                    !string.IsNullOrWhiteSpace(LimbSlot) &&
                                     !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
                                 {
                                     if (InheritAttributes)
@@ -441,11 +442,10 @@ namespace Chummer.Backend.Equipment
                                     objOldItem.Parent = null;
 
                                 if (setAttributesToRefresh.Count < CyberlimbAttributeAbbrevs.Count &&
-                                    Category == "Cyberlimb" && Parent?.InheritAttributes != false
-                                    && ParentVehicle == null
-                                    &&
+                                    IsLimb &&
+                                    Parent?.InheritAttributes != false &&
+                                    ParentVehicle == null &&
                                     !_objCharacter.Settings.DontUseCyberlimbCalculation &&
-                                    !string.IsNullOrWhiteSpace(LimbSlot) &&
                                     !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
                                 {
                                     if (InheritAttributes)
@@ -492,11 +492,11 @@ namespace Chummer.Backend.Equipment
                                 }
 
                                 if (setAttributesToRefresh.Count < CyberlimbAttributeAbbrevs.Count &&
-                                    Category == "Cyberlimb" && Parent?.InheritAttributes != false
-                                    && ParentVehicle == null
-                                    &&
+                                    IsLimb &&
+                                    Parent?.InheritAttributes != false &&
+                                    ParentVehicle == null &&
                                     !_objCharacter.Settings.DontUseCyberlimbCalculation &&
-                                    !string.IsNullOrWhiteSpace(LimbSlot) &&
+
                                     !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
                                 {
                                     if (InheritAttributes)
@@ -527,12 +527,13 @@ namespace Chummer.Backend.Equipment
                         case NotifyCollectionChangedAction.Reset:
                             blnDoEssenceImprovementsRefresh = true;
                             blnDoEncumbranceRefresh = blnEverDoEncumbranceRefresh;
-                            if (Category == "Cyberlimb" && Parent?.InheritAttributes != false
-                                                        && ParentVehicle == null
-                                                        &&
-                                                        !_objCharacter.Settings.DontUseCyberlimbCalculation &&
-                                                        !string.IsNullOrWhiteSpace(LimbSlot) &&
-                                                        !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
+                            if
+                            (
+                                IsLimb &&
+                                Parent?.InheritAttributes != false &&
+                                ParentVehicle == null &&
+                                !_objCharacter.Settings.DontUseCyberlimbCalculation &&
+                                !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
                             {
                                 setAttributesToRefresh.AddRange(CyberlimbAttributeAbbrevs);
                             }
@@ -2084,8 +2085,7 @@ namespace Chummer.Backend.Equipment
                     = await objWriter.StartElementAsync("cyberware", token: token).ConfigureAwait(false);
                 try
                 {
-                    if ((string.IsNullOrWhiteSpace(LimbSlot) && _strCategory != "Cyberlimb")
-                        || CyberlimbAttributeAbbrevs.Count == 0)
+                    if (IsLimb || CyberlimbAttributeAbbrevs.Count == 0)
                     {
                         await objWriter
                               .WriteElementStringAsync(
@@ -2552,10 +2552,13 @@ namespace Chummer.Backend.Equipment
                         _lstIncludeInWirelessPairBonus.Add(value);
                     }
 
-                    if (_objParent?.Category != "Cyberlimb" || _objParent.Parent?.InheritAttributes == false ||
-                        _objParent.ParentVehicle != null || _objCharacter.Settings.DontUseCyberlimbCalculation ||
-                        string.IsNullOrWhiteSpace(_objParent.LimbSlot) ||
-                        _objCharacter.Settings.ExcludeLimbSlot.Contains(_objParent.LimbSlot))
+                    if
+                        (
+                            _objParent?.IsLimb != true ||
+                            _objParent.Parent?.InheritAttributes == false ||
+                            _objParent.ParentVehicle != null ||
+                            _objCharacter.Settings.DontUseCyberlimbCalculation ||
+                            _objCharacter.Settings.ExcludeLimbSlot.Contains(_objParent.LimbSlot))
                         return;
                     // Note: Movement is always handled whenever AGI or STR is changed, regardless of whether or not we use cyberleg movement
                     foreach (KeyValuePair<string, IReadOnlyCollection<string>> kvpToCheck in
@@ -2797,12 +2800,12 @@ namespace Chummer.Backend.Equipment
                 using (EnterReadLock.Enter(LockObject))
                 {
                     string strOldValue = Interlocked.Exchange(ref _strCategory, value);
-                    if (strOldValue != value && (value == "Cyberlimb" || strOldValue == "Cyberlimb")
-                                             && Parent?.InheritAttributes != false &&
-                                             ParentVehicle == null
-                                             && !_objCharacter.Settings.DontUseCyberlimbCalculation &&
-                                             !string.IsNullOrWhiteSpace(LimbSlot) &&
-                                             !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
+                    if (strOldValue != value &&
+                        IsLimb &&
+                        Parent?.InheritAttributes != false &&
+                        ParentVehicle == null &&
+                        !_objCharacter.Settings.DontUseCyberlimbCalculation &&
+                        !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
                     {
                         foreach (CharacterAttrib objCharacterAttrib in _objCharacter.GetAllAttributes())
                         {
@@ -2834,15 +2837,20 @@ namespace Chummer.Backend.Equipment
                 using (EnterReadLock.Enter(LockObject))
                 {
                     string strOldValue = Interlocked.Exchange(ref _strLimbSlot, value);
-                    if (strOldValue != value && (Category == "Cyberlimb" && Parent?.InheritAttributes != false
-                                                                         && ParentVehicle == null &&
-                                                                         !_objCharacter.Settings
-                                                                             .DontUseCyberlimbCalculation &&
-                                                                         (!string.IsNullOrWhiteSpace(value)
-                                                                          && !_objCharacter.Settings.ExcludeLimbSlot
-                                                                              .Contains(value)) ||
-                                                 (!string.IsNullOrWhiteSpace(strOldValue) &&
-                                                  !_objCharacter.Settings.ExcludeLimbSlot.Contains(strOldValue))))
+                    if (
+                            strOldValue != value &&
+                            (
+                                Parent?.InheritAttributes != false &&
+                                ParentVehicle == null &&
+                                !_objCharacter.Settings.DontUseCyberlimbCalculation &&
+                                !string.IsNullOrWhiteSpace(value) &&
+                                !_objCharacter.Settings.ExcludeLimbSlot.Contains(value) ||
+                                (
+                                    !string.IsNullOrWhiteSpace(strOldValue) &&
+                                    !_objCharacter.Settings.ExcludeLimbSlot.Contains(strOldValue)
+                                )
+                            )
+                        )
                     {
                         foreach (CharacterAttrib objCharacterAttrib in _objCharacter.GetAllAttributes())
                         {
@@ -2883,12 +2891,15 @@ namespace Chummer.Backend.Equipment
                 string strNewValue = value.ToString(GlobalSettings.InvariantCultureInfo);
                 using (EnterReadLock.Enter(LockObject))
                 {
-                    if (Interlocked.Exchange(ref _strLimbSlotCount, strNewValue) != strNewValue
-                        && Category == "Cyberlimb"
-                        && Parent?.InheritAttributes != false && ParentVehicle == null &&
+                    if
+                    (
+                        Interlocked.Exchange(ref _strLimbSlotCount, strNewValue) != strNewValue &&
+                        IsLimb &&
+                        Parent?.InheritAttributes != false &&
+                        ParentVehicle == null &&
                         !_objCharacter.Settings.DontUseCyberlimbCalculation &&
-                        !string.IsNullOrWhiteSpace(LimbSlot) &&
-                        !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot))
+                        !_objCharacter.Settings.ExcludeLimbSlot.Contains(LimbSlot)
+                    )
                     {
                         foreach (CharacterAttrib objCharacterAttrib in _objCharacter.GetAllAttributes())
                         {
@@ -4175,11 +4186,11 @@ namespace Chummer.Backend.Equipment
                         {
                             if (IsModularCurrentlyEquipped && ParentVehicle == null)
                             {
-                                if (_objParent?.Category == "Cyberlimb"
+                                if (
+                                    _objParent?.IsLimb == true
                                     && _objParent.Parent?.InheritAttributes != false
                                     && _objParent.ParentVehicle == null
                                     && !_objCharacter.Settings.DontUseCyberlimbCalculation
-                                    && !string.IsNullOrWhiteSpace(_objParent.LimbSlot)
                                     && !_objCharacter.Settings.ExcludeLimbSlot.Contains(_objParent.LimbSlot))
                                 {
                                     foreach (KeyValuePair<string, IReadOnlyCollection<string>> kvpToCheck in
@@ -5349,6 +5360,25 @@ namespace Chummer.Backend.Equipment
                 _objCachedMyXPathNode = objReturn;
                 _strCachedXPathNodeLanguage = strLanguage;
                 return objReturn;
+            }
+        }
+
+        /// <summary>
+        /// Returns true if this ware could modify AGI or STR
+        /// </summary>
+        public bool IsLimb
+        {
+            get
+            {
+                using (EnterReadLock.Enter(LockObject))
+                {
+                    if (!InheritAttributes)
+                    {
+                        return !string.IsNullOrEmpty(LimbSlot);
+                    }
+
+                    return !string.IsNullOrWhiteSpace(LimbSlot) || Children.Any(child => child.IsLimb);
+                }
             }
         }
 
@@ -7081,7 +7111,7 @@ namespace Chummer.Backend.Equipment
                 return 0;
             using (EnterReadLock.Enter(LockObject))
             {
-                if (Category != "Cyberlimb")
+                if (!IsLimb)
                     return 0;
                 switch (strAbbrev)
                 {
@@ -7108,7 +7138,7 @@ namespace Chummer.Backend.Equipment
                 return 0;
             using (await EnterReadLock.EnterAsync(LockObject, token).ConfigureAwait(false))
             {
-                if (Category != "Cyberlimb")
+                if (!IsLimb)
                     return 0;
                 switch (strAbbrev)
                 {
@@ -7239,7 +7269,7 @@ namespace Chummer.Backend.Equipment
                     return intAverageAttribute / intCyberlimbChildrenNumber;
                 }
 
-                if (Category != "Cyberlimb")
+                if (!IsLimb)
                     return 0;
 
                 int intBonus = 0;
@@ -7306,7 +7336,7 @@ namespace Chummer.Backend.Equipment
                     return intAverageAttribute / intCyberlimbChildrenNumber;
                 }
 
-                if (Category != "Cyberlimb")
+                if (!IsLimb)
                     return 0;
 
                 int intBonus = 0;

--- a/Chummer/Backend/Skills/Skill.cs
+++ b/Chummer/Backend/Skills/Skill.cs
@@ -3792,16 +3792,21 @@ namespace Chummer.Backend.Skills
 
                         StringBuilder BuildTooltipString(StringBuilder sb, Cyberware cyberware)
                         {
-                            if (cyberware.Category == "Cybersuite")
+                            if (!cyberware.IsLimb || !cyberware.IsModularCurrentlyEquipped)
                             {
-                                cyberware.Children.ForEach(childWare =>
-                                {
-                                    sb = BuildTooltipString(sb, childWare);
-                                });
+                                return sb;
                             }
 
-                            if (cyberware.Category != "Cyberlimb" || !cyberware.IsModularCurrentlyEquipped)
+                            if (cyberware.InheritAttributes)
+                            {
+                                foreach (var child in cyberware.Children)
+                                {
+                                    sb = BuildTooltipString(sb, child);
+                                }
+
                                 return sb;
+                            }
+
                             sb.AppendLine().AppendLine().Append(strExtraStart)
                                 .Append(cyberware.CurrentDisplayName);
                             if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
@@ -3889,16 +3894,20 @@ namespace Chummer.Backend.Skills
 
                         StringBuilder BuildTooltip(StringBuilder sb, Cyberware cyberware)
                         {
-                            if (cyberware.Category == "Cybersuite")
+                            if (!cyberware.IsLimb || !cyberware.IsModularCurrentlyEquipped)
+                            {
+                                return sb;
+                            }
+
+                            if (cyberware.InheritAttributes)
                             {
                                 cyberware.Children.ForEach(childWare =>
                                 {
                                     sb = BuildTooltip(sb, childWare);
                                 });
+                                return sb;
                             }
 
-                            if (cyberware.Category != "Cyberlimb" || !cyberware.IsModularCurrentlyEquipped)
-                                return sb;
                             sb.AppendLine().AppendLine().Append(strExtraStart).Append(strExclude)
                                      .Append(LanguageManager.GetString("String_Colon")).Append(strSpace)
                                      .Append(CharacterObject.GetObjectName(objSwapSkillAttribute)).Append(strSpace)
@@ -4142,16 +4151,22 @@ namespace Chummer.Backend.Skills
 
                         async Task<StringBuilder> BuildTooltipAsync(StringBuilder sb, Cyberware cyberware)
                         {
-                            if (cyberware.Category == "Cybersuite")
+                            if (!cyberware.IsLimb || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
+                            {
+                                return sb;
+                            }
+
+                            if (cyberware.InheritAttributes)
                             {
                                 foreach (var cyberwareChild in cyberware.Children)
                                 {
                                     sb = await BuildTooltipAsync(sb, cyberwareChild);
                                 }
+
+                                return sb;
                             }
 
-                            if (cyberware.Category != "Cyberlimb" || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
-                                return sb;
+
                             sb.AppendLine().AppendLine().Append(strExtraStart)
                                 .Append(await cyberware.GetCurrentDisplayNameAsync(token).ConfigureAwait(false));
                             if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
@@ -4252,16 +4267,21 @@ namespace Chummer.Backend.Skills
                         continue;
                         async Task<StringBuilder> BuildTooltipAsync(StringBuilder sb, Cyberware cyberware)
                         {
-                            if (cyberware.Category == "Cybersuite")
+                            if (!cyberware.IsLimb || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
+                            {
+                                return sb;
+                            }
+
+                            if (cyberware.InheritAttributes)
                             {
                                 foreach (var cyberwareChild in cyberware.Children)
                                 {
                                     sb = await BuildTooltipAsync(sb, cyberwareChild);
                                 }
+
+                                return sb;
                             }
 
-                            if (cyberware.Category != "Cyberlimb" || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
-                                return sb;
                             sb.AppendLine().AppendLine().Append(strExtraStart).Append(strExclude)
                                      .Append(await LanguageManager.GetStringAsync("String_Colon", token: token)
                                                                   .ConfigureAwait(false)).Append(strSpace)

--- a/Chummer/Backend/Skills/Skill.cs
+++ b/Chummer/Backend/Skills/Skill.cs
@@ -3787,36 +3787,51 @@ namespace Chummer.Backend.Skills
                     {
                         CharacterObject.Cyberware.ForEach(cyberware =>
                         {
+                            sbdReturn = BuildTooltipString(sbdReturn, cyberware);
+                        });
+
+                        StringBuilder BuildTooltipString(StringBuilder sb, Cyberware cyberware)
+                        {
+                            if (cyberware.Category == "Cybersuite")
+                            {
+                                cyberware.Children.ForEach(childWare =>
+                                {
+                                    sb = BuildTooltipString(sb, childWare);
+                                });
+                            }
+
                             if (cyberware.Category != "Cyberlimb" || !cyberware.IsModularCurrentlyEquipped)
-                                return;
-                            sbdReturn.AppendLine().AppendLine().Append(strExtraStart)
-                                     .Append(cyberware.CurrentDisplayName);
+                                return sb;
+                            sb.AppendLine().AppendLine().Append(strExtraStart)
+                                .Append(cyberware.CurrentDisplayName);
                             if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
                             {
-                                sbdReturn.Append(strSpace).Append('(').Append(cyberware.Grade.CurrentDisplayName)
-                                         .Append(')');
+                                sb.Append(strSpace).Append('(').Append(cyberware.Grade.CurrentDisplayName)
+                                    .Append(')');
                             }
 
                             int pool = PoolOtherAttribute(att.Abbrev, false,
-                                                          cyberware.GetAttributeTotalValue(att.Abbrev));
+                                cyberware.GetAttributeTotalValue(att.Abbrev));
                             if ((cyberware.LimbSlot != "arm"
                                  && !cyberware.Name.ContainsAny(" Arm", " Hand"))
                                 || cyberware.Location == CharacterObject.PrimaryArm
                                 || CharacterObject.Ambidextrous
                                 || cyberware.LimbSlotCount > 1)
                             {
-                                sbdReturn.Append(strSpace).Append(pool.ToString(GlobalSettings.CultureInfo));
+                                sb.Append(strSpace).Append(pool.ToString(GlobalSettings.CultureInfo));
                             }
                             else
                             {
-                                sbdReturn.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})", pool - 2,
-                                                       strSpace, -2,
-                                                       LanguageManager.GetString("Tip_Skill_OffHand"));
+                                sb.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})", pool - 2,
+                                    strSpace, -2,
+                                    LanguageManager.GetString("Tip_Skill_OffHand"));
                             }
 
                             if (!string.IsNullOrEmpty(strExtra))
-                                sbdReturn.Append(strExtra);
-                        });
+                                sb.Append(strExtra);
+
+                            return sb;
+                        }
                     }
 
                     if (att.Abbrev != Attribute)
@@ -3868,15 +3883,29 @@ namespace Chummer.Backend.Skills
                             continue;
                         CharacterObject.Cyberware.ForEach(cyberware =>
                         {
+                            sbdReturn = BuildTooltip(sbdReturn, cyberware);
+                        });
+                        continue;
+
+                        StringBuilder BuildTooltip(StringBuilder sb, Cyberware cyberware)
+                        {
+                            if (cyberware.Category == "Cybersuite")
+                            {
+                                cyberware.Children.ForEach(childWare =>
+                                {
+                                    sb = BuildTooltip(sb, childWare);
+                                });
+                            }
+
                             if (cyberware.Category != "Cyberlimb" || !cyberware.IsModularCurrentlyEquipped)
-                                return;
-                            sbdReturn.AppendLine().AppendLine().Append(strExtraStart).Append(strExclude)
+                                return sb;
+                            sb.AppendLine().AppendLine().Append(strExtraStart).Append(strExclude)
                                      .Append(LanguageManager.GetString("String_Colon")).Append(strSpace)
                                      .Append(CharacterObject.GetObjectName(objSwapSkillAttribute)).Append(strSpace)
                                      .Append(cyberware.CurrentDisplayName);
                             if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
                             {
-                                sbdReturn.Append(strSpace).Append('(').Append(cyberware.Grade.CurrentDisplayName)
+                                sb.Append(strSpace).Append('(').Append(cyberware.Grade.CurrentDisplayName)
                                          .Append(')');
                             }
 
@@ -3895,18 +3924,19 @@ namespace Chummer.Backend.Skills
                                 || CharacterObject.Ambidextrous
                                 || cyberware.LimbSlotCount > 1)
                             {
-                                sbdReturn.Append(strSpace).Append(intLoopPool.ToString(GlobalSettings.CultureInfo));
+                                sb.Append(strSpace).Append(intLoopPool.ToString(GlobalSettings.CultureInfo));
                             }
                             else
                             {
-                                sbdReturn.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})",
+                                sb.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})",
                                                        intLoopPool - 2, strSpace, -2,
                                                        LanguageManager.GetString("Tip_Skill_OffHand"));
                             }
 
                             if (!string.IsNullOrEmpty(strExtra))
-                                sbdReturn.Append(strExtra);
-                        });
+                                sb.Append(strExtra);
+                            return sb;
+                        }
                     }
 
                     return sbdReturn.ToString();
@@ -4105,14 +4135,28 @@ namespace Chummer.Backend.Skills
                     {
                         bool blnAmbi = await CharacterObject.GetAmbidextrousAsync(token).ConfigureAwait(false);
                         await (await CharacterObject.GetCyberwareAsync(token).ConfigureAwait(false)).ForEachAsync(async cyberware =>
+                            {
+                                sbdReturn = await BuildTooltipAsync(sbdReturn, cyberware);
+                            }
+                        , token).ConfigureAwait(false);
+
+                        async Task<StringBuilder> BuildTooltipAsync(StringBuilder sb, Cyberware cyberware)
                         {
+                            if (cyberware.Category == "Cybersuite")
+                            {
+                                foreach (var cyberwareChild in cyberware.Children)
+                                {
+                                    sb = await BuildTooltipAsync(sb, cyberwareChild);
+                                }
+                            }
+
                             if (cyberware.Category != "Cyberlimb" || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
-                                return;
-                            sbdReturn.AppendLine().AppendLine().Append(strExtraStart)
+                                return sb;
+                            sb.AppendLine().AppendLine().Append(strExtraStart)
                                 .Append(await cyberware.GetCurrentDisplayNameAsync(token).ConfigureAwait(false));
                             if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
                             {
-                                sbdReturn.Append(strSpace).Append('(').Append(await cyberware.Grade.GetCurrentDisplayNameAsync(token).ConfigureAwait(false))
+                                sb.Append(strSpace).Append('(').Append(await cyberware.Grade.GetCurrentDisplayNameAsync(token).ConfigureAwait(false))
                                     .Append(')');
                             }
 
@@ -4125,19 +4169,20 @@ namespace Chummer.Backend.Skills
                                 || blnAmbi
                                 || cyberware.LimbSlotCount > 1)
                             {
-                                sbdReturn.Append(strSpace).Append(pool.ToString(GlobalSettings.CultureInfo));
+                                sb.Append(strSpace).Append(pool.ToString(GlobalSettings.CultureInfo));
                             }
                             else
                             {
-                                sbdReturn.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})", pool - 2,
+                                sb.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})", pool - 2,
                                     strSpace, -2,
                                     await LanguageManager.GetStringAsync("Tip_Skill_OffHand", token: token)
                                         .ConfigureAwait(false));
                             }
 
                             if (!string.IsNullOrEmpty(strExtra))
-                                sbdReturn.Append(strExtra);
-                        }, token).ConfigureAwait(false);
+                                sb.Append(strExtra);
+                            return sb;
+                        }
                     }
 
                     if (att.Abbrev != Attribute)
@@ -4201,57 +4246,72 @@ namespace Chummer.Backend.Skills
                         await (await CharacterObject.GetCyberwareAsync(token).ConfigureAwait(false)).ForEachAsync(
                             async cyberware =>
                             {
-                                if (cyberware.Category != "Cyberlimb" || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
-                                    return;
-                                sbdReturn.AppendLine().AppendLine().Append(strExtraStart).Append(strExclude)
-                                         .Append(await LanguageManager.GetStringAsync("String_Colon", token: token)
-                                                                      .ConfigureAwait(false)).Append(strSpace)
-                                         .Append(await CharacterObject
-                                                       .GetObjectNameAsync(objSwapSkillAttribute, token: token)
-                                                       .ConfigureAwait(false)).Append(strSpace)
-                                         .Append(
-                                             await cyberware.GetCurrentDisplayNameAsync(token).ConfigureAwait(false));
-                                if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
-                                {
-                                    sbdReturn.Append(strSpace).Append('(').Append(
-                                                 await cyberware.Grade.GetCurrentDisplayNameAsync(token)
-                                                                .ConfigureAwait(false))
-                                             .Append(')');
-                                }
-
-                                int intLoopPool =
-                                    await PoolOtherAttributeAsync(objSwapSkillAttribute.ImprovedName, false,
-                                                                  await cyberware
-                                                                        .GetAttributeTotalValueAsync(
-                                                                            objSwapSkillAttribute.ImprovedName, token)
-                                                                        .ConfigureAwait(false), token)
-                                        .ConfigureAwait(false);
-                                if (objSpecialization != null)
-                                {
-                                    intLoopPool += await objSpecialization.GetSpecializationBonusAsync(token)
-                                                                          .ConfigureAwait(false);
-                                }
-
-                                if ((cyberware.LimbSlot != "arm"
-                                     && !cyberware.Name.ContainsAny(" Arm", " Hand"))
-                                    || cyberware.Location == CharacterObject.PrimaryArm
-                                    || blnAmbi
-                                    || cyberware.LimbSlotCount > 1)
-                                {
-                                    sbdReturn.Append(strSpace).Append(intLoopPool.ToString(GlobalSettings.CultureInfo));
-                                }
-                                else
-                                {
-                                    sbdReturn.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})",
-                                                           intLoopPool - 2, strSpace, -2,
-                                                           await LanguageManager
-                                                                 .GetStringAsync("Tip_Skill_OffHand", token: token)
-                                                                 .ConfigureAwait(false));
-                                }
-
-                                if (!string.IsNullOrEmpty(strExtra))
-                                    sbdReturn.Append(strExtra);
+                                sbdReturn = await BuildTooltipAsync(sbdReturn, cyberware);
                             }, token).ConfigureAwait(false);
+
+                        continue;
+                        async Task<StringBuilder> BuildTooltipAsync(StringBuilder sb, Cyberware cyberware)
+                        {
+                            if (cyberware.Category == "Cybersuite")
+                            {
+                                foreach (var cyberwareChild in cyberware.Children)
+                                {
+                                    sb = await BuildTooltipAsync(sb, cyberwareChild);
+                                }
+                            }
+
+                            if (cyberware.Category != "Cyberlimb" || !await cyberware.GetIsModularCurrentlyEquippedAsync(token).ConfigureAwait(false))
+                                return sb;
+                            sb.AppendLine().AppendLine().Append(strExtraStart).Append(strExclude)
+                                     .Append(await LanguageManager.GetStringAsync("String_Colon", token: token)
+                                                                  .ConfigureAwait(false)).Append(strSpace)
+                                     .Append(await CharacterObject
+                                                   .GetObjectNameAsync(objSwapSkillAttribute, token: token)
+                                                   .ConfigureAwait(false)).Append(strSpace)
+                                     .Append(
+                                         await cyberware.GetCurrentDisplayNameAsync(token).ConfigureAwait(false));
+                            if (cyberware.Grade.Name != "Standard" && cyberware.Grade.Name != "None")
+                            {
+                                sb.Append(strSpace).Append('(').Append(
+                                             await cyberware.Grade.GetCurrentDisplayNameAsync(token)
+                                                            .ConfigureAwait(false))
+                                         .Append(')');
+                            }
+
+                            int intLoopPool =
+                                await PoolOtherAttributeAsync(objSwapSkillAttribute.ImprovedName, false,
+                                                              await cyberware
+                                                                    .GetAttributeTotalValueAsync(
+                                                                        objSwapSkillAttribute.ImprovedName, token)
+                                                                    .ConfigureAwait(false), token)
+                                    .ConfigureAwait(false);
+                            if (objSpecialization != null)
+                            {
+                                intLoopPool += await objSpecialization.GetSpecializationBonusAsync(token)
+                                                                      .ConfigureAwait(false);
+                            }
+
+                            if ((cyberware.LimbSlot != "arm"
+                                 && !cyberware.Name.ContainsAny(" Arm", " Hand"))
+                                || cyberware.Location == CharacterObject.PrimaryArm
+                                || blnAmbi
+                                || cyberware.LimbSlotCount > 1)
+                            {
+                                sb.Append(strSpace).Append(intLoopPool.ToString(GlobalSettings.CultureInfo));
+                            }
+                            else
+                            {
+                                sb.AppendFormat(GlobalSettings.CultureInfo, "{1}{0}{1}({2}{1}{3})",
+                                                       intLoopPool - 2, strSpace, -2,
+                                                       await LanguageManager
+                                                             .GetStringAsync("Tip_Skill_OffHand", token: token)
+                                                             .ConfigureAwait(false));
+                            }
+
+                            if (!string.IsNullOrEmpty(strExtra))
+                                sb.Append(strExtra);
+                            return sb;
+                        }
                     }
 
                     return sbdReturn.ToString();

--- a/Chummer/Forms/Character Forms/CharacterCareer.cs
+++ b/Chummer/Forms/Character Forms/CharacterCareer.cs
@@ -19912,7 +19912,7 @@ namespace Chummer
                                                       x => x.Text = strCost,
                                                       token)
                                                   .ConfigureAwait(false);
-                            if (objCyberware.Category.Equals("Cyberlimb", StringComparison.Ordinal))
+                            if (objCyberware.IsLimb)
                             {
                                 await lblCyberlimbAGILabel.DoThreadSafeAsync(x => x.Visible = true, token)
                                                           .ConfigureAwait(false);

--- a/Chummer/Forms/Character Forms/CharacterCreate.cs
+++ b/Chummer/Forms/Character Forms/CharacterCreate.cs
@@ -14463,7 +14463,7 @@ namespace Chummer
                                              + await LanguageManager.GetStringAsync("String_NuyenSymbol", token: token).ConfigureAwait(false);
                             await lblCyberwareCost.DoThreadSafeAsync(x => x.Text = strCost, token)
                                                   .ConfigureAwait(false);
-                            if (objCyberware.Category.Equals("Cyberlimb", StringComparison.Ordinal)
+                            if (objCyberware.IsLimb
                                 || objCyberware.AllowedSubsystems.Contains("Cyberlimb"))
                             {
                                 await lblCyberlimbAGILabel.DoThreadSafeAsync(x => x.Visible = true, token)

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -5718,6 +5718,9 @@
       <id>92a3677e-cd4c-4ce1-9295-612281946709</id>
       <name>Aztechnology Cuanmiztli A</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>3.06</ess>
       <capacity>0</capacity>
       <avail>8R</avail>
@@ -5754,6 +5757,9 @@
       <id>1a112bdd-df4c-4f9f-94cd-f940fa597dda</id>
       <name>Aztechnology Cuanmiztli B</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>5.31</ess>
       <capacity>0</capacity>
       <avail>12F</avail>
@@ -5795,6 +5801,9 @@
       <id>42c65dfa-8135-4757-ac6e-d2ecbcf10c60</id>
       <name>Evo Atlantis</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.72</ess>
       <capacity>0</capacity>
       <avail>8</avail>
@@ -5834,6 +5843,9 @@
       <id>188068fe-fe38-4d67-afef-0fc3967e5ae1</id>
       <name>Horizon Experience!</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>1.08</ess>
       <capacity>0</capacity>
       <avail>12R</avail>
@@ -5884,6 +5896,9 @@
       <id>7e341285-c2db-4399-a592-68ab427d2b2e</id>
       <name>Renraku Tradejack</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.9</ess>
       <capacity>0</capacity>
       <avail>12</avail>
@@ -5920,6 +5935,9 @@
       <id>eee58e0b-acaf-4c7b-a59d-3667dcbcc95d</id>
       <name>Saeder-Krupp Cyberlogician</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.81</ess>
       <capacity>0</capacity>
       <avail>12</avail>
@@ -5962,6 +5980,9 @@
       <id>bd5ef116-0e9b-47c0-8285-231a2e3de4b5</id>
       <name>Shiawase Kacho</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.45</ess>
       <capacity>0</capacity>
       <avail>4</avail>
@@ -6236,6 +6257,9 @@
       <id>c1eea4ca-e536-45dc-8919-f18a716d47cc</id>
       <name>Spinrad Just a Little Edge</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>3.5</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -6286,6 +6310,9 @@
       <id>27a86814-3486-446e-acf0-10ad3ca2ddc1</id>
       <name>Spinrad Peak Performance</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>5.0</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -6341,6 +6368,9 @@
       <id>d245d0f4-191f-4b10-9662-75c27aac41f3</id>
       <name>Spinrad Super Athlete</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -6396,6 +6426,9 @@
       <id>d6286a7d-e5a5-4277-b1a7-772c23fbeee1</id>
       <name>Evo Freak</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
       <avail>18R</avail>
@@ -6482,14 +6515,20 @@
     </cyberware>
     <cyberware>
       <id>b5406b3c-44a5-4727-bafc-58ed4cda84b5</id>
+      <inheritattributes />
       <name>Evo Better Than Human</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
       <avail>16R</avail>
       <cost>275000</cost>
       <source>LCD</source>
       <page>206</page>
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <blocksmounts>ankle,knee,wrist,elbow,hip,shoulder</blocksmounts>
       <subsystems>
         <cyberware>
@@ -6574,6 +6613,9 @@
       <id>5eb13cce-2c2a-41d0-bd5c-5bdc25e5afbd</id>
       <name>Evo InHuman</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>5</ess>
       <capacity>0</capacity>
       <avail>18R</avail>
@@ -6663,6 +6705,9 @@
       <id>c34d37ff-8bc4-4b8f-809a-c1ad61452a75</id>
       <name>Transys-Erika Mind Boost</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>1</ess>
       <capacity>0</capacity>
       <avail>10</avail>
@@ -6731,6 +6776,9 @@
       <id>8c156d89-e919-48f9-997e-8d7271c76818</id>
       <name>Transys-Erika Mental Gymnast</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>2</ess>
       <capacity>0</capacity>
       <avail>20</avail>
@@ -6799,6 +6847,9 @@
       <id>63d7f3e9-058e-49c6-96fd-02e16a28d550</id>
       <name>Transys-Erika Front Line Mind</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
       <avail>14</avail>
@@ -6882,6 +6933,9 @@
       <id>77d5df71-6e69-495d-b51f-98036d01edc4</id>
       <name>Sony Cybersystems Infiltrator</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>3</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -6951,6 +7005,9 @@
       <id>2a7e2b70-d6c4-415c-bf57-23678e2d104e</id>
       <name>Sony Cybersystems Field Operative</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>2.5</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -7006,6 +7063,9 @@
       <id>d565a072-af08-47dd-85fb-9ca22eab2bec</id>
       <name>Sony Cybersystems Ultimate Warrior</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>5.0</ess>
       <capacity>0</capacity>
       <avail>22R</avail>
@@ -7079,6 +7139,9 @@
       <id>7143a27a-6544-4dea-a6dc-e9e350e9d306</id>
       <name>MCT Kaisatsu</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>2.0</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -7134,6 +7197,9 @@
       <id>92c835be-2152-4623-aa2f-a7967e456fe7</id>
       <name>MCT Abunai</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>3.5</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -7177,6 +7243,9 @@
       <id>6796a057-b452-4a74-96be-eb710a38977e</id>
       <name>MCT Kuro</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>5.25</ess>
       <capacity>0</capacity>
       <avail>22R</avail>
@@ -8222,6 +8291,9 @@
       <id>a77094da-bc4c-4856-a8a0-53d4e6b9a50c</id>
       <name>Siemens Cyberspine</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>2.09</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -8260,6 +8332,9 @@
       <id>6dd9013a-52c4-45be-a4a2-7210f5caa53b</id>
       <name>Siemens Cyberspine Upgrade (Elite Athletic)</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.22</ess>
       <capacity>0</capacity>
       <avail>12R</avail>
@@ -8283,6 +8358,9 @@
       <id>0f53caba-37ea-4676-8c6e-68b2d826ecd0</id>
       <name>Siemens Cyberspine Upgrade (Celestial Athletic)</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.22</ess>
       <capacity>0</capacity>
       <avail>17R</avail>
@@ -8307,6 +8385,9 @@
       <id>70d15d2b-739d-418b-a7fe-3f03dee79546</id>
       <name>Siemens Cyberspine Upgrade (Elite Warrior)</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>0.72</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -8330,6 +8411,9 @@
       <id>6a4ba6e2-0473-47dc-81f5-fd3a95e4b714</id>
       <name>Siemens Cyberspine Upgrade (Celestial Warrior)</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>1.44</ess>
       <capacity>0</capacity>
       <avail>22R</avail>
@@ -8354,6 +8438,9 @@
       <id>a8cff88e-9ea2-41da-9f72-9c45a438a418</id>
       <name>Zeiss Consortium MET2000 Elitepilot</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>2.23</ess>
       <capacity>0</capacity>
       <avail>12R</avail>
@@ -8387,6 +8474,9 @@
       <id>1d574ac6-b07f-46dd-ba06-c896ed2de5e8</id>
       <name>Zeiss Consortium MET2000 Fernspäher</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>1.22</ess>
       <capacity>0</capacity>
       <avail>11R</avail>
@@ -8455,6 +8545,9 @@
       <id>011bedb4-1145-4934-9bd9-dcd92cf296b5</id>
       <name>Zeiss Consortium MET2000 Sturmpionier</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>1.4</ess>
       <capacity>0</capacity>
       <avail>11R</avail>
@@ -8516,6 +8609,9 @@
       <id>78cfabfa-cf45-4ea0-830d-f092fa9b3a5f</id>
       <name>Zeiss Consortium MET2000 Sturmpionier - Trench Wires</name>
       <category>Cybersuite</category>
+      <inheritattributes />
+      <limbslot>all</limbslot>
+      <limbslot>all</limbslot>
       <ess>1.69</ess>
       <capacity>0</capacity>
       <avail>14R</avail>

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -5720,7 +5720,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>3.06</ess>
       <capacity>0</capacity>
       <avail>8R</avail>
@@ -5758,7 +5757,6 @@
       <name>Aztechnology Cuanmiztli B</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>5.31</ess>
       <capacity>0</capacity>
@@ -5803,7 +5801,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>0.72</ess>
       <capacity>0</capacity>
       <avail>8</avail>
@@ -5844,7 +5841,6 @@
       <name>Horizon Experience!</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>1.08</ess>
       <capacity>0</capacity>
@@ -5898,7 +5894,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>0.9</ess>
       <capacity>0</capacity>
       <avail>12</avail>
@@ -5936,7 +5931,6 @@
       <name>Saeder-Krupp Cyberlogician</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>0.81</ess>
       <capacity>0</capacity>
@@ -5981,7 +5975,6 @@
       <name>Shiawase Kacho</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>0.45</ess>
       <capacity>0</capacity>
@@ -6259,7 +6252,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>3.5</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -6311,7 +6303,6 @@
       <name>Spinrad Peak Performance</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>5.0</ess>
       <capacity>0</capacity>
@@ -6370,7 +6361,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -6427,7 +6417,6 @@
       <name>Evo Freak</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
@@ -6520,14 +6509,12 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
       <avail>16R</avail>
       <cost>275000</cost>
       <source>LCD</source>
       <page>206</page>
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <blocksmounts>ankle,knee,wrist,elbow,hip,shoulder</blocksmounts>
       <subsystems>
@@ -6614,7 +6601,6 @@
       <name>Evo InHuman</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>5</ess>
       <capacity>0</capacity>
@@ -6707,7 +6693,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>1</ess>
       <capacity>0</capacity>
       <avail>10</avail>
@@ -6778,7 +6763,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>2</ess>
       <capacity>0</capacity>
       <avail>20</avail>
@@ -6848,7 +6832,6 @@
       <name>Transys-Erika Front Line Mind</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>4.5</ess>
       <capacity>0</capacity>
@@ -6935,7 +6918,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>3</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -7007,7 +6989,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>2.5</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -7064,7 +7045,6 @@
       <name>Sony Cybersystems Ultimate Warrior</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>5.0</ess>
       <capacity>0</capacity>
@@ -7141,7 +7121,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>2.0</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -7199,7 +7178,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>3.5</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -7244,7 +7222,6 @@
       <name>MCT Kuro</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>5.25</ess>
       <capacity>0</capacity>
@@ -8293,7 +8270,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>2.09</ess>
       <capacity>0</capacity>
       <avail>10R</avail>
@@ -8334,7 +8310,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>0.22</ess>
       <capacity>0</capacity>
       <avail>12R</avail>
@@ -8359,7 +8334,6 @@
       <name>Siemens Cyberspine Upgrade (Celestial Athletic)</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>0.22</ess>
       <capacity>0</capacity>
@@ -8387,7 +8361,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>0.72</ess>
       <capacity>0</capacity>
       <avail>14R</avail>
@@ -8412,7 +8385,6 @@
       <name>Siemens Cyberspine Upgrade (Celestial Warrior)</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>1.44</ess>
       <capacity>0</capacity>
@@ -8439,7 +8411,6 @@
       <name>Zeiss Consortium MET2000 Elitepilot</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>2.23</ess>
       <capacity>0</capacity>
@@ -8475,7 +8446,6 @@
       <name>Zeiss Consortium MET2000 Fernspäher</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>1.22</ess>
       <capacity>0</capacity>
@@ -8547,7 +8517,6 @@
       <category>Cybersuite</category>
       <inheritattributes />
       <limbslot>all</limbslot>
-      <limbslot>all</limbslot>
       <ess>1.4</ess>
       <capacity>0</capacity>
       <avail>11R</avail>
@@ -8610,7 +8579,6 @@
       <name>Zeiss Consortium MET2000 Sturmpionier - Trench Wires</name>
       <category>Cybersuite</category>
       <inheritattributes />
-      <limbslot>all</limbslot>
       <limbslot>all</limbslot>
       <ess>1.69</ess>
       <capacity>0</capacity>


### PR DESCRIPTION
This is done by allowing the cybersuite to inherit attributes of their children and raising a ATT refresh when a cybersuite is added or removed. The relevant tooltips are updated to recursively add the children of Cybersuites.

fixes #5045 