### PR TITLE
Structural Fix on Database

### DIFF
--- a/Chummer/data/armor.xml
+++ b/Chummer/data/armor.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <!--This file is part of Chummer5a.
 
     Chummer5a is free software: you can redistribute it and/or modify
@@ -4254,6 +4254,7 @@
       <id>0a7930f5-5466-439a-956d-2bba57f25ed9</id>
       <name>Parachute (Urban Explorer Daedalus)</name>
       <category>General</category>
+      <armor>0</armor>
       <hide />
       <maxrating>0</maxrating>
       <armorcapacity>[0]</armorcapacity>
@@ -4286,6 +4287,7 @@
       <category>General</category>
       <armor>0</armor>
       <maxrating>1</maxrating>
+      <armorcapacity>[0]</armorcapacity>
       <avail>4</avail>
       <cost>0</cost>
       <source>KC</source>

--- a/Chummer/data/critterpowers.xml
+++ b/Chummer/data/critterpowers.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -1750,420 +1750,6 @@
       <page>85</page>
     </power>
     <power>
-      <id>9c5bcd33-ef29-487a-8f3d-5c4f3b314723</id>
-      <name>NeuroFilter</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>SR4</source>
-      <page>243</page>
-    </power>
-    <power>
-      <id>16cd3fa6-e4c8-4980-90d5-59bfeb41b5e5</id>
-      <name>Overclocking</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <matrixinitiativediceadd>1</matrixinitiativediceadd>
-      </bonus>
-      <source>SR4</source>
-      <page>244</page>
-    </power>
-    <power>
-      <id>a6d7482a-2cef-4ab9-8d45-71c0926003bb</id>
-      <name>Resonance Link</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>SR4</source>
-      <page>244</page>
-    </power>
-    <power>
-      <id>c3306789-1ac8-4162-819b-709457b21470</id>
-      <name>System Upgrade</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <livingpersona>
-          <system>1</system>
-        </livingpersona>
-      </bonus>
-      <source>SR4</source>
-      <page>244</page>
-    </power>
-    <power>
-      <id>749f73b1-f131-4a3d-82d9-9d952bc7e16c</id>
-      <name>Amplification</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <livingpersona>
-          <signal>1</signal>
-        </livingpersona>
-      </bonus>
-      <source>UN</source>
-      <page>145</page>
-    </power>
-    <power>
-      <id>39e8b6b2-165f-4c3b-ab67-c61166c4d331</id>
-      <name>Biowire</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <skillwire>Rating</skillwire>
-      </bonus>
-      <source>UN</source>
-      <page>145</page>
-    </power>
-    <power>
-      <id>b2a4a9b7-fe37-4a03-8fd5-21b497d3bf8e</id>
-      <name>Blur</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>145</page>
-    </power>
-    <power>
-      <id>7fa1db24-93cd-45dd-866a-66bb6940f0a4</id>
-      <name>Coenesthesia</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>145</page>
-    </power>
-    <power>
-      <id>bb21e7d0-0415-4e0e-8ab0-12b866c44d70</id>
-      <name>Defragmentation</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>145</page>
-    </power>
-    <power>
-      <id>3c3c2ac3-9d6a-4a29-8d93-4749dfdde03a</id>
-      <name>E-sensing</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>146</page>
-    </power>
-    <power>
-      <id>d4aaf380-eeae-4ee7-a7c3-6004e0fb52c6</id>
-      <name>Flexible Touch</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>146</page>
-    </power>
-    <power>
-      <id>ce6d38b3-fdb3-4829-979d-381249cc4f18</id>
-      <name>Immersion</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>146</page>
-    </power>
-    <power>
-      <id>32f639a6-4e1a-4077-ad59-965efc42daeb</id>
-      <name>Living ECM</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>146</page>
-    </power>
-    <power>
-      <id>35c92b6e-d409-41f9-aa2e-2dafbfbc184b</id>
-      <name>Macro</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>146</page>
-    </power>
-    <power>
-      <id>94fb2fed-bc9d-4090-b103-7f8b0ea86d24</id>
-      <name>Multiprocessing</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>re
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>146</page>
-    </power>
-    <power>
-      <id>16c51017-0e50-413d-bd17-889f7d35e5a7</id>
-      <name>Sift</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>b804f306-b023-4431-811f-22825167165e</id>
-      <name>Skinlink</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>2330af39-6e97-49c0-927a-d23633170e5d</id>
-      <name>Sprite Link</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <selectsprite />
-      </bonus>
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>04f8ba5a-2e12-46b7-a032-7e826658dbca</id>
-      <name>Swap</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>5b3b3212-1ca5-4a82-9ac3-d2a31b8c34c1</id>
-      <name>Widget Crafting</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>0f0b2ab2-3f71-43e6-b815-d9f6f5c6ed60</id>
-      <name>Acceleration</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <initiativepassadd>1</initiativepassadd>
-      </bonus>
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>728df266-8d80-4da5-bcd8-7085958ea083</id>
-      <name>Advanced Overclocking</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus>
-        <matrixinitiativediceadd>1</matrixinitiativediceadd>
-      </bonus>
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>1a192b38-0a18-41b2-9c49-8fa183c9a4c9</id>
-      <name>Enhanced Resonance Link</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>f8dd2f09-e3e8-417c-a42b-69355f7777ff</id>
-      <name>Mesh Reality</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>147</page>
-    </power>
-    <power>
-      <id>ba6c1006-ab3a-4424-b803-eff2813ba392</id>
-      <name>Mind Over Machine</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>148</page>
-    </power>
-    <power>
-      <id>bfb370b9-0ee7-4107-a87a-0dbc33205851</id>
-      <name>Resonance Exchange</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>148</page>
-    </power>
-    <power>
-      <id>7a9c3d97-22b3-4a74-b19a-490eab195100</id>
-      <name>Resonance Trodes</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>148</page>
-    </power>
-    <power>
-      <id>57538d5d-7355-4a93-8849-c67068af9e73</id>
-      <name>Connectivity</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>WAR</source>
-      <page>179</page>
-    </power>
-    <power>
-      <id>4077198b-f469-4e7d-b16b-1db046378780</id>
-      <name>Feral Resonance</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>WAR</source>
-      <page>179</page>
-    </power>
-    <power>
-      <id>17b23235-76e1-491d-9c8a-b7a043537427</id>
-      <name>Bio-Radar</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>WAR</source>
-      <page>179</page>
-    </power>
-    <power>
-      <id>97e0ae7e-3dce-4782-8d7e-3dfb93bd42ad</id>
-      <name>Contaminate</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>178</page>
-    </power>
-    <power>
-      <id>cd285642-e0db-47fe-8f55-2f85c8a5ec1c</id>
-      <name>Malfunction</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>179</page>
-    </power>
-    <power>
-      <id>80d66ca5-a96a-43de-bad3-84ab78231a57</id>
-      <name>Pryon</name>
-      <category>Echoes</category>
-      <type>P</type>
-      <action>Special</action>
-      <range>Special</range>
-      <duration>Special</duration>
-      <bonus />
-      <source>UN</source>
-      <page>179</page>
-    </power>
-    <power>
       <id>df67deb5-91e4-47bc-9af8-baf60fc2311d</id>
       <name>Concealment (Self Only)</name>
       <category>Paranormal</category>
@@ -2594,7 +2180,7 @@
     </power>
     <power>
       <id>dba6b163-0466-4fa1-998a-0a5ac74edba9</id>
-      <name>Enhanced Sense (Wide Band Hearing)</name>
+      <name>Enhanced Sense (Wide-Band Hearing)</name>
       <category>Drake</category>
       <type>P</type>
       <action>Auto</action>
@@ -2606,7 +2192,7 @@
     </power>
     <power>
       <id>27488146-76d0-454c-b375-a63ccc492b70</id>
-      <name>Enhanced Sense (Low Light Vision)</name>
+      <name>Enhanced Sense (Low-Light Vision)</name>
       <category>Drake</category>
       <type>P</type>
       <action>Auto</action>
@@ -4413,7 +3999,7 @@
     </power>
     <power>
       <id>048c7ca6-d626-415e-baae-80246091b8e1</id>
-      <name>Enhanced Sense (Low Light Vision)</name>
+      <name>Enhanced Sense (Low-Light Vision)</name>
       <category>Chimeric Modification</category>
       <type />
       <action />
@@ -4827,6 +4413,78 @@
       <duration />
       <source>HS</source>
       <page>173</page>
+    </power>
+    <!-- End Region -->
+    <!-- Region Automotive Powers -->
+    <power>
+      <id>e16964a0-5a6e-47ef-8f04-d3ee81ceb411</id>
+      <name>Evasion</name>
+      <category>Paranormal</category>
+      <type />
+      <rating>True</rating>
+      <action>Auto</action>
+      <range>Self</range>
+      <duration>Always</duration>
+      <source>FA</source>
+      <page>180</page>
+      <notes>These operate similarly to the autosofts of the same name, with a Rating that matches the spirit's Force.</notes>
+      <hide />
+    </power>
+    <power>
+      <id>fe3beeae-0b61-4fd1-9c6d-1b47c98ce20d</id>
+      <name>Maneuvering</name>
+      <category>Paranormal</category>
+      <type />
+      <rating>True</rating>
+      <action>Auto</action>
+      <range>Self</range>
+      <duration>Always</duration>
+      <source>FA</source>
+      <page>180</page>
+      <notes>These operate similarly to the autosofts of the same name, with a Rating that matches the spirit's Force.</notes>
+      <hide />
+    </power>
+    <power>
+      <id>d3cbc66d-1586-4e86-ab0c-6287506dbd74</id>
+      <name>Stealth</name>
+      <category>Paranormal</category>
+      <type />
+      <rating>True</rating>
+      <action>Auto</action>
+      <range>Self</range>
+      <duration>Always</duration>
+      <source>FA</source>
+      <page>180</page>
+      <notes>These operate similarly to the autosofts of the same name, with a Rating that matches the spirit's Force.</notes>
+      <hide />
+    </power>
+    <!-- End Region -->
+    <!-- Region Automotive Powers -->
+    <power>
+      <id>93484499-4977-45b7-a722-1b58157d7708</id>
+      <name>Fold Perception</name>
+      <category>Free Spirit</category>
+      <type />
+      <action />
+      <range />
+      <duration />
+      <source>HS</source>
+      <page>120</page>
+      <hide />
+      <notes>Alters how space is perceived, making areas seem larger or distorted without changing physical structure. Can affect both physical and astral senses.</notes>
+    </power>
+    <power>
+      <id>6c915799-73ba-470a-b333-b8808127415e</id>
+      <name>Agonizing Pain</name>
+      <category>Free Spirit</category>
+      <type />
+      <action />
+      <range />
+      <duration />
+      <source>HS</source>
+      <page>132</page>
+      <hide />
+      <notes>Induces intense physical and mental agony by embedding barbed tentacles into the target. Movement increases the pain and further debilitates the victim, feeding off the emotional energy generated by the suffering.</notes>
     </power>
     <!-- End Region -->
   </powers>

--- a/Chummer/data/critters.xml
+++ b/Chummer/data/critters.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="UTF-8"?>
+﻿<?xml version="1.0" encoding="UTF-8"?>
 <!--This file is part of Chummer5a.
 
     Chummer5a is free software: you can redistribute it and/or modify
@@ -3385,7 +3385,7 @@
       </metatype>
       <metatype>
          <id>3ac65435-45f1-4d78-ad90-42fbd36b1a85</id>
-         <name>Baboon</name>
+         <name>Ozian Baboon</name>
          <category>Paranormal Critters</category>
          <karma>0</karma>
          <bodmin>5</bodmin>
@@ -5405,88 +5405,6 @@
          <page>77</page>
       </metatype>
       <metatype>
