### PR TITLE
Busted Cyberware Fix

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -17683,6 +17683,7 @@
       <name>Busted Cyberware</name>
       <karma>-4</karma>
       <category>Negative</category>
+      <limit>11</limit>
       <bonus>
         <addware>
           <name>Busted Ware</name>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -17684,6 +17684,7 @@
       <karma>-4</karma>
       <category>Negative</category>
       <limit>11</limit>
+      <chargenonly />
       <bonus>
         <addware>
           <name>Busted Ware</name>


### PR DESCRIPTION
Allows Busted Cyberware to be taken multiple times (a practical limit of 11 was set because any higher and you're just dead).

Also restricts quality to only be available at chargen. 

Source:

![Screenshot 2023-11-04 at 2 11 50 AM](https://github.com/chummer5a/chummer5a/assets/1766631/be766fbe-416c-48ca-b8f7-0a7b319070f9)


Testing this it actually works without issue. Buying multiple ranks simply gives you multiple prompts to identify your busted ware, and giving the same name in multiple prompts causes them to stack together. It assigned the correct number of Busted Cyberware implants, too. 