### PR TITLE
[Fix] Add name to weapon tag

### DIFF
--- a/Chummer/data/vehicles.xml
+++ b/Chummer/data/vehicles.xml
@@ -9225,7 +9225,9 @@
         </weaponmount>
       </weaponmounts>
       <weapons>
-        <weapon>Siemens FWD Screamer Sonic Cannon</weapon>
+        <weapon>
+          <name>Siemens FWD Screamer Sonic Cannon</name>
+        </weapon>
       </weapons>
       <modslots>0</modslots>
       <seats>0</seats>


### PR DESCRIPTION
Otherwise, the weapon is not added when adding the drone. :D