-         <id>dcc973b7-db4f-4f48-8170-61bdb104a3f9</id>
-         <name>Wyrd Mantis</name>
-         <category>Paranormal Critters</category>
-         <karma>0</karma>
-         <bodmin>4</bodmin>
-         <bodmax>4</bodmax>
-         <bodaug>4</bodaug>
-         <agimin>4</agimin>
-         <agimax>4</agimax>
-         <agiaug>4</agiaug>
-         <reamin>4</reamin>
-         <reamax>4</reamax>
-         <reaaug>4</reaaug>
-         <strmin>3</strmin>
-         <strmax>3</strmax>
-         <straug>3</straug>
-         <chamin>2</chamin>
-         <chamax>2</chamax>
-         <chaaug>2</chaaug>
-         <intmin>4</intmin>
-         <intmax>4</intmax>
-         <intaug>4</intaug>
-         <logmin>2</logmin>
-         <logmax>2</logmax>
-         <logaug>2</logaug>
-         <wilmin>3</wilmin>
-         <wilmax>3</wilmax>
-         <wilaug>3</wilaug>
-         <inimin>2</inimin>
-         <inimax>14</inimax>
-         <iniaug>14</iniaug>
-         <edgmin>3</edgmin>
-         <edgmax>3</edgmax>
-         <edgaug>3</edgaug>
-         <magmin>4</magmin>
-         <magmax>7</magmax>
-         <magaug>7</magaug>
-         <resmin>0</resmin>
-         <resmax>6</resmax>
-         <resaug>6</resaug>
-         <depmin>0</depmin>
-         <depmax>0</depmax>
-         <depaug>0</depaug>
-         <essmin>0</essmin>
-         <essmax>6</essmax>
-         <essaug>6</essaug>
-         <movement>5/25</movement>
-         <bonus>
-            <enableattribute>
-               <name>MAG</name>
-               <min>1</min>
-               <max>7</max>
-               <aug>7</aug>
-               <val>4</val>
-            </enableattribute>
-            <enabletab>
-               <name>critter</name>
-            </enabletab>
-            <initiativepass>1</initiativepass>
-         </bonus>
-         <powers>
-            <power>Adaptive Coloration</power>
-            <power rating="2">Armor (Ballistic)</power>
-            <power rating="2">Armor (Impact)</power>
-            <power select="Low-Light Vision">Enhanced Senses</power>
-            <power select="Toxins">Immunity</power>
-            <power>Influence</power>
-            <power>Venom</power>
-            <power>Noxious Breath</power>
-         </powers>
-         <skills>
-            <skill rating="3">Gymnastics</skill>
-            <skill rating="4">Infiltration</skill>
-            <skill rating="3">Perception</skill>
-            <skill rating="2">Running</skill>
-            <skill rating="1">Shadowing</skill>
-            <skill rating="4">Unarmed Combat</skill>
-         </skills>
-         <source>RW</source>
-         <page>151</page>
-      </metatype>
-      <metatype>
          <id>bcae204e-e162-42d1-8cf0-6a4aec5c5c42</id>
          <name>Bandit</name>
          <category>Paranormal Critters</category>
@@ -5908,9 +5826,21 @@
          <wilmin>1</wilmin>
          <wilmax>1</wilmax>
          <wilaug>5</wilaug>
+         <inimin>3</inimin>
+         <inimax>3</inimax>
+         <iniaug>11</iniaug>
          <edgmin>3</edgmin>
          <edgmax>3</edgmax>
          <edgaug>7</edgaug>
+         <magmin>0</magmin>
+         <magmax>6</magmax>
+         <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -5962,12 +5892,21 @@
          <wilmin>2</wilmin>
          <wilmax>2</wilmax>
          <wilaug>6</wilaug>
+         <inimin>8</inimin>
+         <inimax>8</inimax>
+         <iniaug>16</iniaug>
          <edgmin>1</edgmin>
          <edgmax>1</edgmax>
          <edgaug>5</edgaug>
          <magmin>6</magmin>
          <magmax>6</magmax>
          <magaug>10</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -6022,15 +5961,27 @@
          <wilmin>4</wilmin>
          <wilmax>4</wilmax>
          <wilaug>8</wilaug>
+         <inimin>16</inimin>
+         <inimax>16</inimax>
+         <iniaug>24</iniaug>
          <edgmin>2</edgmin>
          <edgmax>2</edgmax>
          <edgaug>6</edgaug>
+         <magmin>0</magmin>
+         <magmax>6</magmax>
+         <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
          <walk>2/1/0</walk>
          <run>6/0/0</run>
-         <sprint>5*/1/0</sprint>
+         <sprint>5/1/0</sprint>
          <armor>4</armor>
          <skills>
             <skill rating="5">Gymnastics</skill>
@@ -6079,12 +6030,21 @@
          <wilmin>5</wilmin>
          <wilmax>5</wilmax>
          <wilaug>9</wilaug>
+         <inimin>12</inimin>
+         <inimax>12</inimax>
+         <iniaug>20</iniaug>
          <edgmin>3</edgmin>
          <edgmax>3</edgmax>
          <edgaug>7</edgaug>
          <magmin>6</magmin>
          <magmax>6</magmax>
          <magaug>10</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -6138,9 +6098,21 @@
          <wilmin>1</wilmin>
          <wilmax>1</wilmax>
          <wilaug>5</wilaug>
+         <inimin>3</inimin>
+         <inimax>3</inimax>
+         <iniaug>11</iniaug>
          <edgmin>3</edgmin>
          <edgmax>3</edgmax>
          <edgaug>7</edgaug>
+         <magmin>0</magmin>
+         <magmax>6</magmax>
+         <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -6154,7 +6126,7 @@
             <skill rating="3">Unarmed Combat</skill>
          </skills>
          <powers>
-            <power select="DV 2P, AP -3">Natural Weapon (Fang)</power>
+            <power select="Fang: DV 2P, AP -3">Natural Weapon</power>
             <power select="Contact">Venom</power>
          </powers>
          <bonus>
@@ -6193,12 +6165,21 @@
          <wilmin>3</wilmin>
          <wilmax>3</wilmax>
          <wilaug>7</wilaug>
+         <inimin>10</inimin>
+         <inimax>10</inimax>
+         <iniaug>18</iniaug>
          <edgmin>2</edgmin>
          <edgmax>2</edgmax>
          <edgaug>2</edgaug>
          <magmin>4</magmin>
          <magmax>6</magmax>
          <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>0</essmin>
          <essmax>6</essmax>
          <essaug>6</essaug>
@@ -6268,9 +6249,21 @@
          <wilmin>1</wilmin>
          <wilmax>1</wilmax>
          <wilaug>5</wilaug>
+         <inimin>4</inimin>
+         <inimax>4</inimax>
+         <iniaug>12</iniaug>
          <edgmin>2</edgmin>
          <edgmax>2</edgmax>
          <edgaug>6</edgaug>
+         <magmin>0</magmin>
+         <magmax>6</magmax>
+         <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -6325,9 +6318,21 @@
          <wilmin>6</wilmin>
          <wilmax>6</wilmax>
          <wilaug>10</wilaug>
+         <inimin>9</inimin>
+         <inimax>9</inimax>
+         <iniaug>17</iniaug>
          <edgmin>3</edgmin>
          <edgmax>3</edgmax>
          <edgaug>7</edgaug>
+         <magmin>0</magmin>
+         <magmax>6</magmax>
+         <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -6378,9 +6383,21 @@
          <wilmin>1</wilmin>
          <wilmax>1</wilmax>
          <wilaug>5</wilaug>
+         <inimin>10</inimin>
+         <inimax>10</inimax>
+         <iniaug>18</iniaug>
          <edgmin>2</edgmin>
          <edgmax>2</edgmax>
          <edgaug>2</edgaug>
+         <magmin>0</magmin>
+         <magmax>6</magmax>
+         <magaug>6</magaug>
+         <resmin>0</resmin>
+         <resmax>6</resmax>
+         <resaug>6</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>0</essmin>
          <essmax>6</essmax>
          <essaug>6</essaug>
@@ -6801,7 +6818,7 @@
             <power select="Hearing, Smell, Motion Detection, Thermosense">Enhanced Senses</power>
             <power select="Toxins">Immunity</power>
             <power select="Bite: (STR+4)P, AP -6">Natural Weapon</power>
-            <power select="Spit">Substance Extrusion</power>
+            <power select="Spit">Secretion/Substance Extrusion</power>
             <power select="Spit">Venom</power>
             <power select="Vector: Contact, Injection, Speed: Instant, Penetration: -6, Power: 12, Effect: Agony, Nausea, Disorientation, Physical Damage">Vulnerability</power>
          </powers>
@@ -6877,7 +6894,7 @@
             <power rating="4">Armor</power>
             <power select="Hearing, Low-Light Vision, Smell">Enhanced Senses</power>
             <power select="Claws/Bite: (STR+2)P">Natural Weapon</power>
-            <power select="Spit">Substance Extrusion</power>
+            <power select="Spit">Secretion/Substance Extrusion</power>
             <power select="Vector: Injection, Speed: 1 Combat Turn, Penetration: 0, Power: 6, Effect: Malaise, Physical Damage">Venom</power>
             <power select="Sunlight, Mild">Allergy</power>
          </powers>
@@ -7601,10 +7618,10 @@
             <power>Sense Link</power>
          </powers>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <source>SG</source>
          <page>200</page>
@@ -8524,11 +8541,11 @@
             <power>Search</power>
          </powers>
          <skills>
-            <skill>Artisan</skill>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Artisan</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <source>SG</source>
          <page>193</page>
@@ -8731,7 +8748,7 @@
          <chamin>F+1</chamin>
          <chamax>F+1</chamax>
          <chaaug>F+1</chaaug>
