### PR TITLE
Update lifestyles.xml to make zombie maids/manservants covered by lifestyle for luxury

### DIFF
--- a/Chummer/data/lifestyles.xml
+++ b/Chummer/data/lifestyles.xml
@@ -1275,7 +1275,7 @@
       <category>Entertainment - Asset</category>
       <lp>2</lp>
       <cost>20000</cost>
-      <allowed>High</allowed>
+      <allowed>High,Luxury</allowed>
       <source>HT</source>
       <page>141</page>
     </quality>


### PR DESCRIPTION
"Zombie maids/manservants" has a minimum lifestyle of high, so cost covered for high and luxury, but currently only is covered by high.