### PR TITLE
Net Gun Typo

### DIFF
--- a/Chummer/data/weapons.xml
+++ b/Chummer/data/weapons.xml
@@ -6118,7 +6118,7 @@
     </weapon>
     <weapon>
       <id>61555ac9-9925-4252-bc25-92c948eb9dfd</id>
-      <name>SA Retarius Net Gun</name>
+      <name>SA Retiarius Net Gun</name>
       <category>Exotic Ranged Weapons</category>
       <type>Ranged</type>
       <conceal>6</conceal>


### PR DESCRIPTION
<img width="416" height="729" alt="image" src="https://github.com/user-attachments/assets/d272cae5-321a-4347-9b3e-ec5b32a3808b" />


Fixing the spelling of the retiarus net gun