### PR TITLE
Security: stored HTML/script injection in character sheets (notes, description, etc.)

### DIFF
--- a/Chummer/PdfConvert.cs
+++ b/Chummer/PdfConvert.cs
@@ -243,6 +243,8 @@ namespace Codaxy.WkHtmlToPdf
                                                           out StringBuilder sbdParams))
             {
                 sbdParams.Append("--page-size A4 ", "--disable-smart-shrinking ");
+                // SECURITY: sheet HTML is untrusted (character notes/description/etc.); block scripting, local-file reads, and remote links.
+                sbdParams.Append("--disable-javascript ", "--disable-local-file-access ", "--disable-external-links ");
 
                 if (!string.IsNullOrEmpty(document.HeaderUrl))
                 {

--- a/Chummer/sheets/xt.PreserveHtml.xslt
+++ b/Chummer/sheets/xt.PreserveHtml.xslt
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<!-- Preserve Line Breaks Template that also preserves Html tag data -->
+<!-- Preserve line breaks (newlines -> <br/>). SECURITY: keep escaping ON; do not add disable-output-escaping (output is rendered by MSHTML/wkhtmltopdf). -->
 <!-- Version -500 -->
 <xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
   <xsl:template name="PreserveHtml">
       <xsl:param name="text" />
     <xsl:choose>
       <xsl:when test="contains($text,'&#xA;')">
-        <xsl:value-of select="substring-before($text,'&#xA;')" disable-output-escaping="yes" />
+        <xsl:value-of select="substring-before($text,'&#xA;')" />
         <br />
         <xsl:call-template name="PreserveHtml">
           <xsl:with-param name="text">
@@ -15,7 +15,7 @@
         </xsl:call-template>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="$text" disable-output-escaping="yes" />
+        <xsl:value-of select="$text" />
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>


### PR DESCRIPTION
Character free-text fields (notes, game notes, concept, description, background) were
written into the generated character sheet with `disable-output-escaping="yes"` (in
`Chummer/sheets/xt.PreserveHtml.xslt`). Sheets are rendered in the MSHTML `WebBrowser`
control from a local file and are also piped to wkhtmltopdf for PDF export — both of
which execute HTML/JavaScript. As a result, a shared `.chum5` save or custom-data XML
could run arbitrary script on a recipient's machine when they preview, print, or export
the character.

Changes:
- Remove `disable-output-escaping` from `xt.PreserveHtml.xslt` so those fields are
  HTML-escaped. Line breaks are still preserved (notes are plain multiline text; each
  newline still emits a `<br/>`). Arbitrary HTML formatting in notes is intentionally no
  longer supported.
- Defense in depth for the PDF path: pass
  `--disable-javascript --disable-local-file-access --disable-external-links` to
  wkhtmltopdf in `PdfConvert.cs`, so untrusted sheet HTML can't run script or read
  local/remote resources during PDF generation.
