### PR TITLE
Adding FA Magical Compounds and buyable alchemy preparations

### DIFF
--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -13544,7 +13544,7 @@
       <id>08b3bf17-e52a-41d4-b023-af6ee5354fe6</id>
       <name>AgHexHex</name>
       <category>Magical Compounds</category>
-      <rating>20</rating>
+      <rating>1000000</rating>
       <ratinglabel>String_Force</ratinglabel>
       <source>SG</source>
       <page>219</page>
@@ -13555,7 +13555,7 @@
       <id>46e9dca6-bb11-4e33-8436-3dcadc23433c</id>
       <name>BDNB</name>
       <category>Magical Compounds</category>
-      <rating>20</rating>
+      <rating>1000000</rating>
       <ratinglabel>String_Force</ratinglabel>
       <source>SG</source>
       <page>220</page>
@@ -13566,7 +13566,7 @@
       <id>bdb141a3-7104-4d9e-a939-6f2d75678c0f</id>
       <name>Lot's Curse</name>
       <category>Magical Compounds</category>
-      <rating>20</rating>
+      <rating>1000000</rating>
       <ratinglabel>String_Force</ratinglabel>
       <source>SG</source>
       <page>220</page>
@@ -13577,7 +13577,7 @@
       <id>e7b70355-cf78-4680-93f2-da82b6fc98a5</id>
       <name>Sage</name>
       <category>Magical Compounds</category>
-      <rating>20</rating>
+      <rating>1000000</rating>
       <ratinglabel>String_Force</ratinglabel>
       <source>SG</source>
       <page>220</page>
@@ -13588,7 +13588,7 @@
       <id>b6bbfa14-9b0f-4474-a182-4f374c1efae2</id>
       <name>Spirit Strength</name>
       <category>Magical Compounds</category>
-      <rating>20</rating>
+      <rating>1000000</rating>
       <ratinglabel>String_Force</ratinglabel>
       <source>SG</source>
       <page>220</page>
@@ -13599,7 +13599,7 @@
       <id>000dd333-262f-4b51-8c66-01495b0df8ab</id>
       <name>Witch's Moss</name>
       <category>Magical Compounds</category>
-      <rating>20</rating>
+      <rating>1000000</rating>
       <ratinglabel>String_Force</ratinglabel>
       <source>SG</source>
       <page>220</page>
@@ -13620,7 +13620,8 @@
       <id>01a0c2a6-3d06-4cf9-9fc4-4388b1c87bb3</id>
       <name>Alchemical Duct Tape</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>194</page>
       <avail>14R</avail>
@@ -13630,7 +13631,8 @@
       <id>82afb8a5-e5b7-4fb2-9b9e-bb8ec9fee029</id>
       <name>Astral Increase</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>194</page>
       <avail>14R</avail>
@@ -13640,7 +13642,8 @@
       <id>a869cbec-e320-417a-b9bc-e7ed8f624670</id>
       <name>Astral Bond</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13650,7 +13653,8 @@
       <id>de78507e-d5ea-4fab-b034-d116d9fafd51</id>
       <name>Baobhan's Tears</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13660,7 +13664,8 @@
       <id>14941349-f9fa-4671-b194-eb0e3b9205fc</id>
       <name>Drain Away</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13670,7 +13675,8 @@
       <id>f48792cd-1c0e-4c69-93d5-ad54caca9827</id>
       <name>Dulled Edges</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13680,7 +13686,8 @@
       <id>c8cc2a19-c40f-44b5-a2f9-6b3c5da2b10d</id>
       <name>Feel No Pain</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13690,7 +13697,8 @@
       <id>86b0f1d8-5777-443f-a90c-4be0a264a5ea</id>
       <name>Force of Personality</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13700,7 +13708,8 @@
       <id>feb6f468-641f-4443-a72a-b78b6cf239d3</id>
       <name>HMHVV II Inhibitor</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13710,7 +13719,8 @@
       <id>9a2f3b3e-4f6c-4d47-bf65-09e79ea0e306</id>
       <name>Laminate</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13720,7 +13730,8 @@
       <id>c40e890f-3744-4151-bcd2-ce8de0cf92fa</id>
       <name>Perfect Sight</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13730,7 +13741,8 @@
       <id>af58e5e2-78aa-440f-9283-937819ef2d17</id>
       <name>Sharpshooter</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>197</page>
       <avail>14R</avail>
