### PR TITLE
Fixing Narcoject Dazzler

### DIFF
--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -18638,7 +18638,7 @@
       <rating>0</rating>
       <required>
         <weapondetails>
-          <conceal operation="greaterthanorequals">4</conceal>
+          <conceal operation="greaterthanequals">4</conceal>
         </weapondetails>
       </required>
     </accessory>


### PR DESCRIPTION
Fixes the Narcoject Dazzler, which was using `greaterthanorequals` when it should have been `greaterthanequals`

Resolves #5130 