### PR TITLE
Update System.Text.Json binding config

### DIFF
--- a/Chummer/app.config
+++ b/Chummer/app.config
@@ -104,7 +104,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.6" newVersion="6.0.0.6" />
+        <bindingRedirect oldVersion="0.0.0.0-7.0.0.3" newVersion="7.0.0.3" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />


### PR DESCRIPTION
Update the System.Text.Json binding config from 6.0.0.6 to 7.0.0.3 to match the installed package version.  I don't know how this got missed in the related nuget upgrade but I doubt it was intentional.

This fixes the SINners plugin, which was previously failing to load with:
`LoaderException 1: Could not load file or assembly 'System.Text.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51' or one of its dependencies. The system cannot find the file specified.`