### PR TITLE
Fix Deadlock Issues in SkillSpecialization Collection Operations

### DIFF
--- a/Chummer/Backend/Characters/Character.cs
+++ b/Chummer/Backend/Characters/Character.cs
@@ -2956,7 +2956,7 @@ namespace Chummer
                         if (string.IsNullOrEmpty(strSpec)) continue;
                         if (objSkill.Specializations.All(x => x.Name != strSpec, token))
                         {
-                            SkillSpecialization objSpec = new SkillSpecialization(this, strSpec);
+                            SkillSpecialization objSpec = new SkillSpecialization(this, objSkill, strSpec, false, false);
                             try
                             {
                                 token.ThrowIfCancellationRequested();
@@ -3743,7 +3743,7 @@ namespace Chummer
                         if (await objSkill.Specializations.AllAsync(async x => await x.GetNameAsync(token).ConfigureAwait(false) != strSpec, token)
                                 .ConfigureAwait(false))
                         {
-                            SkillSpecialization objSpec = new SkillSpecialization(this, strSpec);
+                            SkillSpecialization objSpec = new SkillSpecialization(this, objSkill, strSpec, false, false);
                             try
                             {
                                 token.ThrowIfCancellationRequested();

--- a/Chummer/Backend/Improvements/AddImprovementAsyncCollection.cs
+++ b/Chummer/Backend/Improvements/AddImprovementAsyncCollection.cs
@@ -6189,7 +6189,7 @@ public async Task qualitylevel(XmlNode bonusNode, CancellationToken token = defa
             {
                 // Create the Improvement.
                 string strSpec = bonusNode["spec"]?.InnerTextViaPool(token) ?? string.Empty;
-                SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, strSpec);
+                SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, objSkill, strSpec);
                 try
                 {
                     await (await objSkill.GetSpecializationsAsync(token).ConfigureAwait(false)).AddAsync(objSpec, token).ConfigureAwait(false);
@@ -6239,7 +6239,7 @@ public async Task qualitylevel(XmlNode bonusNode, CancellationToken token = defa
                     await CreateImprovementAsync(await objSkill.GetDictionaryKeyAsync(token).ConfigureAwait(false), _objImprovementSource, SourceName, Improvement.ImprovementType.SkillSpecializationOption, strSpec, token: token).ConfigureAwait(false);
                     if (await (await _objCharacter.GetSettingsAsync(token).ConfigureAwait(false)).GetFreeMartialArtSpecializationAsync(token).ConfigureAwait(false) && _objImprovementSource == Improvement.ImprovementSource.MartialArt)
                     {
-                        SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, strSpec);
+                        SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, objSkill, strSpec);
                         try
                         {
                             await objSkill.Specializations.AddAsync(objSpec, token).ConfigureAwait(false);
@@ -7530,7 +7530,7 @@ public async Task qualitylevel(XmlNode bonusNode, CancellationToken token = defa
                 SelectedValue = strSelected;
             }
             // Create the Improvement.
-            SkillSpecialization objExpertise = new SkillSpecialization(_objCharacter, SelectedValue, true, true);
+            SkillSpecialization objExpertise = new SkillSpecialization(_objCharacter, objSkill, SelectedValue, true, true);
             try
             {
                 await (await objSkill.GetSpecializationsAsync(token).ConfigureAwait(false)).AddAsync(objExpertise, token).ConfigureAwait(false);

--- a/Chummer/Backend/Improvements/AddImprovementCollection.cs
+++ b/Chummer/Backend/Improvements/AddImprovementCollection.cs
@@ -5889,7 +5889,7 @@ namespace Chummer
             {
                 // Create the Improvement.
                 string strSpec = bonusNode["spec"]?.InnerTextViaPool() ?? string.Empty;
-                SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, strSpec);
+                SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, objSkill, strSpec);
                 try
                 {
                     objSkill.Specializations.Add(objSpec);
@@ -5938,7 +5938,7 @@ namespace Chummer
                     CreateImprovement(objSkill.DictionaryKey, _objImprovementSource, SourceName, Improvement.ImprovementType.SkillSpecializationOption, strSpec);
                     if (_objCharacter.Settings.FreeMartialArtSpecialization && _objImprovementSource == Improvement.ImprovementSource.MartialArt)
                     {
-                        SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, strSpec);
+                        SkillSpecialization objSpec = new SkillSpecialization(_objCharacter, objSkill, strSpec);
                         try
                         {
                             objSkill.Specializations.Add(objSpec);
@@ -7080,7 +7080,7 @@ namespace Chummer
                 SelectedValue = strSelected;
             }
             // Create the Improvement.
-            SkillSpecialization objExpertise = new SkillSpecialization(_objCharacter, SelectedValue, true, true);
+            SkillSpecialization objExpertise = new SkillSpecialization(_objCharacter, objSkill, SelectedValue, true, true);
             try
             {
                 objSkill.Specializations.Add(objExpertise);

--- a/Chummer/Backend/Interfaces/IAsyncList.cs
+++ b/Chummer/Backend/Interfaces/IAsyncList.cs
@@ -49,7 +49,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(lstCollection));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -105,19 +108,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -136,7 +139,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(comparer));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -192,19 +198,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -223,7 +229,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(funcComparison));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -279,19 +288,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -429,7 +438,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(lstCollection));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -485,19 +497,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -516,7 +528,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(comparer));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -572,19 +587,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -603,7 +618,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(funcComparison));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -658,20 +676,8 @@ namespace Chummer
                     else
                         intIntervalEnd = intTargetIndex - 1;
                 }
-
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
-                {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
-                }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -690,7 +696,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(funcComparison));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -746,19 +755,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {
@@ -777,7 +786,10 @@ namespace Chummer
                 throw new ArgumentNullException(nameof(funcComparison));
             IAsyncDisposable objLocker = null;
             if (lstCollection is IHasLockObject objHasLock)
-                objLocker = await objHasLock.LockObject.EnterUpgradeableReadLockAsync(token).ConfigureAwait(false);
+            {
+                // Use EnterReadLockWithMatchingParentLockAsync to avoid parent lock acquisition issues
+                objLocker = await objHasLock.LockObject.EnterReadLockWithMatchingParentLockAsync(token).ConfigureAwait(false);
+            }
             else
                 objHasLock = null;
             try
@@ -833,19 +845,19 @@ namespace Chummer
                         intIntervalEnd = intTargetIndex - 1;
                 }
 