@@ -13740,7 +13752,8 @@
       <id>22e38a1f-305d-460f-836d-645818811e60</id>
       <name>Unstoppable Vigor</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>197</page>
       <avail>14R</avail>
@@ -13750,7 +13763,8 @@
       <id>bf435f24-1bf4-416f-8665-a5f9c4595196</id>
       <name>Water Breathing</name>
       <category>Magical Compounds</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>197</page>
       <avail>14R</avail>
@@ -13760,7 +13774,8 @@
       <id>0336261c-a1ae-4d82-91b2-6c03cab65bb9</id>
       <name>Abandon All Hope</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13770,7 +13785,8 @@
       <id>94f8ff12-dfb6-4316-a3a5-fdd50cda26d9</id>
       <name>Barricade</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13780,7 +13796,8 @@
       <id>30e7f5c4-b955-408c-a5c6-a221da65d067</id>
       <name>Burn, Baby, Burn</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13790,7 +13807,8 @@
       <id>7b045c01-6631-4904-b024-824368b6a1e2</id>
       <name>Do your Best</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13800,7 +13818,8 @@
       <id>00125c87-ab8a-4a5d-b9a9-167e305520d7</id>
       <name>Get Away From My Ride</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13810,7 +13829,8 @@
       <id>ee884eb3-9f55-4375-a478-2d735c198d9d</id>
       <name>High As A Kite</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13820,7 +13840,8 @@
       <id>6290d8fe-925b-4c48-80af-35236ae65f91</id>
       <name>Noise On The Line</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13830,7 +13851,8 @@
       <id>8dd76614-b2a6-4cee-9998-33caf2b027c4</id>
       <name>NOMW</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13840,7 +13862,8 @@
       <id>7bd5086c-bb9f-4d5b-aa49-8ed123427a4c</id>
       <name>Lightning Blade</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13850,7 +13873,8 @@
       <id>70ed70bf-1da4-4e2b-b1ee-de6d9778c22e</id>
       <name>Spirit Zapper</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13860,7 +13884,8 @@
       <id>8436a323-e60f-4651-a238-e33a895a0b42</id>
       <name>Stink Bomb</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13870,7 +13895,8 @@
       <id>357492f9-adfe-491d-8893-3ba3f198b283</id>
       <name>Stop Thief!</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13880,7 +13906,8 @@
       <id>7fc912ac-44d0-41ab-97dc-7b6df02ac327</id>
       <name>Truth Serum</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>200</page>
       <avail>14R</avail>
@@ -13890,7 +13917,8 @@
       <id>4a16cc8a-0cd1-4d6b-8962-5edff4dd98aa</id>
       <name>Up And At 'Em</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>200</page>
       <avail>14R</avail>
@@ -13900,7 +13928,8 @@
       <id>6ea96a5d-476f-445d-b439-4328c542983d</id>
       <name>Watch Your Step</name>
       <category>Alchemical Preperations</category>
-      <rating>0</rating>
+      <rating>1000000</rating>
+      <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>200</page>
       <avail>14R</avail>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -13621,6 +13621,7 @@
       <name>Alchemical Duct Tape</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>194</page>
@@ -13632,6 +13633,7 @@
       <name>Astral Increase</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>194</page>
@@ -13643,6 +13645,7 @@
       <name>Astral Bond</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
@@ -13654,6 +13657,7 @@
       <name>Baobhan's Tears</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
@@ -13665,6 +13669,7 @@
       <name>Drain Away</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
@@ -13676,6 +13681,7 @@
       <name>Dulled Edges</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
@@ -13687,6 +13693,7 @@
       <name>Feel No Pain</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>195</page>
@@ -13698,6 +13705,7 @@
       <name>Force of Personality</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
@@ -13709,6 +13717,7 @@
       <name>HMHVV II Inhibitor</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
@@ -13720,6 +13729,7 @@
       <name>Laminate</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
@@ -13731,6 +13741,7 @@
       <name>Perfect Sight</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>196</page>
@@ -13742,6 +13753,7 @@
       <name>Sharpshooter</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>197</page>
@@ -13753,6 +13765,7 @@
       <name>Unstoppable Vigor</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>197</page>