-         <intmin>(F</intmin>
+         <intmin>F</intmin>
          <intmax>F</intmax>
          <intaug>F</intaug>
          <logmin>F</logmin>
@@ -8788,7 +8805,7 @@
             <power>Deathly Aura</power>
             <power select="Essence">Energy Drain</power>
             <power>Fear</power>
-            <power> Magical Guard</power>
+            <power>Magical Guard</power>
             <power>Mimicry</power>
             <power select="Bones">Possession</power>
             <power>Realistic Form</power>
@@ -10054,14 +10071,14 @@
             <unlockskills>Magician</unlockskills>
          </bonus>
          <powers>
-            <power>Evasion</power>
-            <power>Maneuvering</power>
+            <power rating="F">Evasion</power>
+            <power rating="F">Maneuvering</power>
             <power>Materialization</power>
             <power>Sapience</power>
-            <power>Stealth</power>
+            <power rating="F">Stealth</power>
          </powers>
          <skills>
-            <skill rating="F">Free-fall</skill>
+            <skill rating="F">Free-Fall</skill>
             <skill rating="F">Navigation</skill>
             <skill rating="F">Perception</skill>
             <skill rating="F">Pilot Aircraft</skill>
@@ -10138,7 +10155,7 @@
             <power>Astral Form</power>
             <power rating="14">Armor</power>
             <power>Banishing Resistance</power>
-            <power rating="LOS, Touch, and Self">Binding</power>
+            <power select="LOS, Touch, and Self">Binding</power>
             <power>Concealment</power>
             <power>Engulf</power>
             <power>Materialization</power>
@@ -10220,15 +10237,19 @@
             </enabletab>
             <initiativepass>1</initiativepass>
          </bonus>
+         <qualities>
+            <positive>
+               <quality>Astral Perception</quality>
+            </positive>
+         </qualities>
          <powers>
             <power>Astral Form</power>
-            <power>Astral Perception</power>
             <power>Banishing Resistance</power>
             <power>Concealment</power>
             <power>Confusion</power>
-            <power>Devour</power>
+            <power>Devouring</power>
             <power rating="6">Hardened Armor</power>
-            <power rating="Living Vessels">Inhabitation</power>
+            <power select="Living Vessels">Inhabitation</power>
             <power>Movement</power>
             <power>Sapience</power>
             <power>Search</power>
@@ -10240,7 +10261,7 @@
             <skill rating="F">Astral Combat</skill>
             <skill rating="F">Perception</skill>
             <skill rating="F">Running</skill>
-            <skill rating="F">Shadowing</skill>
+            <skill rating="F">Sneaking</skill>
             <skill rating="F">Unarmed Combat</skill>
          </skills>
          <source>AET</source>
@@ -10314,11 +10335,11 @@
             <power>Accident</power>
             <power>Astral Form</power>
             <power>Banishing Resistance</power>
-            <power rating="Low-Light-Vision, Thermographic Vision, Spatial Sense">Enhanced Senses</power>
+            <power select="Low-Light-Vision, Thermographic Vision, Spatial Sense">Enhanced Senses</power>
             <power>Materialization</power>
             <power>Paralyzing Touch</power>
             <power>Sapience</power>
-            <power>Sillence</power>
+            <power>Silence</power>
             <power>Vanishing</power>
          </powers>
          <optionalpowers />
@@ -10401,13 +10422,13 @@
             <power>Astral Form</power>
             <power>Aura Masking</power>
             <power>Banishing Resistance</power>
-            <power rating="Essence">Energy Drain</power>
-            <power rating="Thermographic Vision">Enhanced Senses</power>
-            <power rating="Foreboding">Innate Spell</power>
-            <power rating="Living Vessels">Inhabitation</power>
+            <power select="Essence">Energy Drain</power>
+            <power select="Thermographic Vision">Enhanced Senses</power>
+            <power select="Foreboding">Innate Spell</power>
+            <power select="Living Vessels">Inhabitation</power>
             <power>Materialization</power>
             <power>Sapience</power>
-            <power rating="Metahuman">Shift</power>
+            <power select="Metahuman">Shift</power>
             <power>Transfer Energy (Essence)</power>
             <power>Vanishing</power>
          </powers>
@@ -10491,12 +10512,12 @@
             <power>Accident</power>
             <power>Aura Masking</power>
             <power>Desire Reflection</power>
-            <power rating="Karma">Energy Drain</power>
+            <power select="Karma">Energy Drain</power>
             <power>Influence</power>
-            <power rating="Alter Memory">Innate Spell</power>
+            <power select="Alter Memory">Innate Spell</power>
             <power>Movement</power>
-            <power rating="Inanimate Mechanical Devices Only">Inhabitation</power>
-            <power rating="Occupied Mechanical Device Only">Psychokinesis</power>
+            <power select="Inanimate Mechanical Devices Only">Inhabitation</power>
+            <power select="Occupied Mechanical Device Only">Psychokinesis</power>
          </powers>
          <optionalpowers />
          <skills>
@@ -10560,7 +10581,7 @@
          <essmin>0</essmin>
          <essmax>6</essmax>
          <essaug>6</essaug>
-         <walk>0/0/(0</walk>
+         <walk>0/0/0</walk>
          <run>0/0/0</run>
          <sprint>2/2/2</sprint>
          <bonus>
@@ -10577,22 +10598,20 @@
             <initiativepass>1</initiativepass>
          </bonus>
          <powers>
-            <power rating="Spider Type">Animal Control</power>
+            <power select="Spider Type">Animal Control</power>
             <power>Astral Form</power>
-            <power rating="Touch">Binding</power>
+            <power select="Touch">Binding</power>
             <power>Concealment</power>
-            <power rating="Smell, Thermographic Vision, or Ultrasound">Enhanced Senses</power>
+            <power select="Smell, Thermographic Vision, or Ultrasound">Enhanced Senses</power>
             <power>Movement</power>
             <power>Reinforcement</power>
             <power>Sapience</power>
             <power>Search</power>
          </powers>
-         <optionalpowers />
          <skills>
             <skill rating="F">Assensing</skill>
             <skill rating="F">Astral Combat</skill>
-            <skill rating="F">Dodge</skill>
-            <skill rating="F">Infiltration</skill>
+            <skill rating="F" spec="Dodging">Gymnastics</skill>
             <skill rating="F">Perception</skill>
             <skill rating="F">Sneaking</skill>
             <skill rating="F">Unarmed Combat</skill>
@@ -10648,7 +10667,7 @@
          <essmin>0</essmin>
          <essmax>6</essmax>
          <essaug>6</essaug>
-         <walk>0/0/(0</walk>
+         <walk>0/0/0</walk>
          <run>0/0/0</run>
          <sprint>2/2/2</sprint>
          <bonus>
@@ -10666,7 +10685,7 @@
          </bonus>
          <powers>
             <power>Astral Form</power>
-            <power rating="LOS">Binding</power>
+            <power select="LOS">Binding</power>
             <power>Fear</power>
             <power>Natural Weapon</power>
             <power>Reinforcement</power>
@@ -11151,7 +11170,6 @@
                <name>Beetle</name>
                <karma>0</karma>
                <forcecreature />
-               <karma>0</karma>
                <bodmin>F</bodmin>
                <bodmax>F</bodmax>
                <bodaug>F</bodaug>
@@ -17724,10 +17742,10 @@
             <optionalpower>Silence</optionalpower>
          </optionalpowers>
          <skills>
-            <skill rating="F">Gymnastics</skill>
             <skill rating="F">Assensing</skill>
             <skill rating="F">Astral Combat</skill>
             <skill rating="F">Blades</skill>
+            <skill rating="F">Gymnastics</skill>
             <skill rating="F">Perception</skill>
             <skill rating="F">Running</skill>
             <skill rating="F">Sneaking</skill>
@@ -17828,10 +17846,10 @@
             <optionalpower>Silence</optionalpower>
          </optionalpowers>
          <skills>
-            <skill rating="F">Gymnastics</skill>
             <skill rating="F">Assensing</skill>
             <skill rating="F">Astral Combat</skill>
             <skill rating="F">Blades</skill>
+            <skill rating="F">Gymnastics</skill>
             <skill rating="F">Perception</skill>
             <skill rating="F">Running</skill>
             <skill rating="F">Sneaking</skill>
@@ -17931,16 +17949,16 @@
             <optionalpower>Silence</optionalpower>
          </optionalpowers>
          <skills>
-            <skill rating="F">Gymnastics</skill>
             <skill rating="F">Assensing</skill>
             <skill rating="F">Astral Combat</skill>
             <skill rating="F">Blades</skill>
+            <skill rating="F">Con</skill>
+            <skill rating="F">Disguise</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Impersonation</skill>
             <skill rating="F">Perception</skill>
             <skill rating="F">Running</skill>
             <skill rating="F">Sneaking</skill>
-            <skill rating="F">Con</skill>
-            <skill rating="F">Disguise</skill>
-            <skill rating="F">Impersonation</skill>
             <skill rating="F">Unarmed Combat</skill>
          </skills>
          <source>DTR</source>
@@ -19107,12 +19125,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+1</inimin>
+         <inimax>(F*2)+1</inimax>
+         <iniaug>(F*2)+1</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19121,23 +19148,23 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Automatics</skill>
-            <skill>Blades</skill>
-            <skill>Clubs</skill>
-            <skill>Con</skill>
-            <skill>Demolitions</skill>
-            <skill>Disguise</skill>
-            <skill>Forgery</skill>
-            <skill>Gymnastics</skill>
-            <skill>Impersonation</skill>
-            <skill>Locksmith</skill>
-            <skill>Palming</skill>
-            <skill>Perception</skill>
-            <skill>Pistols</skill>
-            <skill>Sneaking</skill>
-            <skill>Throwing Weapons</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Automatics</skill>
+            <skill rating="F">Blades</skill>
+            <skill rating="F">Clubs</skill>
+            <skill rating="F">Con</skill>
+            <skill rating="F">Demolitions</skill>
+            <skill rating="F">Disguise</skill>
+            <skill rating="F">Forgery</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Impersonation</skill>
+            <skill rating="F">Locksmith</skill>
+            <skill rating="F">Palming</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Pistols</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Throwing Weapons</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Accident</power>
@@ -19181,12 +19208,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)</inimin>
+         <inimax>(F*2)</inimax>
+         <iniaug>(F*2)</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F-2</essmin>
          <essmax>F-2</essmax>
          <essaug>F-2</essaug>
@@ -19195,11 +19231,11 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <group>Close Combat</group>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill select="Thorns">Exotic Ranged Weapon</skill>
-            <skill>Perception</skill>
+            <group rating="F">Close Combat</group>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F" select="Thorns">Exotic Ranged Weapon</skill>
+            <skill rating="F">Perception</skill>
          </skills>
          <optionalpowers>
             <optionalpower>Guard</optionalpower>
@@ -19255,12 +19291,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+1</inimin>
+         <inimax>(F*2)+1</inimax>
+         <iniaug>(F*2)+1</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19268,22 +19313,22 @@
          <run>4/0/0</run>
          <sprint>2/1/0</sprint>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Automatics</skill>
-            <skill>Blades</skill>
-            <skill>Clubs</skill>
-            <skill>Computer</skill>
-            <skill>First Aid</skill>
-            <skill>Gymnastics</skill>
-            <skill>Intimidation</skill>
-            <skill>Locksmith</skill>
-            <skill>Longarms</skill>
-            <skill>Perception</skill>
-            <skill>Pilot Ground Craft</skill>
-            <skill>Pistols</skill>
-            <skill>Sneaking</skill>
-            <skill>Throwing Weapons</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Automatics</skill>
+            <skill rating="F">Blades</skill>
+            <skill rating="F">Clubs</skill>
+            <skill rating="F">Computer</skill>
+            <skill rating="F">First Aid</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Intimidation</skill>
+            <skill rating="F">Locksmith</skill>
+            <skill rating="F">Longarms</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Pilot Ground Craft</skill>
+            <skill rating="F">Pistols</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Throwing Weapons</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Aura Masking</power>
@@ -19330,12 +19375,21 @@
          <wilmin>F+2</wilmin>
          <wilmax>F+2</wilmax>
          <wilaug>F+2</wilaug>
+         <inimin>(F*2)-1</inimin>
+         <inimax>(F*2)-1</inimax>
+         <iniaug>(F*2)-1</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19343,9 +19397,9 @@
          <run>4/0/0</run>
          <sprint>2/1/0</sprint>
          <skills>
-            <group>Close Combat</group>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
+            <group rating="F">Close Combat</group>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
@@ -19365,44 +19419,72 @@
          <name>Bugul</name>
          <category>Extraplanar Travelers</category>
          <forcecreature />
-         <bod>F</bod>
-         <agi>F-1</agi>
-         <rea>F-1</rea>
-         <str>F-2</str>
-         <cha>F</cha>
-         <int>F</int>
-         <log>F+2</log>
-         <wil>F+1</wil>
-         <ini>0</ini>
-         <edg>F/2</edg>
-         <mag>F</mag>
-         <res>0</res>
-         <dep>0</dep>
-         <ess>F</ess>
+         <bodmin>F</bodmin>
+         <bodmax>F</bodmax>
+         <bodaug>F</bodaug>
+         <agimin>F-1</agimin>
+         <agimax>F-1</agimax>
+         <agiaug>F-1</agiaug>
+         <reamin>F-1</reamin>
+         <reamax>F-1</reamax>
+         <reaaug>F-1</reaaug>
+         <strmin>F-2</strmin>
+         <strmax>F-2</strmax>
+         <straug>F-2</straug>
+         <chamin>F</chamin>
+         <chamax>F</chamax>
+         <chaaug>F</chaaug>
+         <intmin>F</intmin>
+         <intmax>F</intmax>
+         <intaug>F</intaug>
+         <logmin>F+2</logmin>
+         <logmax>F+2</logmax>
+         <logaug>F+2</logaug>
+         <wilmin>F+1</wilmin>
+         <wilmax>F+1</wilmax>
+         <wilaug>F+1</wilaug>
+         <inimin>(F*2)-1</inimin>
+         <inimax>(F*2)-1</inimax>
+         <iniaug>(F*2)-1</iniaug>
+         <edgmin>F/2</edgmin>
+         <edgmax>F/2</edgmax>
+         <edgaug>F/2</edgaug>
+         <magmin>F</magmin>
+         <magmax>F</magmax>
+         <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
+         <essmin>F</essmin>
+         <essmax>F</essmax>
+         <essaug>F</essaug>
          <walk>2/1/0</walk>
          <run>4/0/0</run>
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Artisan</skill>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Con</skill>
-            <skill>Counterspelling</skill>
-            <skill>Disenchanting</skill>
-            <skill>Gymnastics</skill>
-            <skill>Negotiation</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Artisan</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Con</skill>
+            <skill rating="F">Counterspelling</skill>
+            <skill rating="F">Disenchanting</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Negotiation</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
             <power>Aura Masking</power>
-            <power select="Smell">Improved Senses</power>
-            <power select="Thermal">Improved Senses</power>
+            <power select="Smell">Enhanced Senses</power>
+            <power select="Thermal">Enhanced Senses</power>
             <power>Materialization</power>
             <power>Sapience</power>
-            <power select="4">Spell Resistance</power>
+            <power rating="4">Magic Resistance</power>
             <power>Spirit Pact</power>
          </powers>
          <bonus>
@@ -19442,12 +19524,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19456,17 +19547,17 @@
          <sprint>2/1/0</sprint>
          <armor>F*2</armor>
          <skills>
-            <skill>Archery</skill>
-            <skill>Blades</skill>
-            <skill>Clubs</skill>
-            <skill>First Aid</skill>
-            <skill>Gymnastics</skill>
+            <skill rating="F">Archery</skill>
+            <skill rating="F">Blades</skill>
+            <skill rating="F">Clubs</skill>
+            <skill rating="F">First Aid</skill>
+            <skill rating="F">Gymnastics</skill>
          </skills>
          <powers>
             <power>Accident</power>
             <power>Astral Form</power>
             <power>Aura Masking</power>
-            <power>Banishing</power>
+            <power>Banishing Resistance</power>
          </powers>
          <bonus>
             <enabletab>
@@ -19505,12 +19596,21 @@
          <wilmin>5</wilmin>
          <wilmax>5</wilmax>
          <wilaug>9</wilaug>
+         <inimin>15</inimin>
+         <inimax>15</inimax>
+         <iniaug>23</iniaug>
          <edgmin>4</edgmin>
          <edgmax>4</edgmax>
          <edgaug>8</edgaug>
          <magmin>6</magmin>
          <magmax>6</magmax>
          <magaug>10</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>2D6</essmin>
          <essmax>2D6</essmax>
          <essaug>2D6</essaug>
@@ -19565,12 +19665,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19579,22 +19688,22 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Artificing</skill>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
-            <skill>Ritual Spellcasting</skill>
-            <skill>Spellcasting</skill>
+            <skill rating="F">Artificing</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Ritual Spellcasting</skill>
+            <skill rating="F">Spellcasting</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
             <power>Aura Masking</power>
-            <power>Fae Glamour</power>
+            <power>Fey Glamour</power>
             <power>Flay Touch</power>
             <power>Fold Perception</power>
-            <power select="Smell">Improved Senses</power>
-            <power select="Thermal">Improved Senses</power>
+            <power select="Smell">Enhanced Senses</power>
+            <power select="Thermal">Enhanced Senses</power>
             <power>Materialization</power>
             <power>Sapience</power>
             <power>Spirit Pact</power>
@@ -19636,12 +19745,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19650,22 +19768,24 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Con</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Con</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
          </skills>
          <qualities>
-            <quality>Shiva Arms</quality>
+            <positive>
+               <quality>Shiva Arms (Pair)</quality>
+            </positive>
          </qualities>
          <powers>
             <power>Astral Form</power>
             <power>Aura Masking</power>
             <power select="Spirit Pact Only">Hidden Life</power>
-            <power select="Touch">Improved Sense</power>
+            <power select="Touch">Enhanced Senses</power>
             <power>Materialization</power>
-            <power select="Spirit Pact Only">Regenerate</power>
+            <power select="Spirit Pact Only">Regeneration</power>
             <power>Sapience</power>
             <power>Spirit Pact</power>
          </powers>
@@ -19706,12 +19826,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19720,21 +19849,20 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Con</skill>
-            <skill>Counterspelling</skill>
-            <skill>Disenchanting</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
-            <skill>Spellcasting</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Con</skill>
+            <skill rating="F">Counterspelling</skill>
+            <skill rating="F">Disenchanting</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Spellcasting</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
             <power>Aura Masking</power>
             <power>Materialization</power>
-            <power select="Essence">Energy Drain</power>
-            <power>Age)</power>
+            <power select="Essence,Age">Energy Drain</power>
             <power>Fey Glamour</power>
             <power>Sapience</power>
             <power>Spirit Pact</power>
@@ -19776,12 +19904,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)</inimin>
+         <inimax>(F*2)</inimax>
+         <iniaug>(F*2)</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19789,23 +19926,23 @@
          <run>4/0/0</run>
          <sprint>1/1/0</sprint>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Automatics</skill>
