### PR TITLE
Fixing Disrupt Focus name

### DIFF
--- a/Chummer/data/spells.xml
+++ b/Chummer/data/spells.xml
@@ -1376,7 +1376,7 @@
     </spell>
     <spell>
       <id>5c9218f6-bdb4-46a5-89ce-00b4adfe0429</id>
-      <name>Disrupt [Object]</name>
+      <name>Disrupt [Focus]</name>
       <page>102</page>
       <source>SG</source>
       <category>Combat</category>


### PR DESCRIPTION
![Screenshot 2025-02-06 at 2 52 09 AM](https://github.com/user-attachments/assets/967fa5a3-0b52-42af-af6b-7b0bed660934)


The Spell is called Disrupt [Focus] in the book. For some reason the data files had it down as Disrupt [Object]


Unclear if it's supposed to be "Select a focus category" or "select a specific type of focus" or what.