### PR TITLE
Setting Prototype Transhuman to <chargenonly />

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -11805,6 +11805,7 @@
       <name>Prototype Transhuman</name>
       <karma>10</karma>
       <category>Positive</category>
+      <chargenonly />
       <bonus>
         <prototypetranshuman>1</prototypetranshuman>
         <selectquality>


### PR DESCRIPTION
Setting Prototype Transhuman to `<chargenonly />` because it can only be taken at chargen and I'm pretty sure it doesn't even work at all when bought post-gen