-            <skill>Blades</skill>
-            <skill>Clubs</skill>
-            <skill>Computer</skill>
-            <skill>First Aid</skill>
-            <skill>Gymnastics</skill>
-            <skill>Intimidation</skill>
-            <skill>Locksmith</skill>
-            <skill>Longarms</skill>
-            <skill>Perception</skill>
-            <skill>Pilot Ground Craft</skill>
-            <skill>Pistols</skill>
-            <skill>Sneaking</skill>
-            <skill>Throwing Weapons</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Automatics</skill>
+            <skill rating="F">Blades</skill>
+            <skill rating="F">Clubs</skill>
+            <skill rating="F">Computer</skill>
+            <skill rating="F">First Aid</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Intimidation</skill>
+            <skill rating="F">Locksmith</skill>
+            <skill rating="F">Longarms</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Pilot Ground Craft</skill>
+            <skill rating="F">Pistols</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Throwing Weapons</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
@@ -19852,12 +19989,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19866,13 +20012,13 @@
          <sprint>4/1/0</sprint>
          <armor>(F x 2)H</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Flight</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
-            <skill>Sneaking</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Flight</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Accident</power>
@@ -19885,9 +20031,7 @@
             <power>Influence</power>
             <power>Materialization</power>
             <power select="Claws (DV (F+2)P AP -F)">Natural Weapon</power>
-            <power select="Wings (DV (F+6)S AP -F)">Natural Weapon</power>
-            <power>AP -Force</power>
-            <power>Knockdown)</power>
+            <power select="Wings (DV (F+6)S AP -Force, Knockdown)">Natural Weapon</power>
             <power>Psychokinesis</power>
             <power>Sapience</power>
          </powers>
@@ -19928,12 +20072,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -19942,16 +20095,16 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Counterspelling</skill>
-            <skill>Gymnastics</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Counterspelling</skill>
+            <skill rating="F">Gymnastics</skill>
          </skills>
          <powers>
             <power select="Domain">Accident</power>
             <power>Alienate</power>
             <power>Astral Form</power>
-            <power>Aura</power>
+            <power>Aura Masking</power>
          </powers>
          <bonus>
             <enabletab>
@@ -19990,12 +20143,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+3</inimin>
+         <inimax>(F*2)+3</inimax>
+         <iniaug>(F*2)+3</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20004,10 +20166,10 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Alchemy</skill>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Con</skill>
+            <skill rating="F">Alchemy</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Con</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
@@ -20051,12 +20213,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+4</inimin>
+         <inimax>(F*2)+4</inimax>
+         <iniaug>(F*2)+4</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20065,10 +20236,10 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Counterspelling</skill>
-            <skill>Gymnastics</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Counterspelling</skill>
+            <skill rating="F">Gymnastics</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
@@ -20112,12 +20283,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)-1</inimin>
+         <inimax>(F*2)-1</inimax>
+         <iniaug>(F*2)-1</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F-2</essmin>
          <essmax>F-2</essmax>
          <essaug>F-2</essaug>
@@ -20126,9 +20306,9 @@
          <sprint>1/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill spec="Elemental Attack">Exotic Ranged Weapon</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F" spec="Elemental Attack">Exotic Ranged Weapon</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
@@ -20182,12 +20362,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20196,19 +20385,19 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Perception</skill>
-            <skill>Ritual Spellcasting</skill>
-            <skill>Sneaking</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Ritual Spellcasting</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Accident</power>
             <power>Astral Form</power>
             <power>Banishing Resistance</power>
             <power select="Low Light">Enhanced Senses</power>
-            <power select="Augury">Innate Ritual</power>
+            <power select="Augury and Sortilege">Innate Ritual</power>
             <power>Magic Sense</power>
             <power>Materialization</power>
             <power>Search</power>
@@ -20250,12 +20439,21 @@
          <wilmin>F-1</wilmin>
          <wilmax>F-1</wilmax>
          <wilaug>F-1</wilaug>
+         <inimin>(F*2)+5</inimin>
+         <inimax>(F*2)+5</inimax>
+         <iniaug>(F*2)+5</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20263,11 +20461,11 @@
          <run>5/0/0</run>
          <sprint>2/1/0</sprint>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Perception</skill>
-            <skill>Sneaking</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Astral Form</power>
@@ -20317,12 +20515,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20331,11 +20538,11 @@
          <sprint>2/1/0</sprint>
          <armor>0</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Accident</power>
@@ -20350,15 +20557,15 @@
             <power>Psychokinesis</power>
          </powers>
          <optionalpowers>
-            <power>Confusion</power>
-            <power>Deathlock</power>
-            <power>Ghost Chain</power>
-            <power>Howl</power>
-            <power>Movement</power>
-            <power>Noxious Breath</power>
-            <power>Paralyzing Touch</power>
-            <power>Sapience</power>
-            <power>Spirit Pact</power>
+            <optionalpower>Confusion</optionalpower>
+            <optionalpower>Deathlock</optionalpower>
+            <optionalpower>Ghost Chain</optionalpower>
+            <optionalpower>Movement</optionalpower>
+            <optionalpower>Noxious Breath</optionalpower>
+            <optionalpower>Paralyzing Touch</optionalpower>
+            <optionalpower>Paralyzing Howl</optionalpower>
+            <optionalpower>Sapience</optionalpower>
+            <optionalpower>Spirit Pact</optionalpower>
          </optionalpowers>
          <bonus>
             <enabletab>
@@ -20397,12 +20604,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20411,14 +20627,14 @@
          <sprint>2/1/0</sprint>
          <armor>F</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Con</skill>
-            <skill>Intimidation</skill>
-            <skill>Negotiation</skill>
-            <skill>Perception</skill>
-            <skill>Sneaking</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Con</skill>
+            <skill rating="F">Intimidation</skill>
+            <skill rating="F">Negotiation</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Sneaking</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Accident</power>
@@ -20433,8 +20649,7 @@
             <power select="F">Hardened Mystic Armor</power>
             <power>Influence</power>
             <power>Materialization</power>
-            <power select="DV (F-1)S">Natural Weapon (Fist)</power>
-            <power>AP -Force)</power>
+            <power select="Fist: (DV (F-1)S AP -Force)">Natural Weapon</power>
             <power>Psychokinesis</power>
             <power>Sapience</power>
             <power>Search</power>
@@ -20476,12 +20691,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F/2</edgmin>
          <edgmax>F/2</edgmax>
          <edgaug>F/2</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20490,11 +20714,11 @@
          <sprint>2/1/0</sprint>
          <armor>(F x 2)H</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power select="double pain modifers">Agonizing Pain</power>
@@ -20545,22 +20769,34 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+2</inimin>
+         <inimax>(F*2)+2</inimax>
+         <iniaug>(F*2)+2</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
+         <walk>2/1/0</walk>
+         <run>4/0/0</run>
+         <sprint>2/1/0</sprint>
          <armor>(F x 2)H</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Astral Combat</skill>
-            <skill>Gymnastics</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Astral Combat</skill>
+            <skill rating="F">Gymnastics</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Accident</power>
@@ -20613,12 +20849,21 @@
          <wilmin>4</wilmin>
          <wilmax>4</wilmax>
          <wilaug>8</wilaug>
+         <inimin>8</inimin>
+         <inimax>8</inimax>
+         <iniaug>16</iniaug>
          <edgmin>4</edgmin>
          <edgmax>4</edgmax>
          <edgaug>8</edgaug>
          <magmin>6</magmin>
          <magmax>6</magmax>
          <magaug>10</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>6</essmin>
          <essmax>6</essmax>
          <essaug>10</essaug>
@@ -20674,12 +20919,21 @@
          <wilmin>F</wilmin>
          <wilmax>F</wilmax>
          <wilaug>F</wilaug>
+         <inimin>(F*2)+5</inimin>
+         <inimax>(F*2)+5</inimax>
+         <iniaug>(F*2)+5</iniaug>
          <edgmin>F</edgmin>
          <edgmax>F</edgmax>
          <edgaug>F</edgaug>
          <magmin>F</magmin>
          <magmax>F</magmax>
          <magaug>F</magaug>
+         <resmin>0</resmin>
+         <resmax>0</resmax>
+         <resaug>0</resaug>
+         <depmin>0</depmin>
+         <depmax>0</depmax>
+         <depaug>0</depaug>
          <essmin>F</essmin>
          <essmax>F</essmax>
          <essaug>F</essaug>
@@ -20688,10 +20942,10 @@
          <sprint>1/1/5</sprint>
          <armor>12H</armor>
          <skills>