-                IAsyncDisposable objLocker2 = objHasLock != null
-                    ? await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false)
-                    : null;
-                try
+                // Release read lock before acquiring write lock to avoid deadlocks
+                if (objLocker != null)
                 {
-                    token.ThrowIfCancellationRequested();
-                    await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
+                    await objLocker.DisposeAsync().ConfigureAwait(false);
+                    objLocker = null;
                 }
-                finally
-                {
-                    if (objLocker2 != null)
-                        await objLocker2.DisposeAsync().ConfigureAwait(false);
-                }
+
+                // Acquire write lock for insertion
+                if (objHasLock != null)
+                    objLocker = await objHasLock.LockObject.EnterWriteLockAsync(token).ConfigureAwait(false);
+
+                token.ThrowIfCancellationRequested();
+                await lstCollection.InsertAsync(intTargetIndex, objNewItem, token).ConfigureAwait(false);
             }
             finally
             {

--- a/Chummer/Backend/Skills/SkillSpecialization.cs
+++ b/Chummer/Backend/Skills/SkillSpecialization.cs
@@ -44,7 +44,7 @@ namespace Chummer.Backend.Skills
 
         #region Constructor, Create, Save, Load, and Print Methods
 
-        public SkillSpecialization(Character objCharacter, string strName, bool blnFree = false, bool blnExpertise = false)
+        public SkillSpecialization(Character objCharacter, Skill objParent, string strName, bool blnFree = false, bool blnExpertise = false)
         {
             _objCharacter = objCharacter ?? throw new ArgumentNullException(nameof(objCharacter));
             LockObject = objCharacter.LockObject;
@@ -52,6 +52,7 @@ namespace Chummer.Backend.Skills
             _guiID = Guid.NewGuid();
             _blnFree = blnFree;
             _blnExpertise = blnExpertise;
+            _objParent = objParent;
         }
 
         /// <summary>
@@ -80,7 +81,7 @@ namespace Chummer.Backend.Skills
         /// </summary>
         /// <param name="objCharacter">Character to load for.</param>
         /// <param name="xmlNode">XmlNode to load.</param>
-        public static SkillSpecialization Load(Character objCharacter, XmlNode xmlNode)
+        public static SkillSpecialization Load(Character objCharacter, Skill objParent, XmlNode xmlNode)
         {
             string strName = string.Empty;
             if (!xmlNode.TryGetStringFieldQuickly("name", ref strName) || string.IsNullOrEmpty(strName))
@@ -88,7 +89,7 @@ namespace Chummer.Backend.Skills
             if (!xmlNode.TryGetField("guid", Guid.TryParse, out Guid guiTemp))
                 guiTemp = Guid.NewGuid();
 
-            return new SkillSpecialization(objCharacter, strName, xmlNode["free"]?.InnerTextIsTrueString() == true, xmlNode["expertise"]?.InnerTextIsTrueString() == true)
+            return new SkillSpecialization(objCharacter, objParent, strName, xmlNode["free"]?.InnerTextIsTrueString() == true, xmlNode["expertise"]?.InnerTextIsTrueString() == true)
             {
                 _guiID = guiTemp
             };
@@ -209,11 +210,6 @@ namespace Chummer.Backend.Skills
                 using (LockObject.EnterReadLock())
                     return _objParent;
             }
-            set
-            {
-                using (LockObject.EnterWriteLock())
-                    _objParent = value;
-            }
         }
 
         /// <summary>
@@ -277,7 +273,7 @@ namespace Chummer.Backend.Skills
 
         private XPathNavigator _objCachedMyXPathNode;
         private string _strCachedXPathNodeLanguage = string.Empty;
-        private Skill _objParent;
+        private readonly Skill _objParent;
 
         public async Task<XPathNavigator> GetNodeXPathCoreAsync(bool blnSync, string strLanguage, CancellationToken token = default)
         {


### PR DESCRIPTION
When loading customdata, Skill Specializations were trying to take a lock while inside a collection change event. 

Rewrote AddWithSortAsync to use read lock, release and take a write lock when doing the insert to prevent parent lock acquisition.

Moved SkillSpecialization parent to only be called when a specialization is created, as there's no circumstance where we would be moving a spec onto another skill, reducing dependency on collectionchanged events. 

Fixes the issue, but not sure it's the correct approach.