### PR TITLE
Change CL-180 to LTAV

### DIFF
--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -8570,7 +8570,7 @@
       <armor>12</armor>
       <avail>12</avail>
       <body>12</body>
-      <category>Rotorcraft</category>
+      <category>LTAV</category>
       <cost>82000</cost>
       <handling>4</handling>
       <pilot>4</pilot>


### PR DESCRIPTION
Per https://discord.com/channels/365227581018079232/365227867535310858/1213851439814942791

The Cargolifter Industries CL-180 was listed as a rotocraft. It sure looks blimpy to me. This changes the vehicle from a Rotocraft to LTAV.


![image](https://github.com/chummer5a/chummer5a/assets/1766631/e2381efa-dfae-4423-a59d-35af57c20134)