-            <skill>Assensing</skill>
-            <skill>Flight</skill>
-            <skill>Perception</skill>
-            <skill>Unarmed Combat</skill>
+            <skill rating="F">Assensing</skill>
+            <skill rating="F">Flight</skill>
+            <skill rating="F">Perception</skill>
+            <skill rating="F">Unarmed Combat</skill>
          </skills>
          <powers>
             <power>Aura Masking</power>
@@ -20747,9 +21001,9 @@
          <wilmin>F-2</wilmin>
          <wilmax>F-2</wilmax>
          <wilaug>F-2</wilaug>
-         <inimin>F*2</inimin>
-         <inimax>F*2</inimax>
-         <iniaug>F*2</iniaug>
+         <inimin>(F*2)</inimin>
+         <inimax>(F*2)</inimax>
+         <iniaug>(F*2)</iniaug>
          <edgmin>0</edgmin>
          <edgmax>0</edgmax>
          <edgaug>0</edgaug>
@@ -21467,12 +21721,12 @@
             <power>Sapience</power>
          </powers>
          <optionalpowers>
-            <power>Magic Resistance</power>
-            <power>Combat Skill</power>
-            <power>Physical Skill</power>
-            <power>Social Skill</power>
-            <power>Technical Skill</power>
-            <power>Vehicle Skill</power>
+            <optionalpower>Magic Resistance</optionalpower>
+            <optionalpower>Combat Skill</optionalpower>
+            <optionalpower>Physical Skill</optionalpower>
+            <optionalpower>Social Skill</optionalpower>
+            <optionalpower>Technical Skill</optionalpower>
+            <optionalpower>Vehicle Skill</optionalpower>
          </optionalpowers>
          <skills>
             <skill rating="F">Assensing</skill>
@@ -24836,6 +25090,11 @@
          <walk>2/0/0</walk>
          <run>6/0/0</run>
          <sprint>4/0/0</sprint>
+         <qualities>
+            <positive>
+               <quality>Munge</quality>
+            </positive>
+         </qualities>
          <bonus>
             <enableattribute>
                <name>RES</name>
@@ -24850,7 +25109,6 @@
             <power>Blend</power>
             <power>Gremlins</power>
             <power>Holographic Concealment</power>
-            <power>Munge</power>
             <power select="Bite: DV (STR+1)P, AP 0, Reach 1">Natural Weapon</power>
             <power>Resonance Feed</power>
             <power>Tunnel</power>
@@ -24929,6 +25187,11 @@
          <walk>2/0/0</walk>
          <run>6/0/0</run>
          <sprint>4/0/0</sprint>
+         <qualities>
+            <positive>
+               <quality>Munge</quality>
+            </positive>
+         </qualities>
          <bonus>
             <enableattribute>
                <name>RES</name>
@@ -24943,7 +25206,6 @@
             <power>Blend</power>
             <power>Gremlins</power>
             <power>Holographic Concealment</power>
-            <power>Munge</power>
             <power select="Bite: DV (STR+1)P, AP 0, Reach 1">Natural Weapon</power>
             <power>Resonance Feed</power>
             <power>Tunnel</power>
@@ -25022,6 +25284,11 @@
          <walk>2/0/0</walk>
          <run>6/0/0</run>
          <sprint>4/0/0</sprint>
+         <qualities>
+            <positive>
+               <quality>Munge</quality>
+            </positive>
+         </qualities>
          <bonus>
             <enableattribute>
                <name>RES</name>
@@ -25036,7 +25303,6 @@
             <power>Blend</power>
             <power>Gremlins</power>
             <power>Holographic Concealment</power>
-            <power>Munge</power>
             <power select="Bite: DV (STR+1)P, AP 0, Reach 1">Natural Weapon</power>
             <power>Resonance Feed</power>
             <power>Tunnel</power>
@@ -25115,6 +25381,11 @@
          <walk>2/0/0</walk>
          <run>6/0/0</run>
          <sprint>4/0/0</sprint>
+         <qualities>
+            <positive>
+               <quality>Munge</quality>
+            </positive>
+         </qualities>
          <bonus>
             <enableattribute>
                <name>RES</name>
@@ -25129,7 +25400,6 @@
             <power>Blend</power>
             <power>Gremlins</power>
             <power>Holographic Concealment</power>
-            <power>Munge</power>
             <power select="Bite: DV (STR+1)P, AP 0, Reach 1">Natural Weapon</power>
             <power>Resonance Feed</power>
             <power>Tunnel</power>
@@ -25788,6 +26058,7 @@
             <power rating="4">Armor</power>
             <power select="Hoof: DV (STR)P, AP 0">Natural Weapon</power>
             <power>Resonance Feed</power>
+            <power>Resonance Hosting</power>
             <power>Blend</power>
             <power>AR-Parallelism</power>
          </powers>
@@ -25809,13 +26080,12 @@
             <complexform select="Attack">Diffusion of [Matrix Attribute]</complexform>
             <complexform select="Data Processing">Diffusion of [Matrix Attribute]</complexform>
             <complexform>Resonance Spike</complexform>
-            <complexform>Resonance Hosting</complexform>
             <complexform>Resonance Channel</complexform>
          </complexforms>
          <source>KC</source>
          <page>175</page>
       </metatype>
-           <metatype>
+      <metatype>
          <id>ae8062f7-8ba1-4e67-aa2c-491a87e72572</id>
          <name>Primate</name>
          <category>Technocritters</category>
@@ -25884,9 +26154,9 @@
          <skills>
             <group rating="4">Athletics</group>
             <skill rating="3">Clubs</skill>
-            <skill rating="4">Perception</skill>           
-            <skill rating="2">Thrown Weapons</skill>           
-            <skill rating="6">Unarmed Combat</skill>           
+            <skill rating="4">Perception</skill>
+            <skill rating="2">Throwing Weapons</skill>
+            <skill rating="6">Unarmed Combat</skill>
             <skill rating="6">Computer</skill>
             <skill rating="5">Cybercombat</skill>
             <skill rating="5">Hacking</skill>
@@ -25894,7 +26164,7 @@
             <skill rating="5">Electronic Warfare</skill>
          </skills>
          <complexforms>
-            <complexform>Deezz</complexform>
+            <complexform>Derezz</complexform>
             <complexform select="Firewall">Diffusion of [Matrix Attribute]</complexform>
             <complexform>Editor</complexform>
             <complexform select="Sleaze">Infusion of [Matrix Attribute]</complexform>
@@ -26035,9 +26305,9 @@
          <resmin>0</resmin>
          <resmax>0</resmax>
          <resaug>0</resaug>
-         <depmin>F</depmin>
-         <depmax>F</depmax>
-         <depaug>F</depaug>
+         <depmin>6</depmin>
+         <depmax>6</depmax>
+         <depaug>6</depaug>
          <essmin>0</essmin>
          <essmax>6</essmax>
          <essaug>6</essaug>
@@ -26048,7 +26318,7 @@
                <quality>Munge</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26110,10 +26380,10 @@
          <resmin>0</resmin>
          <resmax>0</resmax>
          <resaug>0</resaug>
-         <depmin>0</depmin>
-         <depmax>F</depmax>
-         <depaug>F</depaug>
-         <essmin>F</essmin>
+         <depmin>5</depmin>
+         <depmax>5</depmax>
+         <depaug>5</depaug>
+         <essmin>0</essmin>
          <essmax>6</essmax>
          <essaug>6</essaug>
          <movement>Special</movement>
@@ -26124,7 +26394,7 @@
                <quality>Snooper</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26197,7 +26467,7 @@
                <quality>Munge</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26271,7 +26541,7 @@
                <quality>Munge</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26344,7 +26614,7 @@
                <quality>Munge</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26417,7 +26687,7 @@
                <quality>Munge</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26493,7 +26763,7 @@
                <quality>Munge</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -26568,7 +26838,7 @@
                <quality>Redundancy</quality>
             </positive>
             <negative>
-               <quality>Real World Naivete</quality>
+               <quality>Real World Naiveté</quality>
             </negative>
          </qualities>
          <bonus>
@@ -28124,7 +28394,7 @@
            <initiativepass>1</initiativepass>
          </bonus>
          <powers>
-             <power>Agony</power>
+             <power select="Agony">Innate Spell</power>
              <power rating="6">Armor</power>
              <power>Deathlock</power>
              <power select="Low-Light Vision, Smell">Enhanced Senses</power>

--- a/Chummer/data/cyberware.xml
+++ b/Chummer/data/cyberware.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -2559,6 +2559,7 @@
       <limit>False</limit>
       <category>Bodyware</category>
       <ess>0.05</ess>
+      <capacity>0</capacity>
       <allowgear>
         <gearcategory>Drugs</gearcategory>
         <gearcategory>Toxins</gearcategory>
@@ -6493,7 +6494,6 @@
     </cyberware>
     <cyberware>
       <id>b5406b3c-44a5-4727-bafc-58ed4cda84b5</id>
-      <inheritattributes />
       <name>Evo Better Than Human</name>
       <category>Cybersuite</category>
       <inheritattributes />
@@ -8661,6 +8661,7 @@
       <limit>False</limit>
       <capacity>0</capacity>
       <avail>0</avail>
+      <cost>0</cost>
       <removalcost>16000</removalcost>
       <forcegrade>None</forcegrade>
       <source>TSG</source>
@@ -8676,6 +8677,7 @@
       <limit>False</limit>
       <category>Headware</category>
       <ess>0.15</ess>
+      <capacity>0</capacity>
       <avail>4</avail>
       <cost>Rating*3500</cost>
       <rating>3</rating>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -61,7 +61,6 @@
     <category blackmarket="Magic">Formulae</category>
     <category blackmarket="Weapons">Grapple Gun</category>
     <category blackmarket="Software">Hacking Programs</category>
-    <category blackmarket="Nanoware">Hard Nanoware</category>
     <category blackmarket="Electronics">Housewares</category>
     <category>ID/Credsticks</category>
     <category blackmarket="Magic">Magical Compounds</category>
@@ -15685,78 +15684,6 @@
       <armorcapacity>[2]</armorcapacity>
       <cost>1000</cost>
       <costfor>5</costfor>
-    </gear>
-    <!-- End Region -->
-    <!-- Region Hard Nanoware -->
-    <gear>
-      <id>6ba6ff51-9dd3-43fa-8d46-e7fedcc68fe4</id>
-      <name>Anti-Rad</name>
-      <category>Hard Nanoware</category>
-      <rating>6</rating>
-      <source>CF</source>
-      <page>147</page>
-      <avail>14F</avail>
-      <cost>Rating * 6000</cost>
-    </gear>
-    <gear>
-      <id>1fb25d10-fa70-4a4e-87c8-b8a5acbb1473</id>
-      <name>Control Rig Booster</name>
-      <category>Hard Nanoware</category>
-      <rating>3</rating>
-      <source>CF</source>
-      <page>147</page>
-      <avail>12F</avail>
-      <cost>Rating * 6000</cost>
-    </gear>
-    <gear>
-      <id>d139c977-eb78-4234-8cfc-2e4ae909ef6f</id>
-      <name>Nanite Hunters</name>
-      <category>Hard Nanoware</category>
-      <rating>6</rating>
-      <source>CF</source>
-      <page>147</page>
-      <avail>16R</avail>
-      <cost>Rating * 5000</cost>
-    </gear>
-    <gear>
-      <id>f317ccfa-a0ab-4e14-8c6f-436b31061e73</id>
-      <name>Markers</name>
-      <category>Hard Nanoware</category>
-      <rating>3</rating>
-      <source>CF</source>
-      <page>148</page>
-      <avail>12</avail>
-      <cost>Rating * 2000</cost>
-    </gear>
-    <gear>
-      <id>044072d3-824c-49f9-91e2-07ae3e01be3c</id>
-      <name>Nanotattoos</name>
-      <category>Hard Nanoware</category>
-      <rating>6</rating>
-      <source>CF</source>
-      <page>148</page>
-      <avail>12F</avail>
-      <cost>Rating * 1000</cost>
-    </gear>
-    <gear>
-      <id>3718b500-b035-40dd-9f5f-c73682fff3ef</id>
-      <name>Taggants</name>
-      <category>Hard Nanoware</category>
-      <rating>3</rating>
-      <source>CF</source>
-      <page>148</page>
-      <avail>12</avail>
-      <cost>Rating * 600</cost>
-    </gear>
-    <gear>
-      <id>071a20a3-0507-43dc-b504-9aeaeb6df09b</id>
-      <name>Trauma Control System</name>
-      <category>Hard Nanoware</category>
-      <rating>6</rating>
-      <source>CF</source>
-      <page>148</page>
-      <avail>12F</avail>
-      <cost>Rating * 4000</cost>
     </gear>
     <!-- End Region -->
     <!-- Region Food -->

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -8765,6 +8765,17 @@
       <avail>6R</avail>
       <cost>250</cost>
     </gear>
