### PR TITLE
Thicker Hide

### DIFF
--- a/Chummer/data/critterpowers.xml
+++ b/Chummer/data/critterpowers.xml
@@ -4159,7 +4159,7 @@
     </power>
     <power>
       <id>3d4dec14-3a44-41b6-9f78-1d6bd42e15fe</id>
-      <name>Thicker Skin</name>
+      <name>Thicker Hide</name>
       <category>Chimeric Modification</category>
       <type />
       <action />


### PR DESCRIPTION
<img width="628" height="204" alt="Screenshot 2025-09-11 at 3 26 36 PM" src="https://github.com/user-attachments/assets/988b6675-f575-4bad-9655-a2903232c27c" />


Thicker Hide was incorrectly listed as Thicker Skin. This simply renamed it to Thicker Hide as per HS 173