### PR TITLE
Solid/Legendary Rep fix

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -3353,6 +3353,11 @@
       <bonus>
         <selecttext />
       </bonus>
+      <forbidden>
+        <oneof>
+          <quality>Legendary Rep</quality>
+        </oneof>
+      </forbidden>
       <source>RF</source>
       <page>149</page>
     </quality>
@@ -3365,6 +3370,11 @@
       <bonus>
         <selecttext />
       </bonus>
+      <forbidden>
+        <oneof>
+          <quality>Solid Rep</quality>
+        </oneof>
+      </forbidden>
       <source>RF</source>
       <page>149</page>
     </quality>


### PR DESCRIPTION
Sets Solid/Legendary Rep to prevent a character from taking the quality twice. Old behavior allows a character to take the quality twice, once at each level.


![image](https://github.com/chummer5a/chummer5a/assets/1766631/5df7fc32-ae19-4963-9533-9d346a195254)