+    <gear>
+      <id>e5a91f52-8f6d-4a2e-9b8f-3a087e3d97e4</id>
+      <name>Ink Pouch</name>
+      <category>Security Devices</category>
+      <rating>0</rating>
+      <source>R5</source>
+      <page>136</page>
+      <avail>0</avail>
+      <cost>0</cost>
+      <hide />
+    </gear>
     <!-- End Region -->
     <!-- Region Breaking and Entering Gear -->
     <gear>
@@ -16663,6 +16674,17 @@
       <avail>0</avail>
       <cost>1</cost>
       <costfor>4</costfor>
+    </gear>
+    <gear>
+      <id>9c7f1a63-4b2d-4e19-a9cb-fb8b63b5e3ac</id>
+      <name>Plasma Torch</name>
+      <category>Tools</category>
+      <rating>0</rating>
+      <source>R5</source>
+      <page>136</page>
+      <avail>0</avail>
+      <cost>1</cost>
+      <hide />
     </gear>
     <!-- End Region -->
     <!-- Region Housewares -->

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -1947,7 +1947,7 @@
       <page>53</page>
       <avail>10R</avail>
       <cost>Rating*20</cost>
-      <addweapon rating="{Rating}">Grenade: Fuzzy Boom Boom Bunnies</addweapon>-->
+      <addweapon rating="{Rating}">Grenade: Fuzzy Boom Boom Bunnies</addweapon>
     </gear>
     <gear>
       <id>7470ed31-0d81-4992-bae6-38f9de198020</id>
@@ -18747,7 +18747,7 @@
       <rating>0</rating>
       <source>2050</source>
       <page>191</page>
-      <avail>4E</avail>
+      <avail>4</avail>
       <cost>250</cost>
     </gear>
     <gear>
@@ -20344,7 +20344,7 @@
       <rating>0</rating>
       <source>2050</source>
       <page>197</page>
-      <avail>4V</avail>
+      <avail>4R</avail>
       <cost>180</cost>
     </gear>
     <gear>
@@ -20366,7 +20366,7 @@
       <rating>0</rating>
       <source>2050</source>
       <page>197</page>
-      <avail>4E</avail>
+      <avail>4</avail>
       <cost>50</cost>
     </gear>
     <gear>
@@ -20386,7 +20386,7 @@
       <rating>0</rating>
       <source>2050</source>
       <page>197</page>
-      <avail>3V</avail>
+      <avail>3R</avail>
       <cost>360</cost>
     </gear>
     <gear>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -1415,7 +1415,7 @@
     </gear>
     <gear>
       <id>022bc6c7-1f91-4852-b1ee-0f50433a1b97</id>
-      <name>Grenade: Paint (Radioactive Tracking Dye),  Aerodynamic</name>
+      <name>Grenade: Paint (Radioactive Tracking Dye), Aerodynamic</name>
       <category>Ammunition</category>
       <rating>0</rating>
       <source>RG</source>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -61,6 +61,7 @@
     <category blackmarket="Magic">Formulae</category>
     <category blackmarket="Weapons">Grapple Gun</category>
     <category blackmarket="Software">Hacking Programs</category>
+    <category blackmarket="Nanoware">Hard Nanogear</category>
     <category blackmarket="Electronics">Housewares</category>
     <category>ID/Credsticks</category>
     <category blackmarket="Magic">Magical Compounds</category>
@@ -9366,7 +9367,7 @@
     <gear>
       <id>3772ad51-c689-4e38-8c93-b285e78670b5</id>
       <name>Can Make Commcalls</name>
-      <category>Electronic Accessories</category>
+      <category>Electronics Accessories</category>
       <rating>0</rating>
       <source>SR5</source>
       <page>422</page>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -61,7 +61,7 @@
     <category blackmarket="Magic">Formulae</category>
     <category blackmarket="Weapons">Grapple Gun</category>
     <category blackmarket="Software">Hacking Programs</category>
-    <category blackmarket="Nanoware">Hard Nanogear</category>
+    <category blackmarket="Nanoware">Hard Nanoware</category>
     <category blackmarket="Electronics">Housewares</category>
     <category>ID/Credsticks</category>
     <category blackmarket="Magic">Magical Compounds</category>

--- a/Chummer/data/lifemodules.xml
+++ b/Chummer/data/lifemodules.xml
@@ -11035,8 +11035,8 @@
         <addqualities>
           <addquality>
             <options>
-              <collegeeducation>College Education</collegeeducation>
-              <technicalschooleducation>Technical School Education</technicalschooleducation>
+              <quality>College Education</quality>
+              <quality>Technical School Education</quality>
             </options>
           </addquality>
           <addquality>Common Sense</addquality>

--- a/Chummer/data/mentors.xml
+++ b/Chummer/data/mentors.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -3209,8 +3209,6 @@
               <condition>Spirits of Man</condition>
             </specificskill>
           </bonus>
-        </choice>
-        <choice>
         </choice>
         <choice>
           <name>Adept: 1 free level of Mystic Armor</name>

--- a/Chummer/data/metatypes.xml
+++ b/Chummer/data/metatypes.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -18,7 +18,8 @@
     You can obtain the full source code for Chummer5a at
     https://github.com/chummer5a/chummer5a
 -->
-<chummer>
+<chummer xmlns="" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.w3.org/2001/XMLSchema metatypes.xsd">
   <categories>
     <category>Metahuman</category>
     <category>Metavariant</category>
@@ -870,7 +871,6 @@
               <quality>Poor Self Control (Vindictive)</quality>
             </negative>
           </qualities>
-          <karma>5</karma>
           <bonus />
           <source>RF</source>
           <page>104</page>
@@ -928,7 +928,6 @@
               <quality>Ogre Stomach</quality>
             </positive>
           </qualities>
-          <karma>8</karma>
           <bonus />
           <source>RF</source>
           <page>104</page>
@@ -988,7 +987,6 @@
               <quality>Striking Skin Pigmentation</quality>
             </negative>
           </qualities>
-          <karma>4</karma>
           <bonus />
           <source>RF</source>
           <page>104</page>
@@ -1173,7 +1171,6 @@
               <quality>Cyclopean Eye</quality>
             </negative>
           </qualities>
-          <karma>2</karma>
           <bonus>
             <reach>1</reach>
             <lifestylecost>100</lifestylecost>
@@ -1234,7 +1231,6 @@
               <quality>Arcane Arrester</quality>
             </positive>
           </qualities>
-          <karma>12</karma>
           <bonus>
             <reach>1</reach>
             <lifestylecost>100</lifestylecost>
@@ -1295,7 +1291,6 @@
               <quality>Dermal Alteration (Bark Skin)</quality>
             </positive>
           </qualities>
-          <karma>2</karma>
           <bonus>
             <reach>1</reach>
             <lifestylecost>100</lifestylecost>
@@ -1356,7 +1351,6 @@
               <quality>Goring Horns</quality>
             </positive>
           </qualities>
-          <karma>2</karma>
           <bonus>
             <reach>1</reach>
             <lifestylecost>100</lifestylecost>
@@ -1668,7 +1662,6 @@
         <power select="Claws: DV ({STR} + 1)P, AP -, +1 Reach">Natural Weapon</power>
       </powers>
       <addweapon>Claws (Sasquatch)</addweapon>
-      <metavariants />
       <source>RF</source>
       <page>99</page>
     </metatype>
@@ -2680,9 +2673,6 @@
             </negative>
           </qualities>
           <bonus>
-            <enableattribute>
-              <name>MAG</name>
-            </enableattribute>
             <enableattribute>
               <name>MAG</name>
             </enableattribute>
@@ -4079,7 +4069,6 @@
               <quality select="Metahuman Form Only">Thermographic Vision</quality>
             </positive>
           </qualities>
-          <karma>2</karma>
           <bonus>
             <reach>1</reach>
             <lifestylecost>100</lifestylecost>
@@ -4566,7 +4555,6 @@
               <name>critter</name>
             </enabletab>
           </bonus>
-          <qualities />
           <source>RF</source>
           <page>104</page>
         </metavariant>
@@ -5496,7 +5484,6 @@
               <name>critter</name>
             </enabletab>
           </bonus>
-          <karma>4</karma>
           <source>RF</source>
           <page>104</page>
         </metavariant>
@@ -7168,7 +7155,6 @@
               <quality removable="True">Uneducated</quality>
             </negative>
           </qualities>
-          <karma>8</karma>
           <bonus>
             <enableattribute>
               <name>MAG</name>
@@ -7543,7 +7529,6 @@
               <quality removable="True">Uneducated</quality>
             </negative>
           </qualities>
-          <karma>12</karma>
           <bonus>
             <enableattribute>
               <name>MAG</name>
@@ -15383,7 +15368,6 @@
               <page>105</page>
             </naturalweapon>
           </bonus>
-          <karma>165</karma>
           <source>RF</source>
           <page>104</page>
           <initiativedice>2</initiativedice>
@@ -17558,7 +17542,6 @@
               <page>105</page>
             </naturalweapon>
           </bonus>
-          <karma>165</karma>
           <source>RF</source>
           <page>104</page>
           <initiativedice>2</initiativedice>
@@ -19559,9 +19542,6 @@
             </naturalweapon>
             <lifestylecost>20</lifestylecost>
           </bonus>
-          <qualities>
-            <positive />
-          </qualities>
           <source>RF</source>
           <page>90</page>
         </metavariant>
@@ -19753,7 +19733,6 @@
               <page>105</page>
             </naturalweapon>
           </bonus>
-          <karma>175</karma>
           <source>RF</source>
           <page>104</page>
         </metavariant>
@@ -23017,7 +22996,6 @@
           <karma>143</karma>
           <bodmin>1</bodmin>
           <bodmax>6</bodmax>
-          <karma>103</karma>
           <bodaug>10</bodaug>
           <agimin>2</agimin>
           <agimax>7</agimax>
@@ -23814,7 +23792,6 @@
               <page>147</page>
             </naturalweapon>
           </bonus>
-          <bonus />
           <source>RF</source>
           <page>104</page>
         </metavariant>

--- a/Chummer/data/powers.xml
+++ b/Chummer/data/powers.xml
@@ -1455,7 +1455,6 @@
       <source>SSP</source>
       <page>23</page>
       <adeptway>0.25</adeptway>
-      <selectskill />
     </power>
     <power>
       <id>df257b19-9ef7-4f0b-9aaa-4dbc43372431</id>

--- a/Chummer/data/priorities.xml
+++ b/Chummer/data/priorities.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -209,7 +209,6 @@
           <name>Sasquatch</name>
           <value>5</value>
           <karma>20</karma>
-          <metavariants />
         </metatype>
         <metatype>
           <name>Shapeshifter: Bovine</name>
@@ -1667,7 +1666,6 @@
           <name>Sasquatch</name>
           <value>2</value>
           <karma>20</karma>
-          <metavariants />
         </metatype>
         <metatype>
           <name>Shapeshifter: Bovine</name>
@@ -3050,11 +3048,6 @@
               <value>1</value>
               <karma>2</karma>
             </metavariant>
-            <metavariant>
-              <name>Goblin</name>
-              <value>1</value>
-              <karma>27</karma>
-            </metavariant>
           </metavariants>
         </metatype>
         <metatype>
@@ -3103,7 +3096,6 @@
           <name>Sasquatch</name>
           <value>0</value>
           <karma>20</karma>
-          <metavariants />
         </metatype>
         <metatype>
           <name>Shapeshifter: Bovine</name>

--- a/Chummer/data/skills.xml
+++ b/Chummer/data/skills.xml
@@ -941,7 +941,7 @@
         <spec>Magical Health</spec>
         <spec>Organ Culture</spec>
         <spec>Trauma Surgery</spec>
-		<spec>Veterinary</spec>
+        <spec>Veterinary</spec>
       </specs>
       <source>SR5</source>
       <page>145</page>

