### PR TITLE
Fixes GUID on the 4e Critter manifest

### DIFF
--- a/Chummer/customdata/4e Critters Conversion/manifest.xml
+++ b/Chummer/customdata/4e Critters Conversion/manifest.xml
@@ -18,7 +18,7 @@
     https://github.com/chummer5a/chummer5a
 -->
   <manifest xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.w3.org/2001/XMLSchema ../manifest.xsd">
-    <guid>3C9636B8-F5F6-49D4-AE8F-12F8F8371334</guid>
+    <guid>aa284bba-1130-43a0-9915-f0cdfc3552c3</guid>
     <version>1</version>
     <authors>
       <author>


### PR DESCRIPTION
Custom Data manifests for "4e Critters Conversion" and "Adapsin applied as mult, not grade" have the same GUID, which causes Chummer to ignore the Adapsin CD