@@ -13764,6 +13777,7 @@
       <name>Water Breathing</name>
       <category>Magical Compounds</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>197</page>
@@ -13775,6 +13789,7 @@
       <name>Abandon All Hope</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
@@ -13786,6 +13801,7 @@
       <name>Barricade</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
@@ -13797,6 +13813,7 @@
       <name>Burn, Baby, Burn</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
@@ -13808,6 +13825,7 @@
       <name>Do your Best</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
@@ -13819,6 +13837,7 @@
       <name>Get Away From My Ride</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>198</page>
@@ -13830,6 +13849,7 @@
       <name>High As A Kite</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13841,6 +13861,7 @@
       <name>Noise On The Line</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13852,6 +13873,7 @@
       <name>NOMW</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13863,6 +13885,7 @@
       <name>Lightning Blade</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13874,6 +13897,7 @@
       <name>Spirit Zapper</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13885,6 +13909,7 @@
       <name>Stink Bomb</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13896,6 +13921,7 @@
       <name>Stop Thief!</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>199</page>
@@ -13907,6 +13933,7 @@
       <name>Truth Serum</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>200</page>
@@ -13918,6 +13945,7 @@
       <name>Up And At 'Em</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>200</page>
@@ -13929,6 +13957,7 @@
       <name>Watch Your Step</name>
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
+      <minrating>2</minrating>
       <ratinglabel>"Force + Current Potency"</ratinglabel>
       <source>FA</source>
       <page>200</page>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -13622,7 +13622,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>194</page>
       <avail>14R</avail>
@@ -13634,7 +13634,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>194</page>
       <avail>14R</avail>
@@ -13646,7 +13646,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13658,7 +13658,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13670,7 +13670,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13682,7 +13682,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13694,7 +13694,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>195</page>
       <avail>14R</avail>
@@ -13706,7 +13706,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13718,7 +13718,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13730,7 +13730,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13742,7 +13742,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>196</page>
       <avail>14R</avail>
@@ -13754,7 +13754,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>197</page>
       <avail>14R</avail>
@@ -13766,7 +13766,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>197</page>
       <avail>14R</avail>
@@ -13778,7 +13778,7 @@
       <category>Magical Compounds</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>197</page>
       <avail>14R</avail>
@@ -13790,7 +13790,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13802,7 +13802,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13814,7 +13814,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13826,7 +13826,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13838,7 +13838,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>198</page>
       <avail>14R</avail>
@@ -13850,7 +13850,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13862,7 +13862,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13874,7 +13874,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13886,7 +13886,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13898,7 +13898,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13910,7 +13910,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13922,7 +13922,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>199</page>
       <avail>14R</avail>
@@ -13934,7 +13934,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>200</page>
       <avail>14R</avail>
@@ -13946,7 +13946,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>200</page>
       <avail>14R</avail>
@@ -13958,7 +13958,7 @@
       <category>Alchemical Preperations</category>
       <rating>1000000</rating>
       <minrating>2</minrating>
-      <ratinglabel>"Force + Current Potency"</ratinglabel>
+      <ratinglabel>String_Force_Potency</ratinglabel>
       <source>FA</source>
       <page>200</page>
       <avail>14R</avail>

--- a/Chummer/data/gear.xml
+++ b/Chummer/data/gear.xml
@@ -24,6 +24,7 @@
 
   <categories>
     <category blackmarket="Magic">Alchemical Tools</category>
+    <category blackmarket="Magic">Alchemical Preperations</category>
     <category blackmarket="Weapons">Ammunition</category>
     <category>Animals</category>
     <category blackmarket="Armor">Armor Enhancements</category>
@@ -13615,6 +13616,296 @@
       <avail>20R</avail>
       <cost>20000</cost>
     </gear>
