### PR TITLE
Fixing Dual-Natured Defender Prerequesites

### DIFF
--- a/Chummer/data/qualities.xml
+++ b/Chummer/data/qualities.xml
@@ -15070,14 +15070,12 @@
       <required>
         <allof>
           <magenabled />
-        </allof>
-        <oneof>
           <critterpower>Dual Natured</critterpower>
           <skill>
             <name>Astral Combat</name>
             <val>3</val>
           </skill>
-        </oneof>
+        </allof>
       </required>
       <source>FA</source>
       <page>36</page>


### PR DESCRIPTION
Fixes the prerequisite for Dual-Natured Defender to require both Dual Natured AND Astral Combat 3


![Screenshot 2025-04-19 at 9 13 34 PM](https://github.com/user-attachments/assets/184813de-42ac-4662-b3d0-ef5eb625cd2d)
