### PR TITLE
Fixes Discounts for Dedicated Qualities

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -14999,6 +14999,7 @@
             <quality>Aware</quality>
             <quality>Enchanter</quality>
             <quality>Explorer</quality>
+            <quality>Adept</quality>
           </oneof>
         </required>
         <value>-5</value>
@@ -15035,6 +15036,7 @@
             <quality>Aware</quality>
             <quality>Enchanter</quality>
             <quality>Explorer</quality>
+            <quality>Adept</quality>
           </oneof>
         </required>
         <value>-5</value>

--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -14996,7 +14996,6 @@
           <oneof>
             <quality>Apprentice</quality>
             <quality>Aspected Magician</quality>
-            <quality>Aware</quality>
             <quality>Enchanter</quality>
             <quality>Explorer</quality>
             <quality>Adept</quality>
@@ -15033,7 +15032,6 @@
           <oneof>
             <quality>Apprentice</quality>
             <quality>Aspected Magician</quality>
-            <quality>Aware</quality>
             <quality>Enchanter</quality>
             <quality>Explorer</quality>
             <quality>Adept</quality>


### PR DESCRIPTION
This removes Aware from the cost discount of Dedicated Conjurer/Spellslinger, and adds Adept to the list. Supporting RAW below:

![Screenshot 2024-10-22 at 4 36 40 AM](https://github.com/user-attachments/assets/a2f551b4-f56c-4ac2-acc6-f7aac84cf5b5)

The cost Discount on the Dedicated qualities applies to Adpected Magicians, per FA page 36.


![Screenshot 2024-10-22 at 4 39 26 AM](https://github.com/user-attachments/assets/dbb1b00e-39e2-4037-8a74-cd98da79bc52)


FA page 105 provides us with a breakdown of magic, including a definition of what falls into the category of Aspected Magician. This list includes Physical Adepts. This list does not include Aware, who are instead categorized as "Sparks".