--- a/Chummer/data/traditions.xml
+++ b/Chummer/data/traditions.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -2617,7 +2617,7 @@
       <agi>F</agi>
       <rea>F</rea>
       <str>F+2</str>
-      <cha>F–1</cha>
+      <cha>F-1</cha>
       <int>F</int>
       <log>F</log>
       <wil>F</wil>
@@ -2660,10 +2660,10 @@
       <id>1b9737c5-f3dc-4ede-acdb-81ad35afcb7e</id>
       <name>Corpse Spirit</name>
       <bod>F+2</bod>
-      <agi>F–1</agi>
+      <agi>F-1</agi>
       <rea>F+2</rea>
-      <str>F–2</str>
-      <cha>F–1</cha>
+      <str>F-2</str>
+      <cha>F-1</cha>
       <int>F+1</int>
       <log>F</log>
       <wil>F</wil>
@@ -2708,12 +2708,12 @@
       <id>eeca5858-c087-4489-9ad9-469f0664726f</id>
       <name>Rot Spirit</name>
       <bod>F+3</bod>
-      <agi>F–2</agi>
+      <agi>F-2</agi>
       <rea>F</rea>
       <str>F+1</str>
-      <cha>F–1</cha>
+      <cha>F-1</cha>
       <int>F</int>
-      <log>F–1</log>
+      <log>F-1</log>
       <wil>F</wil>
       <ini>0</ini>
       <edg>F/2</edg>
@@ -2759,8 +2759,8 @@
       <bod>F+2</bod>
       <agi>F+1</agi>
       <rea>F+3</rea>
-      <str>F–2</str>
-      <cha>F–1</cha>
+      <str>F-2</str>
+      <cha>F-1</cha>
       <int>F+1</int>
       <log>F</log>
       <wil>F</wil>
@@ -2803,12 +2803,12 @@
       <id>8e7d505f-4c97-4dad-ae15-955080c2fbaf</id>
       <name>Detritus Spirit</name>
       <bod>F+5</bod>
-      <agi>F–3</agi>
+      <agi>F-3</agi>
       <rea>F-1</rea>
       <str>F+4</str>
-      <cha>F–1</cha>
+      <cha>F-1</cha>
       <int>F</int>
-      <log>F–1</log>
+      <log>F-1</log>
       <wil>F</wil>
       <ini>0</ini>
       <edg>F/2</edg>
@@ -3412,7 +3412,7 @@
       <id>5b122a59-408e-4634-855a-763b25fbad16</id>
       <name>Master Shedim</name>
       <category>Shedim</category>
-      <bon>F</bon>
+      <bod>F</bod>
       <agi>F</agi>
       <rea>F+2</rea>
       <str>F+1</str>

--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 
 <!--This file is part of Chummer5a.
 
@@ -2136,7 +2136,7 @@
       </gears>
       <mods>
         <name select="Generator">Special Equipment</name>
-        <name>Rigger Adaptation</name>
+        <name>Rigger Interface</name>
         <name>Rigger Cocoon</name>
         <name select="Aeronautics Mechanic">Workshop</name>
         <name>Standard Drone Rack (Medium)</name>
@@ -3849,11 +3849,9 @@
       <mods>
         <name>Submersible (Drone)</name>
         <name>Gecko Grips (Drone)</name>
-      </mods>
-      <modslots>1</modslots>
-      <mods>
         <name>Rigger Interface</name>
       </mods>
+      <modslots>1</modslots>
     </vehicle>
     <vehicle>
       <id>89392969-1d03-4322-9aa8-c0160ba3ee76</id>
@@ -4414,11 +4412,9 @@
       </gears>
       <mods>
         <name select="Storage Compartment">Special Equipment</name>
-      </mods>
-      <modslots>1</modslots>
-      <mods>
         <name>Rigger Interface</name>
       </mods>
+      <modslots>1</modslots>
     </vehicle>
     <vehicle>
       <id>50d4bce4-79f1-48d4-8b38-68969802dec0</id>
@@ -5821,32 +5817,6 @@
       <seats>8</seats>
     </vehicle>
     <vehicle>
-      <id>8a898851-6409-48f0-95f9-62e831835890</id>
-      <name>Conestoga Vista (Bus)</name>
-      <page>110</page>
-      <source>AR</source>
-      <accel>15/25</accel>
-      <armor>4</armor>
-      <avail>0</avail>
-      <body>20</body>
-      <category>Trucks</category>
-      <cost>25000</cost>
-      <handling>-3</handling>
-      <pilot>1</pilot>
-      <sensor>1</sensor>
-      <speed>90</speed>
-      <gears>
-        <gear>
-          <name>Sensor Array</name>
-          <rating>1</rating>
-          <maxrating>7</maxrating>
-        </gear>
-      </gears>
-      <mods>
-        <name>Amenities (Squatter)</name>
-      </mods>
-    </vehicle>
-    <vehicle>
       <id>81505035-7043-4841-a952-3763e9e7ddc5</id>
       <name>Conestoga Trailblazer (Moving Truck)</name>
       <page>186</page>
@@ -6912,7 +6882,7 @@
         </mod>
         <name>Drone Leg</name>
         <name>Drone Leg</name>
-        <name>Rigger Adaptation</name>
+        <name>Rigger Interface</name>
       </mods>
     </vehicle>
     <vehicle>
@@ -8604,6 +8574,7 @@
       <sensor>3</sensor>
       <speed>2</speed>
       <gears>
+        <gear>Grenade: Flash-Pak</gear>
         <gear>
           <name>Sensor Array</name>
           <rating>3</rating>
@@ -8611,7 +8582,6 @@
         </gear>
       </gears>
       <mods>
-        <name>Flash-Pak</name>
         <name>Gecko Grips (Drone)</name>
         <name>Spotlight (Drone)</name>
         <name>Rigger Interface</name>
@@ -8917,6 +8887,7 @@
       <sensor>1</sensor>
       <speed>1</speed>
       <gears>
+        <gear>Grenade: Flash-Pak</gear>
         <gear>
           <name>Sensor Array</name>
           <rating>1</rating>
@@ -8924,7 +8895,6 @@
         </gear>
       </gears>
       <mods>
-        <name>Flash-Pak</name>
         <name>Rigger Interface</name>
       </mods>
       <modslots>0</modslots>
@@ -9276,7 +9246,6 @@
       </gears>
       <mods>
         <name>Rigger Interface</name>
-        <name>Manual Controls</name>
         <name>Avibras-Nissan AN 822 Device Rating Upgrade</name>
       </mods>
       <seats>5</seats>
@@ -11920,6 +11889,18 @@
       <bonus>
         <seats>+Seats * 0.5</seats>
       </bonus>
+    </mod>
+    <mod>
+      <id>b4c0c7d3-25fb-420f-812a-1747c72d2e4d</id>
+      <name>Amenities (Street)</name>
+      <page>?</page>
+      <source>KK</source>
+      <avail>0</avail>
+      <category>Cosmetic</category>
+      <cost>0</cost>
+      <rating>0</rating>
+      <slots>0</slots>
+      <hide />
     </mod>
     <mod>
       <id>8a90457a-ab4d-454e-ba9f-4e3aa5ba0a0b</id>

--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -3745,7 +3745,7 @@
       <cost>120</cost>
       <source>SR5</source>
       <page>425</page>
-	  <spec>Holdouts</spec>
+      <spec>Holdouts</spec>
       <spec2>Semi-Automatics</spec2>
     </weapon>
     <weapon>
@@ -7103,15 +7103,9 @@
       <ammo>6(m)</ammo>
       <avail>0</avail>
       <cost>0</cost>
-      <source>SR5</source>
-      <page>428</page>
-      <accessorymounts>
-        <mount>Stock</mount>
-        <mount>Side</mount>
-        <mount>Barrel</mount>
-        <mount>Top</mount>
-        <mount>Under</mount>
-      </accessorymounts>
+      <source>RG</source>
+      <page>36</page>
+      <mount>Under</mount>
       <ammocategory>Grenade Launchers</ammocategory>
       <hide />
       <range>Grenade Launchers</range>
@@ -7135,13 +7129,7 @@
       <cost>0</cost>
       <source>SR5</source>
       <page>428</page>
-      <accessorymounts>
-        <mount>Stock</mount>
-        <mount>Side</mount>
-        <mount>Barrel</mount>
-        <mount>Top</mount>
-        <mount>Under</mount>
-      </accessorymounts>
+      <mount>Under</mount>
       <ammocategory>Grenade Launchers</ammocategory>
       <hide />
       <range>Grenade Launchers</range>
@@ -7165,13 +7153,7 @@
       <cost>3500</cost>
       <source>SR5</source>
       <page>428</page>
-      <accessorymounts>
-        <mount>Stock</mount>
-        <mount>Side</mount>
-        <mount>Barrel</mount>
-        <mount>Top</mount>
-        <mount>Under</mount>
-      </accessorymounts>
+      <mount>Under</mount>
       <ammocategory>Grenade Launchers</ammocategory>
       <range>Grenade Launchers</range>
       <required>
@@ -7220,6 +7202,7 @@
       <cost>350</cost>
       <source>RG</source>
       <page>53</page>
+      <mount>Under</mount>
       <range>Heavy Pistols</range>
       <required>
         <weapondetails>
@@ -7247,6 +7230,7 @@
       <cost>600</cost>
       <source>SR5</source>
       <page>449</page>
+      <mount>Under</mount>
       <range>Light Crossbows</range>
       <required>
         <weapondetails>
@@ -7286,13 +7270,7 @@
           <name>Smartgun System, Internal</name>
         </accessory>
       </accessories>
-      <accessorymounts>
-        <mount>Stock</mount>
-        <mount>Side</mount>
-        <mount>Barrel</mount>
-        <mount>Top</mount>
-        <mount>Under</mount>
-      </accessorymounts>
+      <mount>Under</mount>
       <alternaterange>Shotguns (flechette)</alternaterange>
       <ammocategory>Shotguns</ammocategory>
       <hide />
@@ -8542,27 +8520,29 @@
       <mount>Barrel</mount>
       <range>Medium Crossbows</range>
       <required>
-        <OR>
-          <category>Assault Rifles</category>
-          <category>Sniper Rifles</category>
-          <category>Sporting Rifles</category>
-          <useskill>Longarms</useskill>
-          <useskill>Heavy Weapons</useskill>
-          <AND>
-            <useskill NOT="" operation="exists" />
-            <OR>
-              <category>Shotguns</category>
-              <category>Sporting Rifles</category>
-              <category>Sniper Rifles</category>
-              <category>Light Machine Guns</category>
-              <category>Medium Machine Guns</category>
-              <category>Heavy Machine Guns</category>
-              <category>Assault Cannons</category>
-              <category>Grenade Launchers</category>
-              <category>Missile Launchers</category>
-            </OR>
-          </AND>
-        </OR>
+        <weapondetails>
+          <OR>
+            <category>Assault Rifles</category>
+            <category>Sniper Rifles</category>
+            <category>Sporting Rifles</category>
+            <useskill>Longarms</useskill>
+            <useskill>Heavy Weapons</useskill>
+            <AND>
+              <useskill NOT="" operation="exists" />
+              <OR>
+                <category>Shotguns</category>
+                <category>Sporting Rifles</category>
+                <category>Sniper Rifles</category>
+                <category>Light Machine Guns</category>
+                <category>Medium Machine Guns</category>
+                <category>Heavy Machine Guns</category>
+                <category>Assault Cannons</category>
+                <category>Grenade Launchers</category>
+                <category>Missile Launchers</category>
+              </OR>
+            </AND>
+          </OR>
+        </weapondetails>
       </required>
       <useskill>Archery</useskill>
       <useskillspec>Crossbow</useskillspec>
@@ -8588,27 +8568,29 @@
       <mount>Under</mount>
       <range>Shotguns</range>
       <required>