+    <gear>
+      <id>01a0c2a6-3d06-4cf9-9fc4-4388b1c87bb3</id>
+      <name>Alchemical Duct Tape</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>194</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>82afb8a5-e5b7-4fb2-9b9e-bb8ec9fee029</id>
+      <name>Astral Increase</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>194</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>a869cbec-e320-417a-b9bc-e7ed8f624670</id>
+      <name>Astral Bond</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>195</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>de78507e-d5ea-4fab-b034-d116d9fafd51</id>
+      <name>Baobhan's Tears</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>195</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>14941349-f9fa-4671-b194-eb0e3b9205fc</id>
+      <name>Drain Away</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>195</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>f48792cd-1c0e-4c69-93d5-ad54caca9827</id>
+      <name>Dulled Edges</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>195</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>c8cc2a19-c40f-44b5-a2f9-6b3c5da2b10d</id>
+      <name>Feel No Pain</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>195</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>86b0f1d8-5777-443f-a90c-4be0a264a5ea</id>
+      <name>Force of Personality</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>196</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>feb6f468-641f-4443-a72a-b78b6cf239d3</id>
+      <name>HMHVV II Inhibitor</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>196</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>9a2f3b3e-4f6c-4d47-bf65-09e79ea0e306</id>
+      <name>Laminate</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>196</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>c40e890f-3744-4151-bcd2-ce8de0cf92fa</id>
+      <name>Perfect Sight</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>196</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>af58e5e2-78aa-440f-9283-937819ef2d17</id>
+      <name>Sharpshooter</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>197</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>22e38a1f-305d-460f-836d-645818811e60</id>
+      <name>Unstoppable Vigor</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>197</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>bf435f24-1bf4-416f-8665-a5f9c4595196</id>
+      <name>Water Breathing</name>
+      <category>Magical Compounds</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>197</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>0336261c-a1ae-4d82-91b2-6c03cab65bb9</id>
+      <name>Abandon All Hope</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>198</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>94f8ff12-dfb6-4316-a3a5-fdd50cda26d9</id>
+      <name>Barricade</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>198</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>30e7f5c4-b955-408c-a5c6-a221da65d067</id>
+      <name>Burn, Baby, Burn</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>198</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>7b045c01-6631-4904-b024-824368b6a1e2</id>
+      <name>Do your Best</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>198</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>00125c87-ab8a-4a5d-b9a9-167e305520d7</id>
+      <name>Get Away From My Ride</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>198</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>ee884eb3-9f55-4375-a478-2d735c198d9d</id>
+      <name>High As A Kite</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>6290d8fe-925b-4c48-80af-35236ae65f91</id>
+      <name>Noise On The Line</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>8dd76614-b2a6-4cee-9998-33caf2b027c4</id>
+      <name>NOMW</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>7bd5086c-bb9f-4d5b-aa49-8ed123427a4c</id>
+      <name>Lightning Blade</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>70ed70bf-1da4-4e2b-b1ee-de6d9778c22e</id>
+      <name>Spirit Zapper</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>8436a323-e60f-4651-a238-e33a895a0b42</id>
+      <name>Stink Bomb</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>357492f9-adfe-491d-8893-3ba3f198b283</id>
+      <name>Stop Thief!</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>199</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>7fc912ac-44d0-41ab-97dc-7b6df02ac327</id>
+      <name>Truth Serum</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>200</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>4a16cc8a-0cd1-4d6b-8962-5edff4dd98aa</id>
+      <name>Up And At 'Em</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>200</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>
+    <gear>
+      <id>6ea96a5d-476f-445d-b439-4328c542983d</id>
+      <name>Watch Your Step</name>
+      <category>Alchemical Preperations</category>
+      <rating>0</rating>
+      <source>FA</source>
+      <page>200</page>
+      <avail>14R</avail>
+      <cost>Rating * 500</cost>
+    </gear>    
     <!-- End Region -->
     <!-- Region Toxins -->
     <gear>

--- a/Chummer/lang/en-us.xml
+++ b/Chummer/lang/en-us.xml
@@ -959,6 +959,10 @@
       <text>Force</text>
     </string>
     <string>
+      <key>String_Force_Potency</key>
+      <text>Force + Current Potency</text>
+    </string>
+    <string>
       <key>String_Level</key>
       <text>Level</text>
     </string>


### PR DESCRIPTION
Adds the Forbidden Arcana Magical Compounds and "New Alchemical Preparations" from page 194 and 198 respectively. 


Price and Availability is baed off of the following entries:

<img width="474" height="519" alt="Screenshot 2025-08-21 at 11 50 59 AM" src="https://github.com/user-attachments/assets/21c9efa9-fb77-4de1-94f9-5f4595974fb6" />
<img width="473" height="238" alt="Screenshot 2025-08-21 at 11 51 10 AM" src="https://github.com/user-attachments/assets/4dda1762-7bb9-422b-956a-d00a83c34e85" />