-        <OR>
-          <category>Assault Rifles</category>
-          <category>Sniper Rifles</category>
-          <category>Sporting Rifles</category>
-          <useskill>Longarms</useskill>
-          <useskill>Heavy Weapons</useskill>
-          <AND>
-            <useskill NOT="" operation="exists" />
-            <OR>
-              <category>Shotguns</category>
-              <category>Sporting Rifles</category>
-              <category>Sniper Rifles</category>
-              <category>Light Machine Guns</category>
-              <category>Medium Machine Guns</category>
-              <category>Heavy Machine Guns</category>
-              <category>Assault Cannons</category>
-              <category>Grenade Launchers</category>
-              <category>Missile Launchers</category>
-            </OR>
-          </AND>
-        </OR>
+        <weapondetails>
+          <OR>
+            <category>Assault Rifles</category>
+            <category>Sniper Rifles</category>
+            <category>Sporting Rifles</category>
+            <useskill>Longarms</useskill>
+            <useskill>Heavy Weapons</useskill>
+            <AND>
+              <useskill NOT="" operation="exists" />
+              <OR>
+                <category>Shotguns</category>
+                <category>Sporting Rifles</category>
+                <category>Sniper Rifles</category>
+                <category>Light Machine Guns</category>
+                <category>Medium Machine Guns</category>
+                <category>Heavy Machine Guns</category>
+                <category>Assault Cannons</category>
+                <category>Grenade Launchers</category>
+                <category>Missile Launchers</category>
+              </OR>
+            </AND>
+          </OR>
+        </weapondetails>
       </required>
       <useskill>Longarms</useskill>
       <useskillspec>Shotguns</useskillspec>
@@ -8633,27 +8615,29 @@
       <extramount>Side</extramount>
       <mount>Under</mount>
       <required>
-        <OR>
-          <category>Assault Rifles</category>
-          <category>Sniper Rifles</category>
-          <category>Sporting Rifles</category>
-          <useskill>Longarms</useskill>
-          <useskill>Heavy Weapons</useskill>
-          <AND>
-            <useskill NOT="" operation="exists" />
-            <OR>
-              <category>Shotguns</category>
-              <category>Sporting Rifles</category>
-              <category>Sniper Rifles</category>
-              <category>Light Machine Guns</category>
-              <category>Medium Machine Guns</category>
-              <category>Heavy Machine Guns</category>
-              <category>Assault Cannons</category>
-              <category>Grenade Launchers</category>
-              <category>Missile Launchers</category>
-            </OR>
-          </AND>
-        </OR>
+        <weapondetails>
+          <OR>
+            <category>Assault Rifles</category>
+            <category>Sniper Rifles</category>
+            <category>Sporting Rifles</category>
+            <useskill>Longarms</useskill>
+            <useskill>Heavy Weapons</useskill>
+            <AND>
+              <useskill NOT="" operation="exists" />
+              <OR>
+                <category>Shotguns</category>
+                <category>Sporting Rifles</category>
+                <category>Sniper Rifles</category>
+                <category>Light Machine Guns</category>
+                <category>Medium Machine Guns</category>
+                <category>Heavy Machine Guns</category>
+                <category>Assault Cannons</category>
+                <category>Grenade Launchers</category>
+                <category>Missile Launchers</category>
+              </OR>
+            </AND>
+          </OR>
+        </weapondetails>
       </required>
       <useskill>Exotic Ranged Weapon</useskill>
       <useskillspec>Laser Weapons</useskillspec>
@@ -10269,6 +10253,7 @@
       <cost>0</cost>
       <source>2050</source>
       <page>185</page>
+      <mount>Under</mount>
       <ammocategory>Grenade Launchers</ammocategory>
       <hide />
       <range>Grenade Launchers</range>
@@ -11542,13 +11527,7 @@
       <cost>0</cost>
       <source>SAG</source>
       <page>27</page>
-      <accessorymounts>
-        <mount>Stock</mount>
-        <mount>Side</mount>
-        <mount>Barrel</mount>
-        <mount>Top</mount>
-        <mount>Under</mount>
-      </accessorymounts>
+      <mount>Under</mount>
       <ammocategory>Grenade Launchers</ammocategory>
       <hide />
       <range>Grenade Launchers</range>
@@ -11786,13 +11765,7 @@
       <cost>0</cost>
       <source>SAG</source>
       <page>30</page>
-      <accessorymounts>
-        <mount>Stock</mount>
-        <mount>Side</mount>
-        <mount>Barrel</mount>
-        <mount>Top</mount>
-        <mount>Under</mount>
-      </accessorymounts>
+      <mount>Under</mount>
       <ammocategory>Grenade Launchers</ammocategory>
       <hide />
       <range>Grenade Launchers</range>
@@ -15024,6 +14997,8 @@
       <accessories>
         <accessory>
           <name>Smartgun System, Internal</name>
+        </accessory>
+        <accessory>
           <name>Trigger Removal</name>
         </accessory>
       </accessories>
@@ -15067,14 +15042,18 @@
       <type>Ranged</type>
       <conceal>6</conceal>
       <accuracy>6</accuracy>
+      <reach>0</reach>
       <damage>Special</damage>
+      <ap>-</ap>
       <mode>SA</mode>
+      <rc>0</rc>
       <ammo>10(m)</ammo>
       <avail>0</avail>
       <range>Shuriken</range>
       <cost>150</cost>
       <source>SOTG</source>
       <page>13</page>
+      <mount>Under</mount>
       <useskill>Archery</useskill>
       <required>
         <weapondetails>
@@ -17844,8 +17823,8 @@
       <hide />
       <rating>0</rating>
       <required>
-        <OR>
-          <weapondetails>
+        <weapondetails>
+          <OR>
             <category>Assault Rifles</category>
             <category>Sniper Rifles</category>
             <category>Sporting Rifles</category>
@@ -17858,8 +17837,8 @@
                 <category>Sniper Rifles</category>
               </OR>
             </AND>
-          </weapondetails>
-        </OR>
+          </OR>
+        </weapondetails>
       </required>
     </accessory>
     <accessory>
@@ -17888,27 +17867,29 @@
       <hide />
       <rating>0</rating>
       <required>
-        <OR>
-          <category>Assault Rifles</category>
-          <category>Sniper Rifles</category>
-          <category>Sporting Rifles</category>
-          <useskill>Longarms</useskill>
-          <useskill>Heavy Weapons</useskill>
-          <AND>
-            <useskill NOT="" operation="exists" />
-            <OR>
-              <category>Shotguns</category>
-              <category>Sporting Rifles</category>
-              <category>Sniper Rifles</category>
-              <category>Light Machine Guns</category>
-              <category>Medium Machine Guns</category>
-              <category>Heavy Machine Guns</category>
-              <category>Assault Cannons</category>
-              <category>Grenade Launchers</category>
-              <category>Missile Launchers</category>
-            </OR>
-          </AND>
-        </OR>
+        <weapondetails>
+          <OR>
+            <category>Assault Rifles</category>
+            <category>Sniper Rifles</category>
+            <category>Sporting Rifles</category>
+            <useskill>Longarms</useskill>
+            <useskill>Heavy Weapons</useskill>
+            <AND>
+              <useskill NOT="" operation="exists" />
+              <OR>
+                <category>Shotguns</category>
+                <category>Sporting Rifles</category>
+                <category>Sniper Rifles</category>
+                <category>Light Machine Guns</category>
+                <category>Medium Machine Guns</category>
+                <category>Heavy Machine Guns</category>
+                <category>Assault Cannons</category>
+                <category>Grenade Launchers</category>
+                <category>Missile Launchers</category>
+              </OR>
+            </AND>
+          </OR>
+        </weapondetails>
       </required>
     </accessory>
     <accessory>
@@ -19059,7 +19040,6 @@
       <rc>6</rc>
       <rcdeployable>True</rcdeployable>
       <rcgroup>1</rcgroup>
-      <rating>0</rating>
     </accessory>
     <accessory>
       <id>9b09fc1e-cb5b-473f-83a5-6f23a7524012</id>


### PR DESCRIPTION
### Overview

This PR is a subset of the broader changes originally submitted in [PR #5187](https://github.com/chummer5a/chummer5a/pull/5187), which also included XSD modifications. I believe that PR might include too much data at once to be easily reviewed or validated, so this one offers a more focused alternative. Those changes have been set aside to keep this PR focused strictly on impactful XML corrections.

This PR isolates and corrects a variety of structural and content issues across our Shadowrun XML data files. It focuses **exclusively** on XML changes—XSD updates will be addressed separately—to ensure the data schema matches the in-code expectations without breaking existing parsing logic.

---

### Changes by File

#### **Armor.xml**

- Added missing `<armor>` entry for **Parachute**.
- Added missing `armor_capacity` attribute for **Pantheon Quick-Charge Battery Pack**.

#### **Critterpowers.xml**

- **Removed** legacy SR4‑only power.
- Standardized hyphenation: `Low-Light`, `Wire-band` using minus signs.
- **Added** automotive powers.
- **Added** “Fold Perception” and “Agonizing Pain” from *Howling Shadows* (HS).

#### **Critters.xml**

- Renamed **Baboon** → **Ozian Baboon** (per source text).
- **Removed** “Wyrd Mantis” (SR4‑only).
- Populated missing `<initiative>`, `<magic>`, `<resonance>`, and `<depth>` fields for several critters.
- Remove unintended character across the file.
- Applied `<rating>` to skill and automotive powers; replaced stray `<select>`.
- Corrected power and quality names:
  - `Sillence` → **Silence**
  - `Devour` → **Devouring**
  - `Substance Extrusion` → **Secretion/Substance Extrusion**
  - `Shadowing` → **Sneaking**
  - `Improved Senses` → **Enhanced Senses**
  - `Spell Resistance` → **Magic Resistance**
  - `Banishing` → **Banishing Resistance**
  - `Fae Glamour` → **Fey Glamour**
  - `Regenerate` → **Regeneration**
  - `Throw Weapon` → **Throwing Weapon**
  - `Deezz` → **Derezz**
  - `Real World Naivete` → **Real World Naiveté**
- Re-classified:
  - Moved **Astral Perception** into **AdeptPower** or **Quality** (chose Quality).
  - Fixed `<power>` nesting under `<optionalpowers>`.
  - Changed **Munge** to a Quality, **Resonance Hosting** to a Power, **Agony** to a Spell.

#### **cyberware.xml**

- Added missing `<capacity>` and `<cost>` attributes to several implants.
- Removed duplicated `<inheritattributes>` tag.

#### **gears.xml**

- Removed leftover of a commented sections (removing  `-->`).
- Updated SR4 `avail` values to SR5 standards.
- Added missing gear for vehicle `Proteus Krake (Small)`

#### **lifemodules.xml**

- Replaced non-existent `<collegeeducation>` and `<technicalschooleducation>` tags with `<quality>`.

#### **mentors.xml**

- Eliminated empty `<choice>` tag.

#### **metatypes.xml**

- Removed duplicate `<karma>` tags (now handled in `priorities.xml`).
- Deleted redundant `<mag>` attribution.
- Cleaned up stray empty tags for consistency.

#### **powers.xml**

- Removed residual `<selectskill>` from **Enthralling Performance**.

#### **priorities.xml**

- Removed **Goblin** metavariant (SR4‑only).
- Trimmed blank/empty tags.

#### **skill.xml**

- Normalized whitespace (tabs → spaces, trimmed trailing spaces).

#### **traditions.xml**

- Standardized minus signs in place of Unicode en-dashes.
- Corrected spelling: `bon` → **bod**.

#### **vehicles.xml**

- Renamed **Rigger Adaptation** → **Rigger Interface**.
- Removed duplicate `<mods>` block.
- Deleted SR4‑only **Conestoga Vista (Bus)**.
- Moved **Flash-Pak** from mod to gear (`Grenade: Flash-Pak`).
- Removed nonexistent **Manual Control** mod.
- Added **Amenities (Street)** entries per *Krime Katalogue* (KK).

#### **weapons.xml**

- Fixed whitespace and indentation.
- Corrected source entry for **AK-98 Grenade Launcher**.
- Consolidated underbarrel accessory mounts: removed `<accessorymounts>` tags and added `<mount>Under</mount>` where needed, ensuring **Trigger Removal** is now displayed.
- Fixed malformed `<weapondetails>` wrapper.
- Adjusted structure for **Ruhrmetall SFW-30** accessories so that **Trigger Removal** appears correctly.
- Added missing stats for **Ontario Arms Sling-Shot**.
- Removed duplicate `<rating>` from **Krime Explosive Securing Tripod**.

---

### **Testing & Validation**

I cross-checked many of the changes using the custom XSD schema I introduced in [PR #5187](https://github.com/chummer5a/chummer5a/pull/5187) to ensure structural correctness.

---

Thanks for reviewing! This focused PR should resolve the parsing errors and missing data issues without touching the XSD layer. Let me know if any additional tweaks are needed.

